### PR TITLE
fix(skills): link skills into Claude, not just Gemini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ integration-test: ## Run integration tests only
 .PHONY: claude-install
 claude-install: ## Install (or update) Claude Code CLI and link skills/commands/settings
 	./opt/scripts/system/claude_install.sh
+	./opt/scripts/system/sync-skills.sh
 	./opt/scripts/system/install_claude_skills.sh
 
 .PHONY: claude-test

--- a/ai/skills/sync-skills/SKILL.md
+++ b/ai/skills/sync-skills/SKILL.md
@@ -14,7 +14,7 @@ Always run `sync-skills` using the established alias, which points to the versio
 Using the `~/opt` path ensures that you are running the scripts as they are installed in the user's environment, maintaining consistency across different machines and installations.
 
 ### 1. Synchronize Skills
-Link all available skills into `~/.agents/skills`.
+Link all available skills into **both** `~/.agents/skills` (Gemini CLI) and `~/.claude/skills` (Claude Code). The single discovery pass keeps both assistants in sync from one source of truth.
 
 ```bash
 bash ~/opt/scripts/system/sync-skills.sh
@@ -34,7 +34,7 @@ bash ~/opt/scripts/system/sync-skills.sh --build
 
 ## Mandatory Reload
 
-After running `sync-skills`, the agent **MUST** inform the user that they need to manually reload their session for the changes to take effect:
+After running `sync-skills`, the agent **MUST** inform the user that they need to manually reload their session for the newly-linked skills to be discovered:
 
 - **Gemini CLI**: Run `/skills reload`
-- **Claude Code**: Refresh the session or restart the agent.
+- **Claude Code**: Restart Claude Code (skills are scanned from `~/.claude/skills` at startup; a running session will not see new links until relaunched).

--- a/install.sh
+++ b/install.sh
@@ -92,18 +92,21 @@ for file in ".profile" ".zshrc" ".bash_logout" ".bashrc"; do
   ln -sf "${BASE_DIR}/opt/profiles/${file}" "${HOME}/${file}"
 done 
 
-# Gemini CLI Configuration (Skills and Policies)
+# Shared skill sync — links every SKILL.md into BOTH ~/.agents/skills (Gemini)
+# and ~/.claude/skills (Claude). Single source of truth for both assistants.
 if [ -f "${BASE_DIR}/opt/scripts/system/sync-skills.sh" ]; then
     bash "${BASE_DIR}/opt/scripts/system/sync-skills.sh"
 fi
 
+# Gemini CLI Configuration (Policies, Commands, Aliases)
 if [ -f "${BASE_DIR}/opt/scripts/system/install_gemini_skills.sh" ]; then
-    # Keeping the original for policy/command setup, but sync-skills handles the skill links now.
+    # sync-skills handles the skill links now; this only does Gemini-specific config.
     "${BASE_DIR}/opt/scripts/system/install_gemini_skills.sh"
 fi
 
-# Claude Code Configuration (Skills, Commands, Settings)
+# Claude Code Configuration (Settings, Commands, Hooks, Aliases)
 if [ -f "${BASE_DIR}/opt/scripts/system/install_claude_skills.sh" ]; then
+    # sync-skills handles the skill links now; this only does Claude-specific config.
     "${BASE_DIR}/opt/scripts/system/install_claude_skills.sh"
 fi
 

--- a/opt/scripts/system/GEMINI.md
+++ b/opt/scripts/system/GEMINI.md
@@ -4,8 +4,11 @@ This directory contains scripts for configuring the operating system, environmen
 
 ## Scripts
 
+- `sync-skills.sh`: **Canonical skill linker for both assistants.** Discovers every `SKILL.md` (under `src/*/`, `ai/skills/*`, `.gemini/skills/*`) and links it into **both** `~/.agents/skills` (Gemini CLI) and `~/.claude/skills` (Claude Code). Exposed as the `sync-skills` alias; pass `--build` to also rebuild core binaries (`gss`, `tmux-mgr`, `wol`).
 - `gemini_install.sh`: Installs and configures the Gemini CLI and environment.
-- `install_gemini_skills.sh`: Sets up specialized skills for the Gemini CLI.
+- `install_gemini_skills.sh`: Gemini-specific config (policies, commands, aliases). Skill links are handled by `sync-skills.sh`.
+- `claude_install.sh`: Installs (or updates) the Claude Code CLI binary.
+- `install_claude_skills.sh`: Claude-specific config (settings.json, slash commands, hooks, aliases). Skill links are handled by `sync-skills.sh`.
 - `install_sops.sh`: Installs the `sops` secrets-management binary into `~/opt/bin` (Linux/WSL fetches the official release; macOS uses the Brewfile).
 - `nvm`: Helper for Node Version Manager setup.
 - `google-cli-setup.sh`: Configures the Google Cloud SDK.

--- a/opt/scripts/system/install_claude_skills.sh
+++ b/opt/scripts/system/install_claude_skills.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-# install_claude_skills.sh - Idempotently install Claude Code skills, commands, and settings.
+# install_claude_skills.sh - Idempotently install Claude Code's assistant-specific
+# config: settings.json, slash commands, hooks, and shell aliases.
 #
-# Mirrors install_gemini_skills.sh. Reuses the same SKILL.md skill directories
-# under src/*/skill/ (the SKILL.md format is shared between Claude and Gemini),
-# so a single source of truth drives both assistants.
+# Mirrors install_gemini_skills.sh (which handles Gemini's policies/commands/aliases).
+# Skill linking is NOT done here — sync-skills.sh is the single canonical linker that
+# discovers every SKILL.md and links it into BOTH ~/.agents/skills (Gemini) and
+# ~/.claude/skills (Claude). Run sync-skills.sh (or the `sync-skills` alias) to refresh
+# skills; this script only owns the Claude-specific config below.
 
 set -e
 
@@ -12,7 +15,7 @@ BASE_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 echo "Configuring Claude Code..."
 
 CLAUDE_HOME="${HOME}/.claude"
-mkdir -p "$CLAUDE_HOME/skills" "$CLAUDE_HOME/commands"
+mkdir -p "$CLAUDE_HOME/commands"
 
 cleanup_broken_links() {
     local dir="$1"
@@ -53,39 +56,8 @@ fi
 cleanup_broken_links "$CLAUDE_HOME/commands"
 
 # --- Skills ---
-echo "  Linking skills..."
-
-link_skill() {
-    local src="$1"
-    local dest="$2"
-
-    if [ ! -d "$src" ]; then
-        echo "    Skipping missing skill src: $src"
-        return
-    fi
-    src="${src%/}"
-
-    if [ -L "$dest" ]; then
-        if [ "$(readlink "$dest")" = "$src" ]; then
-            return
-        fi
-        rm "$dest"
-    elif [ -e "$dest" ]; then
-        echo "    Warning: $dest exists but is not a symlink. Moving to $dest.bak"
-        mv "$dest" "$dest.bak"
-    fi
-
-    echo "    Linking $(basename "$dest") -> $src"
-    ln -s "$src" "$dest"
-}
-
-# Reuse the same skill directories Gemini uses (SKILL.md is the shared format)
-link_skill "$BASE_DIR/src/ssh-host-finder"   "$CLAUDE_HOME/skills/ssh-host-finder"
-link_skill "$BASE_DIR/src/tmux-mgr/skill"    "$CLAUDE_HOME/skills/tmux"
-link_skill "$BASE_DIR/src/gss/skill"         "$CLAUDE_HOME/skills/git-safe-sync"
-link_skill "$BASE_DIR/src/ssh-key-sync"      "$CLAUDE_HOME/skills/ssh-key-sync"
-
-cleanup_broken_links "$CLAUDE_HOME/skills"
+# Handled by sync-skills.sh, which links every discovered SKILL.md into
+# ~/.claude/skills (and ~/.agents/skills for Gemini). Nothing to do here.
 
 # --- Hooks (referenced by absolute path from settings.json) ---
 # We don't symlink hooks — settings.json points at them in-place. Just ensure

--- a/opt/scripts/system/sync-skills.sh
+++ b/opt/scripts/system/sync-skills.sh
@@ -7,12 +7,19 @@ set -e
 # Use readlink -f to handle symlinks (like ~/opt) and find the physical repo root
 SCRIPT_PATH="$(readlink -f "$0")"
 BASE_DIR="$(cd "$(dirname "$SCRIPT_PATH")/../../.." && pwd)"
-SKILLS_DEST="${HOME}/.agents/skills"
+
+# Destinations that receive the synced skills. Gemini CLI reads ~/.agents/skills;
+# Claude Code reads ~/.claude/skills. The SKILL.md format is shared between both
+# assistants, so the single discovery pass below links every skill into each one.
+# This is the canonical skill linker for BOTH tools — install_gemini_skills.sh
+# and install_claude_skills.sh only handle their assistant-specific config now.
+SKILLS_DESTS=("${HOME}/.agents/skills" "${HOME}/.claude/skills")
 
 show_help() {
     echo "Usage: sync-skills [FLAGS]"
     echo ""
-    echo "Synchronizes agent skills from the dotfiles repository to ~/.agents/skills."
+    echo "Synchronizes agent skills from the dotfiles repository into both"
+    echo "~/.agents/skills (Gemini CLI) and ~/.claude/skills (Claude Code)."
     echo ""
     echo "Flags:"
     echo "  --build     Build associated binaries (gss, tmux-mgr, wol) while syncing."
@@ -35,20 +42,22 @@ for arg in "$@"; do
 done
 
 echo "Synchronizing AI agent skills..."
-mkdir -p "$SKILLS_DEST"
+for dest_root in "${SKILLS_DESTS[@]}"; do
+    mkdir -p "$dest_root"
+done
 
 # Function to safely create a symlink for a skill
 link_skill() {
     local src="$1"
     local dest="$2"
-    
+
     if [ ! -d "$src" ]; then
         return
     fi
-    
+
     # Remove trailing slash if any
     src="${src%/}"
-    
+
     if [ -L "$dest" ]; then
         if [ "$(readlink "$dest")" = "$src" ]; then
             return
@@ -58,9 +67,19 @@ link_skill() {
         echo "    Warning: $dest exists but is not a symlink. Moving to $dest.bak"
         mv "$dest" "$dest.bak"
     fi
-    
+
     echo "    Linking $(basename "$dest") -> $src"
     ln -s "$src" "$dest"
+}
+
+# Link a skill (by basename) into every destination in SKILLS_DESTS.
+link_skill_all() {
+    local src="$1"
+    local name="$2"
+    local dest_root
+    for dest_root in "${SKILLS_DESTS[@]}"; do
+        link_skill "$src" "$dest_root/$name"
+    done
 }
 
 # Function to build a component if build.sh exists
@@ -96,10 +115,10 @@ for dir in "$BASE_DIR/src"/*/; do
             gss) dest_name="git-safe-sync" ;;
             tmux-mgr) dest_name="tmux" ;;
         esac
-        link_skill "${dir}skill" "$SKILLS_DEST/$dest_name"
+        link_skill_all "${dir}skill" "$dest_name"
     # Priority 2: 'SKILL.md' file in the directory (like src/ssh-host-finder/SKILL.md)
     elif [ -f "${dir}SKILL.md" ]; then
-        link_skill "$dir" "$SKILLS_DEST/$name"
+        link_skill_all "$dir" "$name"
     fi
 done
 
@@ -109,7 +128,7 @@ if [ -d "$BASE_DIR/ai/skills" ]; then
         [ -d "$skill_dir" ] || continue
         skill_name=$(basename "$skill_dir")
         if [ -f "${skill_dir}SKILL.md" ]; then
-            link_skill "$skill_dir" "$SKILLS_DEST/$skill_name"
+            link_skill_all "$skill_dir" "$skill_name"
         fi
     done
 fi
@@ -120,15 +139,17 @@ if [ -d "$BASE_DIR/.gemini/skills" ]; then
         [ -d "$skill_dir" ] || continue
         skill_name=$(basename "$skill_dir")
         if [ -f "${skill_dir}SKILL.md" ]; then
-            link_skill "$skill_dir" "$SKILLS_DEST/$skill_name"
+            link_skill_all "$skill_dir" "$skill_name"
         fi
     done
 fi
 
-# Cleanup broken symlinks
-if [ -d "$SKILLS_DEST" ]; then
-    echo "  Cleaning up broken links in $SKILLS_DEST..."
-    find "$SKILLS_DEST" -type l ! -exec test -e {} \; -delete
-fi
+# Cleanup broken symlinks in every destination
+for dest_root in "${SKILLS_DESTS[@]}"; do
+    if [ -d "$dest_root" ]; then
+        echo "  Cleaning up broken links in $dest_root..."
+        find "$dest_root" -type l ! -exec test -e {} \; -delete
+    fi
+done
 
 echo "Skill synchronization complete."


### PR DESCRIPTION
## What
Make `sync-skills.sh` the single canonical skill linker for both AI assistants. One discovery pass now links every `SKILL.md` into **both** `~/.agents/skills` (Gemini CLI) and `~/.claude/skills` (Claude Code). `install_claude_skills.sh` is slimmed down to Claude-only config (settings.json, slash commands, hooks, aliases), mirroring its Gemini sibling.

## Why
Skills added under `ai/skills/*` (e.g. `sync-skills`, `sync-forks`) were visible to Gemini but never loaded by Claude Code. Two divergent installers were the cause: `sync-skills.sh` only wrote to `~/.agents/skills`, while `install_claude_skills.sh` linked a hardcoded list of 4 skills into `~/.claude/skills` with no `ai/skills/*` discovery. A session reload could not help because no symlink was ever created in Claude's directory.

## Impact
- New skills now reach Claude automatically — `sync-skills`, `sync-forks`, and `git-machete` are now linked into `~/.claude/skills`.
- One source of truth: adding or editing a `SKILL.md` flows to both assistants from a single `sync-skills` run.
- `make claude-install` now also runs `sync-skills.sh`, so that entry point still links skills.
- Corrected the `sync-skills` SKILL.md reload note (restart Claude Code; skills are scanned at startup).

## Testing
- `bash -n` syntax check on both modified scripts: pass.
- Ran `sync-skills.sh`: `~/.claude/skills` gained `sync-skills`, `sync-forks`, `git-machete`; original 4 preserved. Harness re-scan confirmed the three now appear in the available-skills list.
- Slimmed `install_claude_skills.sh` runs clean (exit 0); slash commands + settings.json symlink intact, skills untouched.
- Re-running `sync-skills.sh` is idempotent (re-links nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)