### PR TITLE
Workaround for broken mount

### DIFF
--- a/opt/docs/powerline-fonts.md
+++ b/opt/docs/powerline-fonts.md
@@ -35,4 +35,6 @@ cat > .fonts.conf << FONTS
 FONTS
 ```
 
-Restart chromeOS
+In the case that you get an error saying something like `.fonts.conf does not exist`, try using `--rbind` instead of `--bind`.
+
+Save, then restart Chrome OS.


### PR DESCRIPTION
In some situations, the /user path of the Chronos user is mounted separately. To work around this, --bind must be replaced with --rbind.
