### PR TITLE
feat(desktop): deploy desktop scripts to Windows via install.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ opt/bin/*
 !opt/bin/pkg-install
 !opt/bin/pkg-install-apt
 !opt/bin/pkg-install-brew
+!opt/bin/install_windows.sh
 
 # Opt Subdirectory Configuration
 opt/.DS_Store
@@ -49,7 +50,7 @@ opt/nano/
 !docs/**
 
 # Source Code Build Artifacts
-src/tmux-mgr/tmux-mgr
+src/tmux-mgr/tmux-mg
 coverage/
 
 # System & Local Settings (Always Private)

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,24 @@ else
   ln -sf "${BASE_DIR}/opt" "${HOME}/opt"
 fi
 
+# ---------------------------------------------------------------------------
+# Windows/WSL only: deploy opt/Desktop/* onto the real Windows Desktop.
+# The Desktop is often OneDrive-redirected, so ask Windows for its real path
+# (via PowerShell) and translate it with wslpath. No-op off Windows.
+# ---------------------------------------------------------------------------
+if grep -qi microsoft /proc/version 2>/dev/null && command -v powershell.exe >/dev/null 2>&1; then
+  win_desktop_raw="$(powershell.exe -NoProfile -Command "[Environment]::GetFolderPath('Desktop')" 2>/dev/null | tr -d '\r')"
+  if [ -n "$win_desktop_raw" ]; then
+    win_desktop="$(wslpath -u "$win_desktop_raw" 2>/dev/null)"
+    if [ -n "$win_desktop" ] && [ -d "$win_desktop" ]; then
+      echo "Deploying opt/Desktop -> ${win_desktop}"
+      cp -r "${BASE_DIR}/opt/Desktop/." "${win_desktop}/"
+    else
+      echo "WARNING: could not resolve Windows Desktop (${win_desktop_raw}); skipping desktop deploy."
+    fi
+  fi
+fi
+
 # Source hardware detection
 if [ -f "${BASE_DIR}/opt/lib/hardware.sh" ]; then
   . "${BASE_DIR}/opt/lib/hardware.sh"

--- a/install.sh
+++ b/install.sh
@@ -37,30 +37,10 @@ else
   ln -sf "${BASE_DIR}/opt" "${HOME}/opt"
 fi
 
-# ---------------------------------------------------------------------------
 # Windows/WSL only: deploy opt/Desktop/* onto the real Windows Desktop.
-# The Desktop is often OneDrive-redirected, so ask Windows for its real path
-# (via PowerShell) and translate it with wslpath. No-op off Windows.
-# ---------------------------------------------------------------------------
-if grep -qi microsoft /proc/version 2>/dev/null; then
-  # Locate powershell.exe: prefer PATH, fall back to the standard System32 path
-  # (Windows exes are not always on the WSL PATH, e.g. appendWindowsPath=false).
-  ps_exe="$(command -v powershell.exe 2>/dev/null || true)"
-  if [ -z "$ps_exe" ] && [ -x "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" ]; then
-    ps_exe="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
-  fi
-  if [ -n "$ps_exe" ]; then
-    win_desktop_raw="$("$ps_exe" -NoProfile -Command "[Environment]::GetFolderPath('Desktop')" 2>/dev/null | tr -d '\r')"
-    win_desktop="$(wslpath -u "$win_desktop_raw" 2>/dev/null)"
-    if [ -n "$win_desktop" ] && [ -d "$win_desktop" ]; then
-      echo "Deploying opt/Desktop -> ${win_desktop}"
-      cp -r "${BASE_DIR}/opt/Desktop/." "${win_desktop}/"
-    else
-      echo "WARNING: could not resolve Windows Desktop (${win_desktop_raw}); skipping desktop deploy."
-    fi
-  else
-    echo "NOTE: powershell.exe not found; skipping Windows Desktop deploy."
-  fi
+# Logic is isolated in opt/bin/install_windows.sh for clarity.
+if [ -f "${BASE_DIR}/opt/bin/install_windows.sh" ]; then
+  bash "${BASE_DIR}/opt/bin/install_windows.sh" "${BASE_DIR}"
 fi
 
 # Source hardware detection
@@ -77,10 +57,10 @@ if [ -f "${BASE_DIR}/opt/lib/hardware.sh" ]; then
       "${BASE_DIR}/opt/scripts/system/setup_jtop.sh"
     fi
     
-    # Set Chromium as default browser
+    # Set Chromium as default browse
     if command -v apt-get &> /dev/null; then
       echo "Ensuring Chromium is installed and set as default..."
-      sudo apt-get install -y -qq chromium-browser
+      sudo apt-get install -y -qq chromium-browse
       
       # Set as default in update-alternatives
       sudo update-alternatives --set x-www-browser /usr/bin/chromium-browser 2>/dev/null || true
@@ -130,7 +110,7 @@ else
   # Install the curated common-core packages. They are defined once in
   # opt/profiles/packages.tsv; the per-platform installers in opt/bin translate
   # that list to the right package manager (apt on Debian/Ubuntu/WSL, Homebrew
-  # on macOS). These can also be run by hand: `pkg-install` (auto-detect) or
+  # on macOS). These can also be run by hand: `pkg-install` (auto-detect) o
   # `pkg-install-apt` / `pkg-install-brew` directly.
   if [ -x "${BASE_DIR}/opt/bin/pkg-install" ]; then
     "${BASE_DIR}/opt/bin/pkg-install" || echo "WARNING: package install reported problems; continuing."
@@ -191,7 +171,7 @@ fi
 
 # only setup these scripts when docker is installed and responsive
 if command -v docker &> /dev/null; then
-    # Setup docker permissions for the current user
+    # Setup docker permissions for the current use
     "${BASE_DIR}/opt/scripts/docker/setup_docker_perms.sh"
     
     # Check if Docker daemon is actually running (timeout after 5 seconds)
@@ -348,7 +328,7 @@ if [ -f "${BASE_DIR}/src/gss/build.sh" ]; then
     fi
 fi
 
-# build and install tmux-mgr
+# build and install tmux-mg
 if [ -f "${BASE_DIR}/src/tmux-mgr/build.sh" ]; then
     echo "Installing tmux-mgr..."
     bash "${BASE_DIR}/src/tmux-mgr/build.sh"

--- a/install.sh
+++ b/install.sh
@@ -42,9 +42,15 @@ fi
 # The Desktop is often OneDrive-redirected, so ask Windows for its real path
 # (via PowerShell) and translate it with wslpath. No-op off Windows.
 # ---------------------------------------------------------------------------
-if grep -qi microsoft /proc/version 2>/dev/null && command -v powershell.exe >/dev/null 2>&1; then
-  win_desktop_raw="$(powershell.exe -NoProfile -Command "[Environment]::GetFolderPath('Desktop')" 2>/dev/null | tr -d '\r')"
-  if [ -n "$win_desktop_raw" ]; then
+if grep -qi microsoft /proc/version 2>/dev/null; then
+  # Locate powershell.exe: prefer PATH, fall back to the standard System32 path
+  # (Windows exes are not always on the WSL PATH, e.g. appendWindowsPath=false).
+  ps_exe="$(command -v powershell.exe 2>/dev/null || true)"
+  if [ -z "$ps_exe" ] && [ -x "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" ]; then
+    ps_exe="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+  fi
+  if [ -n "$ps_exe" ]; then
+    win_desktop_raw="$("$ps_exe" -NoProfile -Command "[Environment]::GetFolderPath('Desktop')" 2>/dev/null | tr -d '\r')"
     win_desktop="$(wslpath -u "$win_desktop_raw" 2>/dev/null)"
     if [ -n "$win_desktop" ] && [ -d "$win_desktop" ]; then
       echo "Deploying opt/Desktop -> ${win_desktop}"
@@ -52,6 +58,8 @@ if grep -qi microsoft /proc/version 2>/dev/null && command -v powershell.exe >/d
     else
       echo "WARNING: could not resolve Windows Desktop (${win_desktop_raw}); skipping desktop deploy."
     fi
+  else
+    echo "NOTE: powershell.exe not found; skipping Windows Desktop deploy."
   fi
 fi
 

--- a/opt/Desktop/Apps/scripts/copilot-key-detect.ahk
+++ b/opt/Desktop/Apps/scripts/copilot-key-detect.ahk
@@ -1,0 +1,37 @@
+#Requires AutoHotkey v2.0
+#SingleInstance Force
+
+; ============================================================================
+;  Copilot-key detector. Run this, press your Copilot key 2-3 times, then
+;  press the letter 'a' once. It logs every key it sees (without blocking it)
+;  to copilot-key-detect.log next to this script, then closes after ~30s.
+;
+;  If the Copilot key shows up in the log -> AHK can see it; we read the real
+;  vk/sc and fix the hotkey. If only 'a' shows up -> the key bypasses AHK and
+;  we remap it through Windows Settings instead.
+; ============================================================================
+
+log := A_ScriptDir "\copilot-key-detect.log"
+try FileDelete(log)
+FileAppend("=== Copilot key detector ===`nStarted: " A_Now "`n"
+    . "Press your Copilot key 2-3 times, then press the 'a' key once.`n"
+    . "Closes automatically after ~30s (writes '=== done ===').`n`n", log)
+
+ih := InputHook("V")            ; V = don't block keys, just observe
+ih.KeyOpt("{All}", "N")         ; notify on every key
+ih.OnKeyDown := LogDown
+ih.Start()
+
+LogDown(hook, vk, sc) {
+    global log
+    FileAppend(Format("DOWN  vk={:#04x}  sc={:#04x}  name={}`n",
+        vk, sc, GetKeyName(Format("vk{:x}", vk))), log)
+}
+
+TrayTip("Copilot key detector running", "Press the Copilot key a few times, then 'a'.", 1)
+SetTimer(End, -30000)
+End() {
+    global log
+    FileAppend("`n=== done ===`n", log)
+    ExitApp()
+}

--- a/opt/Desktop/Apps/scripts/macos.ahk
+++ b/opt/Desktop/Apps/scripts/macos.ahk
@@ -1,0 +1,184 @@
+#Requires AutoHotkey v2.0
+#SingleInstance Force
+
+; ==============================================================================
+;  macOS-style shortcuts for Windows  (AutoHotkey v2)
+; ------------------------------------------------------------------------------
+;  Left Windows key (LWin)  ->  acts like the macOS Command (Cmd) key
+;  Left Alt           (!)   ->  acts like the macOS Option (Opt) key
+;
+;  This is the single canonical script. Old v1 files live in _archive_v1\.
+; ==============================================================================
+
+cmdTabActive := false
+
+; --- Make a lone Cmd (LWin) tap do nothing, like macOS --------------------------
+; Tilde keeps LWin working as a modifier; the unassigned vkE8 keystroke absorbs
+; the press so Windows never shows the Start menu when Cmd is tapped on its own.
+~LWin::Send "{Blind}{vkE8}"
+
+~LWin Up::
+{
+    global cmdTabActive
+    if cmdTabActive
+    {
+        Send "{Blind}{Alt up}"      ; release Alt -> commit the Cmd+Tab choice
+        cmdTabActive := false
+    }
+}
+
+; --- Core editing ---------------------------------------------------------------
+<#c::Send "^c"                  ; Cmd+C        Copy
+<#v::Send "^v"                  ; Cmd+V        Paste
+<#+v::Send "^+v"                ; Cmd+Shift+V  Paste and match style
+<#x::Send "^x"                  ; Cmd+X        Cut
+<#a::Send "^a"                  ; Cmd+A        Select all
+<#z::Send "^z"                  ; Cmd+Z        Undo
+<#+z::Send "^y"                 ; Cmd+Shift+Z  Redo
+<#s::Send "^s"                  ; Cmd+S        Save
+<#+s::Send "^+s"                ; Cmd+Shift+S  Save as
+<#f::Send "^f"                  ; Cmd+F        Find
+<#g::Send "{F3}"                ; Cmd+G        Find next
+<#+g::Send "+{F3}"              ; Cmd+Shift+G  Find previous
+<#o::Send "^o"                  ; Cmd+O        Open
+<#n::Send "^n"                  ; Cmd+N        New
+<#p::Send "^p"                  ; Cmd+P        Print
+<#/::Send "^/"                  ; Cmd+/        Toggle line comment (editors)
+
+; --- Window & app management ----------------------------------------------------
+<#w::Send "^w"                  ; Cmd+W        Close tab / window
+<#m::WinMinimize "A"            ; Cmd+M        Minimize active window
+<#h::WinMinimize "A"            ; Cmd+H        Hide (minimize) active window
+<#!Esc::Send "^+{Esc}"          ; Cmd+Opt+Esc  Force quit (Task Manager)
+
+<#q::                           ; Cmd+Q        Quit active app
+{
+    if InStr(WinGetTitle("A"), "World of Warcraft")
+        return                  ; never Alt+F4 the game
+    Send "!{F4}"
+}
+
+; --- Cmd+Tab app switcher (hold Cmd, tap Tab to cycle, release to choose) --------
+<#Tab::
+{
+    global cmdTabActive
+    cmdTabActive := true
+    Send "{Blind}{Alt down}{Tab}"
+}
+<#+Tab::
+{
+    global cmdTabActive
+    cmdTabActive := true
+    Send "{Blind}{Alt down}{Shift down}{Tab}{Shift up}"
+}
+
+; --- Navigation & system --------------------------------------------------------
+<#Space::Send "#s"              ; Cmd+Space    Spotlight (Windows Search)
+<#l::Send "^l"                  ; Cmd+L        Focus address bar
+<#r::Send "{F5}"                ; Cmd+R        Reload / refresh
+
+; --- Line navigation (Cmd + arrows) ---------------------------------------------
+<#Left::Send "{Home}"           ; Cmd+Left     Start of line
+<#Right::Send "{End}"           ; Cmd+Right    End of line
+<#Up::Send "^{Home}"            ; Cmd+Up       Top of document
+<#Down::Send "^{End}"           ; Cmd+Down     Bottom of document
+
+; --- Line selection (Cmd + Shift + arrows) --------------------------------------
+<#+Left::Send "+{Home}"         ; select to start of line
+<#+Right::Send "+{End}"         ; select to end of line
+<#+Up::Send "+^{Home}"          ; select to top of document
+<#+Down::Send "+^{End}"         ; select to bottom of document
+
+; --- Delete behaviour -----------------------------------------------------------
+<#Backspace::Send "+{Home}{Del}"   ; Cmd+Delete   Delete to start of line
+!Backspace::Send "^{Backspace}"    ; Opt+Delete   Delete previous word
+
+; --- Word navigation (Option / Alt + arrows) ------------------------------------
+!Left::Send "^{Left}"           ; Opt+Left          Previous word
+!Right::Send "^{Right}"         ; Opt+Right         Next word
+!+Left::Send "+^{Left}"         ; Opt+Shift+Left    Select previous word
+!+Right::Send "+^{Right}"       ; Opt+Shift+Right   Select next word
+
+; --- Browser tabs ---------------------------------------------------------------
+<#t::Send "^t"                  ; Cmd+T        New tab
+<#+t::Send "^+t"                ; Cmd+Shift+T  Reopen closed tab
+<#[::Send "!{Left}"             ; Cmd+[        Back
+<#]::Send "!{Right}"            ; Cmd+]        Forward
+<#1::Send "^1"                  ; Cmd+1..8     Jump to tab N
+<#2::Send "^2"
+<#3::Send "^3"
+<#4::Send "^4"
+<#5::Send "^5"
+<#6::Send "^6"
+<#7::Send "^7"
+<#8::Send "^8"
+<#9::Send "^9"                  ; Cmd+9        Jump to last tab
+
+; --- Screenshots ----------------------------------------------------------------
+<#+3::Send "#{PrintScreen}"     ; Cmd+Shift+3  Full screen -> Pictures\Screenshots
+<#+4::Send "#+s"                ; Cmd+Shift+4  Region capture (Snip & Sketch)
+^+c::CaptureActiveWindow()      ; Ctrl+Shift+C Capture active window -> Pictures\Screenshots
+
+; ==============================================================================
+;  Copilot key  ->  Claude Desktop  (then start voice typing)
+; ------------------------------------------------------------------------------
+;  The dedicated Copilot key sends Shift+Win+F23, but the modifiers don't always
+;  register cleanly, so we fire on F23 with ANY modifiers (*) -- nothing else on
+;  a keyboard emits F23. Intercepting it (no ~) also stops Windows launching
+;  Copilot. We open/focus Claude for Windows -- a packaged app launched by its
+;  AppID -- then fire Win+H so Windows voice typing dictates into Claude's input.
+; ==============================================================================
+*F23::LaunchClaude()
+
+LaunchClaude()
+{
+    if !WinExist("ahk_exe Claude.exe")
+    {
+        Run 'explorer.exe shell:AppsFolder\Claude_pzs8sxrjxfjjc!Claude'
+        if !WinWait("ahk_exe Claude.exe", , 12)   ; bail if it never appears
+            return
+    }
+    WinActivate "ahk_exe Claude.exe"
+    WinWaitActive "ahk_exe Claude.exe", , 5
+    Sleep 400                       ; let the input box take focus
+    Send "#h"                       ; Win+H -> Windows voice typing
+}
+
+; ==============================================================================
+;  Hot corners  (move the pointer to the top-right corner -> Task View)
+; ==============================================================================
+SetTimer HotCorners, 200
+
+HotCorners()
+{
+    static armed := true
+    CoordMode "Mouse", "Screen"
+    MouseGetPos &mx, &my
+    T := 3
+    inTopRight := (my <= T) && (mx >= A_ScreenWidth - T)
+    if (inTopRight && armed)
+    {
+        armed := false
+        Send "#{Tab}"               ; Task View (show all open windows)
+    }
+    else if (!inTopRight)
+    {
+        armed := true               ; re-arm once the pointer leaves the corner
+    }
+}
+
+; ==============================================================================
+;  Capture the active window to Pictures\Screenshots (DPI-aware helper)
+; ==============================================================================
+CaptureActiveWindow()
+{
+    hwnd := WinGetID("A")
+    if !hwnd
+        return
+    ps     := A_WinDir "\System32\WindowsPowerShell\v1.0\powershell.exe"
+    helper := A_ScriptDir "\screenshot-window.ps1"
+    Run('"' ps '" -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "' helper '" -Hwnd ' hwnd, , "Hide")
+    SoundBeep(1000, 90)                                   ; audible shutter cue
+    ToolTip("Screenshot saved to Pictures\Screenshots")
+    SetTimer(() => ToolTip(), -1600)                      ; auto-hide the tip
+}

--- a/opt/Desktop/Apps/scripts/screenshot-window.ps1
+++ b/opt/Desktop/Apps/scripts/screenshot-window.ps1
@@ -1,0 +1,56 @@
+# ============================================================================
+#  Captures a single window to a PNG in  Pictures\Screenshots  (DPI-aware).
+#  Called by macos.ahk on Ctrl+Shift+C, passing the active window's handle.
+#  Run standalone to capture the current foreground window.
+# ============================================================================
+param([long]$Hwnd = 0)
+
+$ErrorActionPreference = 'Stop'
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class WinShot {
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool IsIconic(IntPtr h);
+  [DllImport("dwmapi.dll")] public static extern int DwmGetWindowAttribute(IntPtr h, int a, out RECT r, int s);
+  [DllImport("shcore.dll")] public static extern int SetProcessDpiAwareness(int v);
+  [StructLayout(LayoutKind.Sequential)] public struct RECT { public int Left, Top, Right, Bottom; }
+}
+"@
+
+# Per-monitor DPI aware -> coordinates are real (physical) pixels at 200% scaling.
+try { [WinShot]::SetProcessDpiAwareness(2) | Out-Null } catch {}
+
+Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName System.Windows.Forms
+
+$h = if ($Hwnd -ne 0) { [IntPtr]::new($Hwnd) } else { [WinShot]::GetForegroundWindow() }
+if ($h -eq [IntPtr]::Zero -or [WinShot]::IsIconic($h)) { exit 2 }
+
+$r = New-Object WinShot+RECT
+# DWMWA_EXTENDED_FRAME_BOUNDS = 9 -> the true visible bounds (skips invisible borders)
+if ([WinShot]::DwmGetWindowAttribute($h, 9, [ref]$r, 16) -ne 0) {
+    [WinShot]::GetWindowRect($h, [ref]$r) | Out-Null
+}
+
+$w  = $r.Right - $r.Left
+$ht = $r.Bottom - $r.Top
+if ($w -le 0 -or $ht -le 0) { exit 3 }
+
+$bmp = New-Object System.Drawing.Bitmap($w, $ht)
+$g = [System.Drawing.Graphics]::FromImage($bmp)
+$g.CopyFromScreen($r.Left, $r.Top, 0, 0, $bmp.Size)
+$g.Dispose()
+
+$dir = Join-Path ([Environment]::GetFolderPath('MyPictures')) 'Screenshots'
+if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+$file = Join-Path $dir ('Screenshot {0}.png' -f (Get-Date -Format 'yyyy-MM-dd HHmmss-fff'))
+$bmp.Save($file, [System.Drawing.Imaging.ImageFormat]::Png)
+
+# Also copy to clipboard (best effort, matches macOS-ish behaviour).
+try { [System.Windows.Forms.Clipboard]::SetImage($bmp) } catch {}
+$bmp.Dispose()
+
+Write-Output $file

--- a/opt/Desktop/Apps/scripts/setup-autostart.ps1
+++ b/opt/Desktop/Apps/scripts/setup-autostart.ps1
@@ -1,0 +1,48 @@
+# ============================================================================
+#  Registers a Task Scheduler job that auto-starts the macOS-style hotkeys
+#  (macos.ahk) at logon, elevated, so the shortcuts also work in apps that
+#  run as administrator (Task Manager, installers, etc.).
+#
+#  Re-run this any time you need to recreate the task. It self-elevates
+#  (you'll see one UAC prompt). Right-click -> "Run with PowerShell", or just
+#  double-click is fine.
+# ============================================================================
+
+$ErrorActionPreference = 'Stop'
+
+$taskName = 'macOS Hotkeys'
+$user     = 'ashyumi\edwar'
+$alias    = 'C:\Users\edwar\AppData\Local\Microsoft\WindowsApps\AutoHotkey.exe'
+$script   = 'C:\Users\edwar\OneDrive\Desktop\Apps\scripts\macos.ahk'
+$log      = 'C:\Windows\Temp\macos-hotkeys-setup.log'
+
+# --- self-elevate if not already running as administrator -------------------
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+            ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Start-Process powershell -Verb RunAs -ArgumentList @(
+        '-NoProfile','-ExecutionPolicy','Bypass','-File',"`"$PSCommandPath`""
+    )
+    return
+}
+
+try {
+    if (-not (Test-Path $alias))  { throw "AutoHotkey alias not found: $alias" }
+    if (-not (Test-Path $script)) { throw "Script not found: $script" }
+
+    $action    = New-ScheduledTaskAction -Execute $alias -Argument ('"{0}"' -f $script)
+    $trigger   = New-ScheduledTaskTrigger -AtLogOn -User $user
+    $principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Highest
+    $settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+                    -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew -StartWhenAvailable
+
+    Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger `
+        -Principal $principal -Settings $settings `
+        -Description 'Starts macOS-style keyboard shortcuts (macos.ahk) at logon.' -Force | Out-Null
+
+    "OK $(Get-Date -Format o): registered task '$taskName' for $user" | Out-File $log -Encoding utf8
+    Write-Output "Registered scheduled task '$taskName'."
+} catch {
+    "ERROR $(Get-Date -Format o): $($_.Exception.Message)" | Out-File $log -Encoding utf8
+    Write-Output "FAILED: $($_.Exception.Message)"
+}

--- a/opt/Desktop/Apps/scripts/setup-autostart.ps1
+++ b/opt/Desktop/Apps/scripts/setup-autostart.ps1
@@ -11,9 +11,9 @@
 $ErrorActionPreference = 'Stop'
 
 $taskName = 'macOS Hotkeys'
-$user     = 'ashyumi\edwar'
-$alias    = 'C:\Users\edwar\AppData\Local\Microsoft\WindowsApps\AutoHotkey.exe'
-$script   = 'C:\Users\edwar\OneDrive\Desktop\Apps\scripts\macos.ahk'
+$user     = "$env:USERDOMAIN\$env:USERNAME"
+$alias    = "$env:LOCALAPPDATA\Microsoft\WindowsApps\AutoHotkey.exe"
+$script   = Join-Path $PSScriptRoot 'macos.ahk'
 $log      = 'C:\Windows\Temp\macos-hotkeys-setup.log'
 
 # --- self-elevate if not already running as administrator -------------------

--- a/opt/bin/install_windows.sh
+++ b/opt/bin/install_windows.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# =============================================================================
+# install_windows.sh — Windows/WSL-only deploy step
+#
+# Copies opt/Desktop/* onto the real Windows Desktop. The Desktop folder is
+# often OneDrive-redirected, so we ask Windows for its actual path via
+# PowerShell and translate it with wslpath.
+#
+# Usage (called from install.sh):
+#   bash "${BASE_DIR}/opt/bin/install_windows.sh" "<BASE_DIR>"
+#
+# No-op when not running inside WSL / Windows.
+# =============================================================================
+
+set -euo pipefail
+
+BASE_DIR="${1:-}"
+if [ -z "$BASE_DIR" ]; then
+  echo "ERROR: install_windows.sh requires BASE_DIR as the first argument." >&2
+  exit 1
+fi
+
+# Only run inside WSL (Windows Subsystem for Linux).
+if ! grep -qi microsoft /proc/version 2>/dev/null; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Locate powershell.exe: prefer PATH, fall back to the standard System32 path.
+# (Windows exes are not always on the WSL PATH, e.g. appendWindowsPath=false.)
+# ---------------------------------------------------------------------------
+ps_exe="$(command -v powershell.exe 2>/dev/null || true)"
+if [ -z "$ps_exe" ] && [ -x "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" ]; then
+  ps_exe="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+fi
+
+if [ -z "$ps_exe" ]; then
+  echo "NOTE: powershell.exe not found; skipping Windows Desktop deploy."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve the real Desktop path (may be OneDrive-redirected).
+# ---------------------------------------------------------------------------
+win_desktop_raw="$("$ps_exe" -NoProfile -Command "[Environment]::GetFolderPath('Desktop')" 2>/dev/null | tr -d '\r')"
+win_desktop="$(wslpath -u "$win_desktop_raw" 2>/dev/null)"
+
+if [ -z "$win_desktop" ] || [ ! -d "$win_desktop" ]; then
+  echo "WARNING: could not resolve Windows Desktop (${win_desktop_raw}); skipping desktop deploy."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Deploy opt/Desktop/* onto the Windows Desktop.
+# ---------------------------------------------------------------------------
+echo "Deploying opt/Desktop -> ${win_desktop}"
+cp -r "${BASE_DIR}/opt/Desktop/." "${win_desktop}/"


### PR DESCRIPTION
## Summary
- Add Windows desktop helper scripts under `opt/Desktop/Apps/scripts/`: macos.ahk, copilot-key-detect.ahk, screenshot-window.ps1, setup-autostart.ps1.
- Add an `install.sh` step that mirrors `opt/Desktop/*` onto the real Windows Desktop when running on Windows/WSL, resolving the (possibly OneDrive-redirected) Desktop path via PowerShell. No-op off Windows.
- De-hardcode setup-autostart.ps1: use USERDOMAIN/USERNAME, LOCALAPPDATA, and a PSScriptRoot-relative macos.ahk so it works for any user/host.

## Test plan
- [ ] Run install.sh on a Windows/WSL machine; confirm scripts land in Desktop\Apps\scripts.
- [ ] Confirm it is a no-op on macOS/Linux native.
- [ ] Run setup-autostart.ps1; confirm the scheduled task registers for the current user.