### PR TITLE
gsl: plan

### DIFF
--- a/docs/plans/gsl-status-line-execution.md
+++ b/docs/plans/gsl-status-line-execution.md
@@ -1,0 +1,176 @@
+# Execution Plan: `gsl` status line
+
+Companion to [`gsl-status-line.md`](./gsl-status-line.md). That document is the
+**design** (what & why); this is the **execution plan** (the ordered tasks, the
+full file manifest, the test plan, and the integration plan). Where the two
+overlap, the design doc is authoritative on intent and this doc is authoritative
+on sequencing and acceptance gates.
+
+## How to read this
+
+- Work is grouped into **four checkpoints (CP1–CP4)** that map 1:1 onto a gss
+  feature-worker stack on feature **gsl** (`feature/gsl/edward-raigosa/impl` and
+  its workers). CP1↔CP2 parallelize once the seam interfaces land; CP3 depends on
+  both; CP4 is final.
+- Every task carries an **acceptance gate** — the objective check that closes it.
+  A checkpoint is done only when all its task gates pass **and** the global gates
+  (`go build ./...`, `check-deps.sh`, `go test ./... -cover` ≥ target) are green.
+- Conventions are inherited verbatim from `src/gss`: goenv-aware `build.sh`,
+  version stamping via `-X .../internal/version.*`, an `os/exec` **seam** confined
+  to `internal/{git,mcp,gh}` and enforced by `scripts/check-deps.sh`, TDD with
+  `≥60%` coverage per package (`src/CLAUDE.md`).
+
+---
+
+## Task breakdown by checkpoint
+
+### CP1 — Scaffolding & core (no external calls yet)
+
+| # | Task | Files | Gate |
+| --- | --- | --- | --- |
+| 1.1 | Create `src/gsl/` module (`go mod init github.com/wenlock/dotfiles/gsl`), `VERSION`, `LICENSE` (Apache-2.0), `README.md` stub | `src/gsl/{go.mod,VERSION,LICENSE,README.md}` | `go build ./...` succeeds on empty tree |
+| 1.2 | Copy `src/gss/build.sh` → `src/gsl/build.sh`, swap names/paths/module to `gsl`; output `~/opt/bin/gsl`; stamp version | `src/gsl/build.sh` | `bash src/gsl/build.sh` builds & installs; `gsl version` prints stamped version |
+| 1.3 | Copy `src/gss/scripts/check-deps.sh`, adjust seam allowlist to `internal/{git,mcp,gh}`; allow cobra in `cmd/`, bubbletea in `internal/preview` | `src/gsl/scripts/check-deps.sh` | check-deps green on scaffold; fails if `os/exec` added outside seams |
+| 1.4 | cobra root + `Execute()` (mirror `src/gss/cmd/root.go`); wire `main.go` | `src/gsl/main.go`, `src/gsl/cmd/root.go` | `gsl --help` lists command stubs |
+| 1.5 | `internal/version` (var + `Get()` fallback, copy gss) | `src/gsl/internal/version/version.go` | `gsl version --json` returns version/commit/date |
+| 1.6 | `internal/payload` — defensive parse of Claude stdin JSON; **all fields pointers**; empty stdin → empty struct, no error | `src/gsl/internal/payload/payload.go` + `testdata/` | unit tests in 2.x; compiles, parses sample fixture |
+| 1.7 | `internal/config` — `Config`, `Default()`, `Load/Save`, segment + style fields, toggle helpers; missing file → defaults | `src/gsl/internal/config/config.go` | `Default()` returns working config; round-trips |
+| 1.8 | Define seam interfaces + `fake/` runners for `git`, `mcp`, `gh` (no real exec yet) | `src/gsl/internal/{git,mcp,gh}/exec.go`, `.../fake/runner.go` | interfaces compile; fakes satisfy them |
+
+**CP1 done when:** `go build ./...` + check-deps green; `gsl --help`/`version` work; no panic with no config file present.
+
+### CP2 — Detection & render (parallel with CP1 after 1.8)
+
+| # | Task | Files | Gate |
+| --- | --- | --- | --- |
+| 2.1 | `internal/git`: `status --porcelain=v2 --branch` + `git stash list` via `CommandContext` (~800ms); parse staged/unstaged/untracked/ahead/behind/stash | `internal/git/status.go` | unit tests pass (scripted porcelain, clean, not-a-repo, detached, timeout) |
+| 2.2 | `internal/git/worktree.go`: `IsLinked` (`--git-dir` vs `--git-common-dir`), `Count` (`git worktree list --porcelain`), `Toplevel` | `internal/git/worktree.go` | root vs linked detection + count tests pass |
+| 2.3 | `internal/mcp`: `ConfiguredCount` (instant parse of `~/.claude.json` + `./.mcp.json`, honor `CLAUDE_CONFIG_DIR`); `ActiveCount` (cache `${XDG_CACHE_HOME:-~/.cache}/gsl/mcp.json`, refresh ≤60s via `claude mcp list`, ~500ms) | `internal/mcp/{detect.go,cache.go}` | configured-count + active-count + **cache-hit-no-spawn** tests pass |
+| 2.4 | `internal/repo`: root/worktree detect; `registry.go` reads `${XDG_CONFIG_HOME:-~/.config}/gss/worktrees/registry.json` (guard `schema_version`), match toplevel/branch → feature name + `pr_url`→number + `pr_state` | `internal/repo/{detect.go,registry.go}` + `testdata/registry.json` | registry parse + match + schema-bump-ignored tests pass |
+| 2.5 | `internal/gh`: `gh pr view --json number,state` via seam, cached `${XDG_CACHE_HOME:-~/.cache}/gsl/pr-<branch>.json` 60s, ~800ms; PR# fallback only | `internal/gh/pr.go` | PR# parse + **cache-hit-no-spawn** + absent-gh-omit tests pass |
+| 2.6 | `internal/repo/pr.go`: `repo.PR(branch, toplevel)` — registry first, gh fallback | `internal/repo/pr.go` | registry-hit avoids gh; missing registry → gh fallback |
+| 2.7 | `internal/style`: `Style` struct, `builtins.go` (`powerline` default + `emoji`), `resolve.go` (deep-merge user `styles` over built-in; unknown→powerline+warn; `glyphs:ascii` forces ASCII) | `internal/style/{style.go,builtins.go,resolve.go}` | lookup/unknown/merge/new-style/ascii tests pass |
+| 2.8 | `internal/render`: `segment.go`, `glyphs.go`, `render.go` (concurrent segments, parent ctx, per-segment deadline) + `seg_dirgit.go`, `seg_repo.go`, `seg_ai.go`, `seg_time.go` | `internal/render/*.go` | golden line per style × (root,worktree); ordering/disable; tz fallback tests pass |
+
+**CP2 done when:** all detection packages ≥ coverage target; render produces correct golden lines for both built-in styles in root & worktree fixtures; timeout tests prove no hang.
+
+### CP3 — CLI, preview & install wiring
+
+| # | Task | Files | Gate |
+| --- | --- | --- | --- |
+| 3.1 | `cmd/render.go` — read stdin payload, print line(s) (Claude path) | `cmd/render.go` | sample payload → one powerline line |
+| 3.2 | `cmd/status.go` — no stdin, pretty render; payload-only segments self-omit | `cmd/status.go` | `gsl status` → dir+git+repo+time, ai omitted |
+| 3.3 | `cmd/config.go` — `get/set/enable/disable/toggle [<segment>]` + `config style <name>` / `--list` | `cmd/config.go` | toggle/style-switch/list reflected on next render |
+| 3.4 | `cmd/preview.go` + `internal/preview` — bubbletea TUI (segment toggle, **style cycle**, 1s tick) + `--once` golden frame | `cmd/preview.go`, `internal/preview/{ui.go,fixtures.go}` | `gsl preview --once` golden; TUI toggles/cycles/ticks |
+| 3.5 | `cmd/version.go` — `version [--json]` | `cmd/version.go` | matches version output |
+| 3.6 | **NEW shim** `ai/claude/statusline-command.sh` (`chmod +x`): read stdin, `exec ~/opt/bin/gsl render` if present, else minimal bash fallback | `ai/claude/statusline-command.sh` | with binary → gsl line; without → bash fallback line |
+| 3.7 | **EDIT** `install_claude_skills.sh`: symlink shim with backup-if-not-symlink guard + `chmod +x` | `opt/scripts/system/install_claude_skills.sh` | re-run → `~/.claude/statusline-command.sh` symlink, executable |
+| 3.8 | **EDIT** `sync-skills.sh`: add `"gsl"` to build loop; add `gsl) dest_name="gsl-status" ;;` to name case | `opt/scripts/system/sync-skills.sh` | `--build` builds gsl, links `~/.claude/skills/gsl-status` + `~/.agents/skills/gsl-status` |
+| 3.9 | **NEW** `ai/gemini/commands/gsl-status.toml` (mirror `gss.toml`): `description` + prompt with `!{gsl status}` + `{{args}}` | `ai/gemini/commands/gsl-status.toml` | `install_gemini_skills.sh` auto-links it (glob, no script edit) |
+| 3.10 | `skill/SKILL.md` for gsl (drives `gsl-status` skill) | `src/gsl/skill/SKILL.md` | links via sync-skills |
+
+**CP3 done when:** all subcommands work; both wiring scripts link correctly on a clean re-run; Gemini command linked; shim fallback verified with binary moved aside.
+
+### CP4 — Docs & finalize
+
+| # | Task | Files | Gate |
+| --- | --- | --- | --- |
+| 4.1 | `src/gsl/README.md` (usage, subcommands, config schema, styles) | `src/gsl/README.md` | renders; matches behavior |
+| 4.2 | `src/gsl/docs/design.md` (in-tree design pointer) + polish `SKILL.md` | `src/gsl/docs/design.md` | consistent with this plan |
+| 4.3 | Fold final decisions back into `docs/plans/gsl-status-line.md` + check this execution plan's boxes | `docs/plans/*` | plan reflects shipped reality |
+
+---
+
+## File manifest (complete)
+
+| Action | Path | CP | Purpose |
+| --- | --- | --- | --- |
+| NEW | `src/gsl/go.mod`, `go.sum` | 1 | module `github.com/wenlock/dotfiles/gsl`; deps cobra (Apache-2.0), bubbletea (MIT), yaml |
+| NEW | `src/gsl/VERSION`, `LICENSE` | 1 | version source; Apache-2.0 |
+| NEW | `src/gsl/build.sh` | 1 | goenv-aware build, version stamp, install to `~/opt/bin/gsl`, run check-deps |
+| NEW | `src/gsl/scripts/check-deps.sh` | 1 | seam + license gate (`os/exec` only in `internal/{git,mcp,gh}`) |
+| NEW | `src/gsl/main.go`, `cmd/root.go` | 1 | cobra root + `Execute()` |
+| NEW | `src/gsl/cmd/{render,status,config,preview,version}.go` | 3 | subcommand tree |
+| NEW | `src/gsl/internal/version/version.go` | 1 | version var + `Get()` |
+| NEW | `src/gsl/internal/payload/payload.go` (+ `testdata/`) | 1 | Claude stdin JSON parse (pointer fields) |
+| NEW | `src/gsl/internal/config/config.go` | 1 | config schema, defaults, load/save, toggles |
+| NEW | `src/gsl/internal/git/{exec,status,worktree}.go` + `fake/runner.go` | 1–2 | git seam, porcelain v2, worktree |
+| NEW | `src/gsl/internal/mcp/{detect,cache}.go` + `fake/runner.go` | 1–2 | configured (instant) + active (cached) MCP counts |
+| NEW | `src/gsl/internal/repo/{detect,registry,pr}.go` (+ `testdata/registry.json`) | 2 | root/worktree, gss registry reader, PR# resolve |
+| NEW | `src/gsl/internal/gh/{exec,pr}.go` + `fake/runner.go` | 1–2 | gh seam, cached `gh pr view` fallback |
+| NEW | `src/gsl/internal/style/{style,builtins,resolve}.go` | 2 | style struct, powerline+emoji built-ins, merge |
+| NEW | `src/gsl/internal/render/{segment,glyphs,render,seg_dirgit,seg_repo,seg_ai,seg_time}.go` | 2 | concurrent segment renderer |
+| NEW | `src/gsl/internal/preview/{ui,fixtures}.go` | 3 | bubbletea preview TUI + fixtures |
+| NEW | `src/gsl/skill/SKILL.md` | 3 | `gsl-status` skill |
+| NEW | `src/gsl/README.md`, `docs/design.md` | 4 | docs |
+| NEW | `ai/claude/statusline-command.sh` | 3 | shim the settings template already references |
+| NEW | `ai/gemini/commands/gsl-status.toml` | 3 | Gemini on-demand command |
+| EDIT | `opt/scripts/system/install_claude_skills.sh` | 3 | symlink shim (backup-guard + chmod) |
+| EDIT | `opt/scripts/system/sync-skills.sh` | 3 | build-loop `gsl` + `gsl) gsl-status` case |
+| NONE | `.gitignore` (`!src/**` covers tree), `install.sh`, `Makefile` (`make bin` auto-discovers), `ai/claude/settings.json.template` (allow-rule + `statusLine.command` already correct) | — | no edits required |
+
+---
+
+## Test plan
+
+**Strategy:** TDD; seams faked via `git/fake` + `mcp/fake` + `gh/fake`; payload fixtures under `internal/payload/testdata/`, registry fixtures under `internal/repo/testdata/`. Run `cd src/gsl && go test ./... -cover`. Per-package coverage targets (floor `60%` per `src/CLAUDE.md`):
+
+| Package | Target | Key cases |
+| --- | --- | --- |
+| payload | ~95% | full fixture; malformed JSON → error; **empty stdin → empty struct, no error**; `used_percentage:null` → nil; `seven_day` absent / `five_hour` present |
+| git | 70% | scripted porcelain=v2 (staged/unstaged/untracked, ahead 2/behind 1, stashes); clean → zeros; not-a-repo error; detached HEAD; **timeout (fake sleeps past deadline) → degrade, no hang** |
+| mcp | 60% | configured from temp `~/.claude.json` + `.mcp.json` (`CLAUDE_CONFIG_DIR` honored); active from fake `claude mcp list` (mixed ✓/✗); **cache hit <60s ⇒ spy NOT called**; stale + timeout → last value |
+| repo | 70% | root (`--git-dir`==`--git-common-dir`) vs linked (differ); worktree count (1, 4); registry match by toplevel **and** branch, `pr_url`→number, `pr_state` + feature name; worker w/o `pr_url`; **bumped `schema_version` ⇒ ignored → gh fallback**; missing registry → gh |
+| gh | 60% | PR# from fake `gh pr view` (open/draft/none); **cache hit <60s ⇒ spy NOT called**; timeout / gh absent / no remote → omit |
+| style | 80% | built-in lookup (`powerline`,`emoji`); unknown → `powerline` + stderr warn; user `styles` **deep-merge** over built-in (one field) and **new style**; `glyphs:ascii` forces ASCII table |
+| config | 70% | `Default()`; load-missing → defaults; round-trip; toggle; `style` set/list; bad-tz fallback |
+| render | 75% | ordering + disable; master `enabled=false` → empty; **repo indicator per style (powerline tinted root/wt vs emoji 🏠/🌳)**; PR#/count omission; `name` modes (feature/worker/branch/off); tz + bad-tz→UTC; nerdfont/emoji/ascii; **golden line at fixed time+payload, per style × (root,worktree)** |
+| cmd | 80% | each subcommand happy path + flag parsing; `render` from stdin; `status` no-stdin omits ai |
+| preview | 60% | `--once` golden frame; bubbletea model toggle/**style-cycle**/tick transitions |
+
+**End-to-end timeout proof (non-unit):** prepend a `PATH` dir with `git`/`claude`/`gh` that `sleep 5`; `time ~/opt/bin/gsl status` returns within the render budget (soft ~150ms / hard ~1000ms) with graceful degradation.
+
+**Golden tests:** fixed clock + fixed payload, asserted per style × {root, worktree}; `gsl preview --once` snapshot.
+
+---
+
+## Integration plan
+
+**Order matters** — build the binary before linking the skill, link the shim before relying on the live status line.
+
+1. **Build & install:** `bash src/gsl/build.sh` → `~/opt/bin/gsl`; check-deps green. (`make bin` auto-discovers it.)
+2. **Skill sync:** `sync-skills.sh` build loop gains `gsl`; the name `case` maps `gsl) dest_name="gsl-status"`, so `bash opt/scripts/system/sync-skills.sh --build` links `~/.claude/skills/gsl-status` and `~/.agents/skills/gsl-status`.
+3. **Claude shim:** `install_claude_skills.sh` symlinks `ai/claude/statusline-command.sh` → `~/.claude/statusline-command.sh` (backup-if-not-symlink guard, `chmod +x`). The settings template's `statusLine.command` already points at this path, and the `Bash($HOME/opt/bin/*:*)` allow-rule already covers `gsl render`.
+4. **Gemini command:** `ai/gemini/commands/gsl-status.toml` is auto-linked by `install_gemini_skills.sh`'s existing `*.toml` glob — no script edit.
+5. **Full installer:** `./install.sh` already runs sync-skills + both install scripts, so a fresh clone wires everything with no new install.sh edit.
+
+**Rollout / on-off layers (both honored):**
+- **Hard off:** remove `statusLine.command` from Claude settings.
+- **Soft off:** `gsl config disable` (master) → `gsl render` prints empty stdout; per-segment `gsl config disable <segment>`.
+
+**Fallback / safety:**
+- Pre-build (no `~/opt/bin/gsl`): shim prints a minimal bash line (`basename $PWD` + branch + date) so the status line never breaks.
+- Every subprocess is `CommandContext` with the budget in the design doc's timeout table; on timeout each segment degrades (omit / last cache) and the line still renders.
+
+---
+
+## Verification checklist (acceptance)
+
+Mirrors the design doc's Verification section as closable gates:
+
+- [ ] **Build:** `bash src/gsl/build.sh` installs `~/opt/bin/gsl`; check-deps passes
+- [ ] **Tests:** `go test ./... -cover` ≥ target per package
+- [ ] **Render (Claude):** sample payload piped to `gsl render` → 4-part powerline line
+- [ ] **On-demand (Gemini/CLI):** `gsl status` (no stdin) → dir+git+repo+time, ai omitted
+- [ ] **Repo segment:** root → root indicator + PR# + `⑂N`; from a gss worktree → worktree indicator + feature name + `PR#<n>` (from registry, no network) + `⑂N`; registry moved → cached `gh` fallback; no PR → `PR#` omits; lone main → `⑂N` omits
+- [ ] **Preview:** `gsl preview --once` one frame; `gsl preview` TUI toggles/cycles/ticks
+- [ ] **Styles:** `gsl config style emoji` re-renders; `--list` shows `powerline`*,`emoji`(+user); unknown → powerline + warn; user override reflected
+- [ ] **Toggle:** disable `time`/`repo` removes them; enable restores; master disable → empty
+- [ ] **Timeout proof:** slow `git`/`claude`/`gh` on PATH → returns within budget
+- [ ] **Wiring:** sync-skills `--build` links `gsl-status` (both dirs); `install_claude_skills.sh` → executable shim symlink; `install_gemini_skills.sh` → `gsl-status.toml` linked
+- [ ] **Shim fallback:** binary moved aside → minimal bash line; restored after
+- [ ] **Live Claude pickup:** after an assistant turn the status line renders via shim → `gsl render`
+
+## Definition of done
+
+All four checkpoints closed; all acceptance boxes checked; coverage gate green; check-deps + license gate green; `./install.sh` on a clean clone wires gsl end-to-end; design doc updated to match shipped behavior. Ships as the `impl` PR on the **gsl** stack (base of PR #21).

--- a/docs/plans/gsl-status-line-execution.md
+++ b/docs/plans/gsl-status-line-execution.md
@@ -158,19 +158,25 @@ on sequencing and acceptance gates.
 
 Mirrors the design doc's Verification section as closable gates:
 
-- [ ] **Build:** `bash src/gsl/build.sh` installs `~/opt/bin/gsl`; check-deps passes
-- [ ] **Tests:** `go test ./... -cover` ≥ target per package
-- [ ] **Render (Claude):** sample payload piped to `gsl render` → 4-part powerline line
-- [ ] **On-demand (Gemini/CLI):** `gsl status` (no stdin) → dir+git+repo+time, ai omitted
-- [ ] **Repo segment:** root → root indicator + PR# + `⑂N`; from a gss worktree → worktree indicator + feature name + `PR#<n>` (from registry, no network) + `⑂N`; registry moved → cached `gh` fallback; no PR → `PR#` omits; lone main → `⑂N` omits
-- [ ] **Preview:** `gsl preview --once` one frame; `gsl preview` TUI toggles/cycles/ticks
-- [ ] **Styles:** `gsl config style emoji` re-renders; `--list` shows `powerline`*,`emoji`(+user); unknown → powerline + warn; user override reflected
-- [ ] **Toggle:** disable `time`/`repo` removes them; enable restores; master disable → empty
-- [ ] **Timeout proof:** slow `git`/`claude`/`gh` on PATH → returns within budget
-- [ ] **Wiring:** sync-skills `--build` links `gsl-status` (both dirs); `install_claude_skills.sh` → executable shim symlink; `install_gemini_skills.sh` → `gsl-status.toml` linked
-- [ ] **Shim fallback:** binary moved aside → minimal bash line; restored after
-- [ ] **Live Claude pickup:** after an assistant turn the status line renders via shim → `gsl render`
+- [x] **Build:** `bash src/gsl/build.sh` installs `~/opt/bin/gsl`; check-deps passes
+- [x] **Tests:** `go test ./... -cover` ≥ target per package (git 94.3, repo 94.9, style 96.5, render 91.6, preview 83.5, cmd 80.7, payload 90.0, config 79.1, mcp 65.1, gh 63.0; `-race` clean)
+- [x] **Render (Claude):** sample payload piped to `gsl render` → 4-part powerline line
+- [x] **On-demand (Gemini/CLI):** `gsl status` (no stdin) → dir+git+repo+time, ai omitted
+- [x] **Repo segment:** from a gss worktree → worktree indicator + feature name (`gsl`) + `⑂N`; `PR#` self-omits when the worker is unpushed; root/registry-moved/no-PR/lone-main paths covered by `internal/repo` unit tests (registry-first, `gh` fallback, schema-bump-ignored)
+- [x] **Preview:** `gsl preview --once` one frame; TUI toggle/style-cycle/tick covered by `internal/preview` Model.Update tests
+- [x] **Styles:** `gsl config style emoji` re-renders; `--list` shows `powerline`*,`emoji`(+user); unknown → powerline + warn; user override (fill-presence) reflected
+- [x] **Toggle:** disable `time` removes it; enable restores; master disable → empty
+- [x] **Timeout proof:** slow `git`/`gh`/`claude` on PATH → `gsl status` returns ~1s and degrades (verified with `exec sleep` fakes; `SystemRunner` uses `exec.CommandContext`)
+- [x] **Wiring:** `sync-skills --build` links `gsl-status` (both dirs) + builds gsl; `install_claude_skills.sh` → executable shim symlink; `install_gemini_skills.sh` auto-links `gsl-status.toml` via its `*.toml` glob (verified under a temp `HOME`); `install.sh` builds the binary on a fresh clone
+- [x] **Shim fallback:** binary moved aside → minimal bash line; `execfail`-safe; restored after
+- [ ] **Live Claude pickup:** _deferred — requires activating the live status line in `~/.claude` (the `statusLine.command` + shim symlink); intentionally left as the user's opt-in step, not done autonomously. Run `./install.sh` (or `install_claude_skills.sh`) on the host to enable, then it renders via shim → `gsl render` after each turn._
 
 ## Definition of done
 
-All four checkpoints closed; all acceptance boxes checked; coverage gate green; check-deps + license gate green; `./install.sh` on a clean clone wires gsl end-to-end; design doc updated to match shipped behavior. Ships as the `impl` PR on the **gsl** stack (base of PR #21).
+- [x] All four checkpoints (CP1–CP4) closed, each two-stage reviewed (spec + code-quality) with fixes folded in.
+- [x] Coverage gate green (all packages ≥ their floor); `go vet` + `-race` clean.
+- [x] **check-deps seam gate green**; **license gate SKIP** — `go-licenses` is not installed on the build host, so the optional license scan is skipped (set `GSL_STRICT_CHECK=1` after `go install github.com/google/go-licenses@latest` to enforce). Dependencies were **manually verified permissive**: cobra **Apache-2.0**, bubbletea **MIT**, transitives MIT/BSD — compliant with `src/CLAUDE.md`.
+- [x] `./install.sh` on a clean clone wires gsl end-to-end (a `gsl` build block was added to `install.sh` — the plan had assumed no edit was needed, but install.sh builds each Go tool via an explicit block rather than auto-discovery).
+- [x] Design doc updated to match shipped behavior (see "Shipped" note below).
+- [x] Ships as the **`impl` PR #27** on the **gsl** feature, alongside the **plan** PR #21.
+- [ ] Live Claude status-line activation — deferred to the user (see the acceptance gate above).

--- a/docs/plans/gsl-status-line.md
+++ b/docs/plans/gsl-status-line.md
@@ -408,3 +408,40 @@ seams land; CP3 depends on both; CP4 is final.
     `bash ~/.claude/statusline-command.sh` → minimal bash line; restore binary.
 12. **Live Claude pickup**: start a Claude Code session; after an assistant turn the status
     line renders (harness pipes the live payload → shim → `gsl render`).
+
+---
+
+## Shipped (PR #27)
+
+Implemented end-to-end as **PR #27** (`feature/gsl/edward-raigosa/impl`), alongside this
+**plan** PR #21, over CP1–CP4. The design above shipped essentially as written; the notable
+decisions and deviations folded back from implementation + the per-checkpoint reviews:
+
+- **`install.sh` edit (deviation from the plan).** The plan assumed no `install.sh` change
+  was needed ("`make bin` auto-discovers"). In reality `install.sh` builds each Go tool via an
+  explicit per-tool block and calls `sync-skills.sh` *without* `--build`, so a `gsl` build
+  block was added (mirroring the gss/tmux-mgr/wol blocks) to wire gsl on a fresh clone.
+- **Style config wiring — fill-presence merge.** `internal/style` gained `ResolveConfig`
+  (alongside `Resolve`): it converts `config.styles` (`map[string]any`) to styles and merges
+  presence-aware, so a user override that omits `fill` does **not** silently disable a
+  built-in's `fill:true`. The render/cmd path uses `ResolveConfig`.
+- **`repo` segment specifics.** `PR#<n>` is rendered as a literal `PR#` token tinted by PR
+  state (no dedicated Nerd-Font PR glyph in the icon table). `name=worker` derives the label
+  from the branch's trailing segment (the gss `registry.json` parse keeps the feature name +
+  `pr_url`/`pr_state`, not the worker `user`/`purpose`). The powerline repo segment keeps its
+  background block across the PR# + count badges (single trailing ANSI reset).
+- **Timeout/degrade.** Segments render concurrently under a ~1s parent deadline + per-segment
+  deadlines; the real `SystemRunner` uses `exec.CommandContext`. Verified: a slow `git` on PATH
+  → `gsl status` returns ~1s and degrades. (A shell-wrapper fake whose `sleep` grandchild holds
+  the stdout pipe can mask this in testing — real binaries release the pipe at the deadline.)
+- **License gate.** `check-deps.sh`'s seam gate is enforced (+ a `check-deps_test.sh` driver);
+  the optional license scan **skips** when `go-licenses` is absent. Deps were verified manually:
+  cobra **Apache-2.0**, bubbletea **MIT**, transitives MIT/BSD.
+- **Coverage.** All packages meet their floor; `payload` landed at ~90% (vs the ~95% aim),
+  well above the 60% floor.
+- **Live activation is opt-in.** The shim + install wiring are in place, but flipping the live
+  Claude status line (the `statusLine.command` + `~/.claude/statusline-command.sh` symlink) is
+  left to the user / `./install.sh` on the host — it was not activated autonomously.
+
+See the closed acceptance checklist + Definition of Done in
+[`gsl-status-line-execution.md`](./gsl-status-line-execution.md).

--- a/docs/plans/gsl-status-line.md
+++ b/docs/plans/gsl-status-line.md
@@ -75,9 +75,14 @@ covered too. Research established:
    the same binary in plain-text mode; document Gemini's built-in footer toggles.
 3. MCP segment: **best-effort cached** — instant "configured" count + an "active" count from
    `claude mcp list` refreshed at most once/60s.
-4. `repo` segment: **🏠/🌳 root-vs-worktree indicator + gss feature name + PR# + worktree count**,
+4. `repo` segment: **root-vs-worktree indicator + gss feature name + PR# + worktree count**,
    sourced from the gss `registry.json` (instant) and local git, with a cached `gh pr view`
    fallback for the PR number on non-gss branches.
+5. **Configurable styles**: a named **style** bundles glyph set (per-segment icons), separator
+   (`powerline`/`thin`/`space`), background-fill on/off, glyph mode (`nerdfont`/`emoji`/`ascii`),
+   and theme colors. Two built-ins ship — **`powerline`** (default; NF tinted ` `/` ` repo
+   glyph) and **`emoji`** (color-emoji markers, airy spacing). Users add or override styles in
+   `config.json`; `gsl config style <name>` switches; `gsl preview` cycles them.
 
 **Outcome:** one fast (~ms startup) binary renders a 4-part powerline status line —
 `dir+git` · `repo(root/worktree · PR# · worktree-count)` · `AI(context/model/MCP/rate-limits)` ·
@@ -88,34 +93,45 @@ toggleable via a config file and a configuration skill.
 
 ## What it looks like (preview)
 
-Nerd-Font glyphs (representative; actual glyphs from `opt/profiles/.p10k.zsh`). The `repo`
-segment (2nd) renders differently at the repo root vs inside a linked worktree:
+The line is rendered by the active **style** (see "Styles" below). Two built-ins ship; both show
+the `repo` segment (2nd) differently at the repo root vs inside a linked worktree.
+
+**`powerline` (default)** — NF tinted repo glyph (` ` root = blue, ` ` worktree = magenta) on a
+neutral powerline; the glyph is foreground-tinted (which emoji can't be), so the root/worktree
+colour reads cleanly:
 
 ```
 root checkout:
-  ~/dotfiles   main +2 !1 ?3 ⇡2 ⇣1    🏠 PR#42 ⑂4    Opus 4.7  42% 84k/200k  MCP 2/5  5h 12% · 7d 45%   Sat 05/24 15:30 PDT
+  ~/dotfiles   main +2 !1 ?3 ⇡2 ⇣1     PR#42 ⑂4    Opus 4.7  42% 84k/200k  MCP 2/5  5h 12% · 7d 45%   Sat 05/24 15:30 PDT
 └──────── dirgit ────────┘ └─── repo ───┘ └──────────────────────── ai ────────────────────────┘ └──────── time ───────┘
 
 inside a worktree:
-  …/gsl/…/plan   feature/gsl… +1     🌳 gsl PR#21 ⑂4    Opus 4.7  42% 84k/200k  MCP 2/5  5h 12% · 7d 45%   Sat 05/24 15:30 PDT
+  …/gsl/…/plan   feature/gsl… +1      gsl PR#21 ⑂4    Opus 4.7  42% 84k/200k  MCP 2/5  5h 12% · 7d 45%   Sat 05/24 15:30 PDT
 └──────── dirgit ─────────┘ └────── repo ──────┘ └──────────────────────── ai ────────────────────────┘ └──────── time ───────┘
 ```
 
-`repo` glyphs: 🏠 = repo root (blue), 🌳 = linked worktree (magenta); `gsl` = the gss feature the
-worktree belongs to; `PR#21` is tinted by PR state (draft dim / open normal); `⑂4` = 4 worktrees
-exist. Parts self-omit: no PR ⇒ no `PR#`, a lone main checkout ⇒ no `⑂N`, a non-git dir ⇒ the whole
-`repo` segment disappears.
+**`emoji`** — color-emoji markers, thin separators, no background fills (airier; emoji carry the
+root/worktree distinction by shape — 🏠 vs 🌳 — since emoji can't be ANSI-tinted):
 
-ASCII fallback (`glyphs: ascii`):
+```
+📁 ~/dotfiles  🌿 main +2 !1   🏠 PR#42 ⑂4   🤖 Opus 4.7  🧠 42%  🔌 2/5   ⏰ Sat 15:30
+📁 …/plan      🌿 feat/gsl +1   🌳 gsl PR#21 ⑂4   🤖 Opus 4.7  🧠 42%  🔌 2/5   ⏰ Sat 15:30
+```
+
+In both, `gsl` = the gss feature the worktree belongs to; `PR#21` is tinted by PR state (draft dim /
+open normal); `⑂4` = 4 worktrees exist. Parts self-omit: no PR ⇒ no `PR#`, a lone main checkout ⇒
+no `⑂N`, a non-git dir ⇒ the whole `repo` segment disappears.
+
+**ASCII fallback** (any style with `glyphs: ascii`, or when no Nerd Font is detected):
 
 ```
 [~/dotfiles] (main +2 !1 ?3 ^2 v1) | [root] PR#42 wt4 | Opus 4.7 42% 84k/200k MCP 2/5 5h 12% 7d 45% | Sat 05/24 15:30 PDT
 [~/…/plan]   (feature/gsl… +1)     | [wt] gsl PR#21 wt4 | Opus 4.7 42% 84k/200k MCP 2/5 5h 12% 7d 45% | Sat 05/24 15:30 PDT
 ```
 
-`gsl preview` renders this against fixture payloads (clean repo, dirty repo, high-context,
-rate-limited, **root vs worktree**); `gsl preview` interactive lets you toggle each segment, switch
-glyphs/theme, and watch the clock tick before saving config.
+`gsl preview` renders these against fixture payloads (clean repo, dirty repo, high-context,
+rate-limited, **root vs worktree**); the interactive TUI lets you toggle each segment, **cycle
+styles**, switch glyphs/theme, and watch the clock tick before saving config.
 
 ---
 
@@ -146,6 +162,8 @@ src/gsl/
     repo/         detect.go (root/worktree via git) registry.go (gss registry.json reader)
                   pr.go (PR# from registry → gh fallback)
     gh/           exec.go (Runner seam, CommandContext) pr.go (gh pr view, cached/60s)  fake/runner.go
+    style/        style.go (Style struct) builtins.go (powerline default + emoji) resolve.go
+                  (merge user styles/overrides over built-ins)
     render/       segment.go glyphs.go render.go + seg_dirgit.go seg_repo.go seg_ai.go seg_time.go
     preview/      ui.go (bubbletea Model/Update/View) fixtures.go  (+ golden tests)
   skill/SKILL.md  scripts/check-deps.sh  docs/design.md
@@ -159,6 +177,8 @@ src/gsl/
   TUI (toggle segments/glyphs/theme, 1s clock tick); `--once` prints one frame and exits
   (CI/golden-test friendly).
 - `gsl config get|set|enable|disable|toggle [<segment>]` — drives the configuration skill.
+- `gsl config style <name>` / `gsl config style --list` — switch the active style / list built-ins
+  + user-defined styles.
 - `gsl version [--json]`.
 
 **Segments** (ordered, individually toggleable):
@@ -223,13 +243,28 @@ timed out as above; no PR / no `gh` / no remote ⇒ the `PR#` part self-omits.
 
 **Config + on/off** (`internal/config`): JSON at `${XDG_CONFIG_HOME:-~/.config}/gsl/config.json`,
 with `enabled` (master), an ordered `segments[]` (each `{type, enabled, options}`), `timezone`,
-time/date formats, `glyphs` (`nerdfont`|`ascii`), powerline separators, and `theme`. The `repo`
-segment's `options` carry `show_pr` (bool), `show_count` (bool), and `name`
-(`feature`|`worker`|`branch`|`off`, default `feature`); its colors live in `theme`
-(`repo_root`/`repo_worktree`, default blue/magenta). **Missing file ⇒ sane defaults** (the binary
-works with zero config; `repo` enabled by default). Two on/off layers, both honored:
-the harness `statusLine.command` key (hard off = remove it) and `config.enabled` (soft off:
-`gsl render` prints empty stdout) plus per-segment toggles — all reachable via `gsl config …`.
+time/date formats, the active `style` (default `powerline`), and a `styles` map of user
+definitions/overrides (see "Styles"). The `repo` segment's `options` carry `show_pr` (bool),
+`show_count` (bool), and `name` (`feature`|`worker`|`branch`|`off`, default `feature`). **Missing
+file ⇒ sane defaults** (the binary works with zero config; `repo` enabled, `style: powerline`).
+Two on/off layers, both honored: the harness `statusLine.command` key (hard off = remove it) and
+`config.enabled` (soft off: `gsl render` prints empty stdout) plus per-segment toggles — all
+reachable via `gsl config …`.
+
+**Styles** (`internal/style`): a *style* is a named bundle controlling presentation (segments and
+their data are unchanged): `separator` (`powerline` ` `/`thin` ` `/`space`), `fill` (bool —
+draw segment background blocks), `glyphs` (`nerdfont`|`emoji`|`ascii`), a per-segment `icons` map,
+and `theme` colors (incl. `repo_root`/`repo_worktree`, default blue/magenta). `builtins.go` ships
+two compiled-in styles — **`powerline`** (default: NF tinted repo glyph, filled powerline) and
+**`emoji`** (emoji icons, thin separators, no fill). `resolve.go` produces the effective style:
+look up the built-in named by `config.style`, then deep-merge any same-named entry from
+`config.styles` over it (so users tweak one field or define a brand-new style). Unknown style name
+⇒ fall back to `powerline` (warn to stderr, never crash). `glyphs: ascii` (or no Nerd Font on
+`PATH`/`TERM`) forces the ASCII fallback table regardless of style. The render layer reads only the
+resolved `Style`, so adding a style is data, not code. Example user styles a contributor could drop
+in `config.json` (not shipped, but exercised by the design): a `glyphicon` style (NF icon per
+segment), a `compact` style (emoji status indicators — ⚠️ dirty, 🟢/🟡/🔴 rate-limit, ◉/● PR
+state), and a `spacious` style (no fill, fg-only glyphs, wide separators).
 
 ### Wiring into install (exact edits)
 
@@ -257,7 +292,7 @@ the harness `statusLine.command` key (hard off = remove it) and `config.enabled`
 
 | Action | Path |
 | --- | --- |
-| NEW (tool tree) | `src/gsl/**` — cobra Go source, `build.sh`, `VERSION`, `internal/{repo,gh}` (worktree + PR# detection), `internal/preview` (bubbletea), `skill/SKILL.md`, `scripts/check-deps.sh`, tests |
+| NEW (tool tree) | `src/gsl/**` — cobra Go source, `build.sh`, `VERSION`, `internal/{repo,gh}` (worktree + PR# detection), `internal/style` (powerline + emoji built-ins), `internal/preview` (bubbletea), `skill/SKILL.md`, `scripts/check-deps.sh`, tests |
 | NEW | `ai/claude/statusline-command.sh` (shim) |
 | NEW | `ai/gemini/commands/gsl-status.toml` |
 | EDIT | `opt/scripts/system/install_claude_skills.sh` (symlink shim) |
@@ -296,12 +331,14 @@ seams land; CP3 depends on both; CP4 is final.
 - **CP2 — Detection & render.** `internal/git` (porcelain v2 + timeout + `worktree.go`),
   `internal/mcp` (configured instant + active cached/timeout + spy-tested cache hit),
   `internal/repo` (root/worktree detect + registry reader) and `internal/gh` (cached PR# fallback
-  + spy-tested cache hit), `internal/render` (**4 segments** incl. `seg_repo.go`, glyphs,
-  powerline join, per-segment deadline).
-- **CP3 — CLI, preview & wiring.** `cmd/{render,status,config,version,preview}`;
-  `internal/preview` bubbletea TUI + `--once` golden snapshot; `ai/claude/statusline-command.sh`
-  shim + `install_claude_skills.sh` symlink; `sync-skills.sh` build loop + `gsl) gsl-status`
-  case; `ai/gemini/commands/gsl-status.toml`; `skill/SKILL.md`.
+  + spy-tested cache hit), `internal/style` (`powerline` + `emoji` built-ins + resolve/merge),
+  `internal/render` (**4 segments** incl. `seg_repo.go`, style-driven glyphs/separators/fills,
+  per-segment deadline).
+- **CP3 — CLI, preview & wiring.** `cmd/{render,status,config,version,preview}` incl.
+  `gsl config style`; `internal/preview` bubbletea TUI (segment toggle + **style cycle**) + `--once`
+  golden snapshot; `ai/claude/statusline-command.sh` shim + `install_claude_skills.sh` symlink;
+  `sync-skills.sh` build loop + `gsl) gsl-status` case; `ai/gemini/commands/gsl-status.toml`;
+  `skill/SKILL.md`.
 - **CP4 — Docs & finalize.** `README.md`, `SKILL.md` polish, fold final decisions into this doc.
 
 ---
@@ -311,7 +348,7 @@ seams land; CP3 depends on both; CP4 is final.
 1. **Build**: `bash src/gsl/build.sh` → `gsl built and installed to ~/opt/bin/gsl`,
    check-deps passes. (`make bin` also works.)
 2. **Tests/coverage** (TDD, ≥60% per pkg per `src/CLAUDE.md`; targets: payload ~95, git 70,
-   mcp 60, repo 70, gh 60, config 70, render 75, cmd 80, preview 60):
+   mcp 60, repo 70, gh 60, style 80, config 70, render 75, cmd 80, preview 60):
    `cd src/gsl && go test ./... -cover`. Seams faked via `git/fake` + `mcp/fake` + `gh/fake`;
    payload fixtures under `internal/payload/testdata/`, registry fixtures under
    `internal/repo/testdata/`. Cases per package:
@@ -330,34 +367,44 @@ seams land; CP3 depends on both; CP4 is final.
      (falls through to gh); missing registry ⇒ gh fallback.
    - gh: PR# from fake `gh pr view` (open/draft/none); **cache hit <60s ⇒ spy NOT called**;
      timeout/`gh` absent/no remote ⇒ omit.
-   - render: segment ordering + disable; master `enabled=false` ⇒ empty output; **repo: 🏠 root vs
-     🌳 worktree glyph + color, PR#/count omission, `name` modes (feature/worker/branch/off)**; tz
-     render + bad-tz→UTC fallback; nerdfont vs ascii glyphs; **golden line at fixed time + fixed
-     payload, for both root and worktree**.
-   - preview: `--once` golden frame; bubbletea model toggle/tick transitions.
-   - config: Default(); Load-missing → defaults; round-trip; toggle; bad-tz fallback.
+   - style: built-in lookup (`powerline`, `emoji`); unknown name ⇒ `powerline` + stderr warn;
+     user `styles` entry **deep-merges** over a built-in (override one field) and **defines a new
+     style**; `glyphs: ascii` forces the ASCII table regardless of style.
+   - render: segment ordering + disable; master `enabled=false` ⇒ empty output; **repo indicator
+     per style — `powerline` NF tinted ` `/` ` (root blue / worktree magenta) vs `emoji` 🏠/🌳**;
+     PR#/count omission, `name` modes (feature/worker/branch/off); tz render + bad-tz→UTC fallback;
+     nerdfont/emoji/ascii glyphs; **golden line at fixed time + fixed payload, per style × (root,
+     worktree)**.
+   - preview: `--once` golden frame; bubbletea model toggle/**style-cycle**/tick transitions.
+   - config: Default(); Load-missing → defaults; round-trip; toggle; `style` set/list; bad-tz
+     fallback.
 3. **Render (Claude path)**: pipe a sample payload —
    `printf '%s' '{"cwd":"'"$PWD"'","model":{"display_name":"Opus 4.7"},"context_window":{"used_percentage":42,"total_input_tokens":84000,"context_window_size":200000},"rate_limits":{"five_hour":{"used_percentage":12.5,"resets_at":"2026-05-24T20:00:00Z"}}}' | ~/opt/bin/gsl render`
    → one powerline line: dir+git, repo(root/worktree·PR#·count), AI(model/ctx%/tokens/MCP/5h+7d), time.
 4. **On-demand (Gemini/CLI)**: `~/opt/bin/gsl status` (no stdin) → dir+git+repo+time, AI omitted
    (repo renders without a payload).
-5. **Repo segment (root vs worktree)**: run `~/opt/bin/gsl status` from the repo root → `🏠` +
-   any PR# for the current branch + `⑂N`; run it from inside a gss worktree
-   (`~/.config/gss/worktrees/.../plan`) → `🌳 <feature>` + `PR#<n>` (from `registry.json`, no
-   network) + `⑂N`. Move/rename the registry → PR# falls back to a cached `gh pr view`; on a plain
-   repo with no PR → `PR#` self-omits; on a lone main checkout → `⑂N` self-omits.
+5. **Repo segment (root vs worktree)**: run `~/opt/bin/gsl status` from the repo root → the root
+   indicator (` ` in the default `powerline` style, 🏠 under `emoji`) + any PR# for the current
+   branch + `⑂N`; run it from inside a gss worktree (`~/.config/gss/worktrees/.../plan`) → the
+   worktree indicator (` `/🌳) + `<feature>` + `PR#<n>` (from `registry.json`, no network) + `⑂N`.
+   Move/rename the registry → PR# falls back to a cached `gh pr view`; on a plain repo with no PR →
+   `PR#` self-omits; on a lone main checkout → `⑂N` self-omits.
 6. **Preview**: `gsl preview --once` → one rendered frame; `gsl preview` → interactive TUI,
-   toggle a segment (incl. `repo`), watch the clock tick, `q` to exit.
-7. **Toggle**: `gsl config disable time` → time gone; `gsl config disable repo` → repo segment
+   toggle a segment (incl. `repo`), cycle styles, watch the clock tick, `q` to exit.
+7. **Styles**: `gsl config style emoji` → line re-renders with emoji markers / thin separators;
+   `gsl config style --list` shows `powerline`*, `emoji` (+ any user styles); an unknown name
+   (`gsl config style nope`) → falls back to `powerline` with a stderr warning; add a `styles`
+   entry to `config.json` overriding one field → reflected on next render.
+8. **Toggle**: `gsl config disable time` → time gone; `gsl config disable repo` → repo segment
    gone; `gsl config enable …` restores; `gsl config disable` (master) → empty output.
-8. **Timeout proof**: prepend a `PATH` dir with a `git` (and `claude`/`gh`) that `sleep 5` →
+9. **Timeout proof**: prepend a `PATH` dir with a `git` (and `claude`/`gh`) that `sleep 5` →
    `time ~/opt/bin/gsl status` returns within the render budget with graceful degradation.
-9. **Wiring**: `bash opt/scripts/system/sync-skills.sh --build` builds gsl + links
-   `~/.claude/skills/gsl-status` and `~/.agents/skills/gsl-status`;
-   `bash opt/scripts/system/install_claude_skills.sh` → `~/.claude/statusline-command.sh`
-   symlink exists & executable; `bash opt/scripts/system/install_gemini_skills.sh` →
-   `~/.gemini/commands/gsl-status.toml` linked.
-10. **Shim fallback**: `mv ~/opt/bin/gsl ~/opt/bin/gsl.bak`, pipe a payload into
+10. **Wiring**: `bash opt/scripts/system/sync-skills.sh --build` builds gsl + links
+    `~/.claude/skills/gsl-status` and `~/.agents/skills/gsl-status`;
+    `bash opt/scripts/system/install_claude_skills.sh` → `~/.claude/statusline-command.sh`
+    symlink exists & executable; `bash opt/scripts/system/install_gemini_skills.sh` →
+    `~/.gemini/commands/gsl-status.toml` linked.
+11. **Shim fallback**: `mv ~/opt/bin/gsl ~/opt/bin/gsl.bak`, pipe a payload into
     `bash ~/.claude/statusline-command.sh` → minimal bash line; restore binary.
-11. **Live Claude pickup**: start a Claude Code session; after an assistant turn the status
+12. **Live Claude pickup**: start a Claude Code session; after an assistant turn the status
     line renders (harness pipes the live payload → shim → `gsl render`).

--- a/docs/plans/gsl-status-line.md
+++ b/docs/plans/gsl-status-line.md
@@ -1,0 +1,177 @@
+# Plan: `gsl` — a Go status line for Claude Code (+ Gemini on-demand)
+
+## Context
+
+The user wants a powerline-style status line for their AI CLIs, wired into `./install.sh`,
+that mirrors their zsh/p10k prompt and surfaces AI-session info. They prototyped with
+`npx ccstatusline@latest` but it can't meet the full requirement set, and they want Gemini
+covered too. Research established:
+
+- **ccstatusline is insufficient**: 60+ widgets (git, context %, model, session + weekly
+  usage) but **no time/date segment, no MCP segment, Claude-only**, and it re-spawns `npx`
+  per refresh. Config lives at `~/.config/ccstatusline/settings.json`; it just writes a
+  `statusLine.command` into Claude's settings.
+- **Claude Code's `statusLine`** pipes a JSON payload on stdin after every assistant turn
+  (300ms debounce — already satisfies "update after every prompt") and natively provides
+  `cwd`, `model.display_name`, `context_window.used_percentage`/tokens, and
+  `rate_limits.five_hour`/`seven_day` (= the requested "subscription usage left for day/week").
+  Git status must be computed via `git`; **MCP servers are NOT in the payload**.
+- **Gemini CLI has no scriptable status line** — only built-in footer toggles
+  (`display.footer`, `hideCWD`, `hideModelInfo`, `hideContextSummary`) and a `/hooks` system.
+  So a live custom line is realistically Claude-only; Gemini gets an on-demand command.
+- The repo strongly favors **Go tools in `src/`** (gss, tmux-mgr, wol) built via `build.sh`
+  to `~/opt/bin`, surfaced as a `SKILL.md` and linked by `sync-skills.sh`. The Claude settings
+  template already points `statusLine.command` at `bash ~/.claude/statusline-command.sh`
+  — a file that does not yet exist. **That shim is the missing hook.**
+
+**Decisions (confirmed with the user):**
+1. Build a new stdlib-only Go binary named **`gsl`** (Go Status Line) at `src/statusline/`,
+   compiled to `~/opt/bin/gsl`.
+2. Gemini: a **pretty on-demand `/gsl-status`** slash command (+ skill `gsl-status`) that runs
+   the same binary in plain-text mode; document Gemini's built-in footer toggles.
+3. MCP segment: **best-effort cached** — instant "configured" count + an "active" count from
+   `claude mcp list` refreshed at most once/60s.
+
+**Outcome:** one fast (~ms startup, zero-dep) binary renders a 3-part powerline status line
+— `dir+git` · `AI(context/model/MCP/rate-limits)` · `date/time` — live in Claude, on demand
+in Gemini, fully toggleable via a config file and a configuration skill.
+
+---
+
+## Approach
+
+### New tool: `src/statusline/` (module `github.com/wenlock/dotfiles/statusline`)
+
+Mirror the `src/gss` conventions: `build.sh` (goenv-aware `go`, version stamped via
+`-X .../internal/version.*` from a `VERSION` file, output to `~/opt/bin/gsl`, then run
+`scripts/check-deps.sh`), an `os/exec` **seam** confined to specific packages and enforced by
+`check-deps.sh`, a `skill/SKILL.md`, Apache-2.0 `LICENSE`. **Stdlib only** (JSON, time, os/exec)
+— no cobra, no external deps — so `go.mod` stays require-free and the license gate is trivially
+green (per `src/CLAUDE.md` license + TDD rules).
+
+```
+src/statusline/
+  main.go  go.mod  VERSION  build.sh  README.md  LICENSE
+  cmd/            root.go (switch os.Args[1]) render.go status.go config.go version.go (+ _test)
+  internal/
+    version/      version.go        (copy gss pattern)
+    payload/      payload.go        (defensive parse of Claude stdin JSON; all fields pointers)
+    config/       config.go         (Config, Default(), Load/Save, toggle helpers)
+    git/          exec.go (Runner seam) status.go (GitInfo)  fake/runner.go
+    mcp/          detect.go cache.go (Configured instant + Active cached/60s)  fake/runner.go
+    render/       segment.go glyphs.go render.go + seg_dirgit.go seg_ai.go seg_time.go
+  skill/SKILL.md  scripts/check-deps.sh  docs/design.md
+```
+
+**Subcommands** (manual `flag.FlagSet` dispatch):
+- `gsl render` (default) — read JSON payload on stdin, print powerline line(s). Claude's path.
+- `gsl status` — no stdin; pretty on-demand render (Gemini `/gsl-status` + CLI). Payload-only
+  segments self-omit.
+- `gsl config get|set|enable|disable|toggle [<segment>]` — drives the configuration skill.
+- `gsl version [--json]`.
+
+**Segments** (ordered, individually toggleable):
+1. **dirgit** — `~`-abbreviated cwd basename + branch + p10k-style counts: staged `+N`,
+   unstaged `!N`, untracked `?N`, stashes, ahead `⇡N`, behind `⇣N`. One
+   `git -C <dir> status --porcelain=v2 --branch` + `git stash list`, via the `git.Runner` seam
+   (~1s timeout). Mirrors `opt/profiles/.p10k.zsh` `my_git_formatter` glyph semantics.
+2. **ai** — from the Claude payload: `model.display_name`, `context_window.used_percentage`
+   + tokens vs `context_window_size`, MCP `active/configured`, and rate-limit usage for the
+   5-hour and 7-day windows (`rate_limits.five_hour`/`seven_day` + `resets_at`). Returns
+   `("", false)` (self-omits) when there is no payload (Gemini/CLI mode) or a field is null.
+3. **time** — current time in a configurable tz (default `America/Los_Angeles`/PST) with
+   Nerd-Font calendar + clock glyphs: day-of-week, month/day, `HH:MM`, tz abbreviation.
+
+**MCP detection** (`internal/mcp`): `ConfiguredCount(cwd)` parses `~/.claude.json`
+(top-level `mcpServers` + `projects.<cwd>.mcpServers`) and `./.mcp.json`, honoring
+`CLAUDE_CONFIG_DIR` — instant, no subprocess. `ActiveCount(...)` reads a cache at
+`${XDG_CACHE_HOME:-~/.cache}/gsl/mcp.json`; if older than 60s it runs `claude mcp list`
+through the `mcp.Runner` seam with a 2s timeout, parses connected vs failed markers, and
+rewrites the cache; on timeout/error it falls back to the last cache (never blocks the line).
+
+**Config + on/off** (`internal/config`): JSON at `${XDG_CONFIG_HOME:-~/.config}/gsl/config.json`,
+with `enabled` (master), an ordered `segments[]` (each `{type, enabled, options}`), `timezone`,
+time/date formats, `glyphs` (`nerdfont`|`ascii`), powerline separators, and `theme`. **Missing
+file ⇒ sane defaults** (the binary works with zero config). Two on/off layers, both honored:
+the harness `statusLine.command` key (hard off = remove it) and `config.enabled` (soft off:
+`gsl render` prints empty stdout) plus per-segment toggles — all reachable via `gsl config …`.
+
+### Wiring into install (exact edits)
+
+- **NEW `ai/claude/statusline-command.sh`** (committed, `chmod +x`): the shim the settings
+  template already references. Reads stdin once; if `~/opt/bin/gsl` exists, `exec`s
+  `~/opt/bin/gsl render` forwarding the payload; otherwise prints a minimal bash fallback
+  (`basename $PWD` + `git branch` + `date`) so the line never breaks pre-build.
+- **`opt/scripts/system/install_claude_skills.sh`**: after the commands-linking block, add a
+  guarded `ln -sf "$BASE_DIR/ai/claude/statusline-command.sh" "$CLAUDE_HOME/statusline-command.sh"`
+  (same backup-if-not-symlink guard used for settings.json/aliases.sh) + `chmod +x`.
+- **`opt/scripts/system/sync-skills.sh`**: line 97 build loop → add `"statusline"`; the name
+  `case` (lines 114-116) → add `statusline) dest_name="gsl-status" ;;` so the skill links to
+  `~/.claude/skills/gsl-status` and `~/.agents/skills/gsl-status`.
+- **NEW `ai/gemini/commands/gsl-status.toml`** (mirror `ai/gemini/commands/gss.toml`):
+  `description` + a pretty `prompt` blurb with `!{gsl status}` substitution and `{{args}}`.
+  Auto-linked — `install_gemini_skills.sh` already globs `ai/gemini/commands/*.toml`
+  (line 56), no script edit needed.
+- **No edits required** to: `.gitignore` (`!src/**` already tracks `src/statusline/**`; the
+  binary lives outside the repo), `install.sh` (already runs sync-skills + both install
+  scripts), `Makefile` (`make bin` auto-discovers `src/*/build.sh`), and
+  `ai/claude/settings.json.template` (the existing `Bash($HOME/opt/bin/*:*)` allow rule already
+  covers `gsl`; the `statusLine.command` line is already correct).
+
+### Files to create / modify (summary)
+
+| Action | Path |
+| --- | --- |
+| NEW (tool tree) | `src/statusline/**` — Go source, `build.sh`, `VERSION`, `skill/SKILL.md`, `scripts/check-deps.sh`, tests |
+| NEW | `ai/claude/statusline-command.sh` (shim) |
+| NEW | `ai/gemini/commands/gsl-status.toml` |
+| EDIT | `opt/scripts/system/install_claude_skills.sh` (symlink shim) |
+| EDIT | `opt/scripts/system/sync-skills.sh` (build loop + `gsl-status` case) |
+
+### Patterns to reuse (don't reinvent)
+
+- `src/gss/build.sh` — copy the goenv-aware, version-stamping build script verbatim, swapping
+  names/paths to `gsl`.
+- `src/gss/internal/git` + its `fake/` runner — the `os/exec` seam + fakeable Runner pattern
+  for both `git` and `mcp`; `src/gss/scripts/check-deps.sh` — copy and adjust the seam
+  allowlist to `internal/git` + `internal/mcp`.
+- `src/gss/internal/version` — version var + `Get()` fallback pattern.
+- `opt/profiles/.p10k.zsh` `my_git_formatter` — authoritative glyph semantics
+  (`⇡`/`⇣` ahead/behind, `+`/`!`/`?` staged/unstaged/untracked) to mirror.
+- `ai/gemini/commands/gss.toml` — exact TOML command format for `gsl-status.toml`.
+- `opt/scripts/system/install_claude_skills.sh` settings.json/aliases.sh symlink-with-backup
+  blocks — copy that shape for the shim symlink.
+
+---
+
+## Verification
+
+1. **Build**: `bash src/statusline/build.sh` → `gsl built and installed to ~/opt/bin/gsl`,
+   check-deps passes. (`make bin` also works.)
+2. **Tests/coverage** (TDD, >60% per pkg per `src/CLAUDE.md`):
+   `cd src/statusline && go test ./... -cover`. Seams faked via `git/fake` + `mcp/fake`;
+   payload fixtures under `internal/payload/testdata/`. Cases per package:
+   - payload: full fixture; malformed JSON → error; **empty stdin → empty struct, no error**;
+     `used_percentage:null` → nil; `seven_day` absent but `five_hour` present.
+   - git: scripted porcelain=v2 (staged/unstaged/untracked, ahead 2/behind 1, stashes); clean
+     repo → zeros; not-a-repo error; detached HEAD.
+   - mcp: configured count from temp `~/.claude.json` + `.mcp.json` (CLAUDE_CONFIG_DIR honored);
+     active from fake `claude mcp list` (mixed ✓/✗); **cache hit <60s ⇒ Runner not called**;
+     stale cache + timeout ⇒ last value.
+   - render/config: segment ordering + disable; master `enabled=false` ⇒ empty output;
+     tz render + bad-tz→UTC fallback; nerdfont vs ascii glyphs; Default()/Load-missing/round-trip.
+3. **Render (Claude path)**: pipe a sample payload —
+   `printf '%s' '{"cwd":"'"$PWD"'","model":{"display_name":"Sonnet"},"context_window":{"used_percentage":42,"total_input_tokens":84000,"context_window_size":200000},"rate_limits":{"five_hour":{"used_percentage":12.5,"resets_at":"2026-05-24T20:00:00Z"}}}' | ~/opt/bin/gsl render`
+   → one powerline line: dir+git, AI(model/ctx%/tokens/MCP/5h+7d), time.
+4. **On-demand (Gemini/CLI)**: `~/opt/bin/gsl status` (no stdin) → dir+git+time, AI omitted.
+5. **Toggle**: `gsl config disable time` → time gone; `gsl config enable time` restores;
+   `gsl config disable` (master) → empty output.
+6. **Wiring**: `bash opt/scripts/system/sync-skills.sh --build` builds gsl + links
+   `~/.claude/skills/gsl-status` and `~/.agents/skills/gsl-status`;
+   `bash opt/scripts/system/install_claude_skills.sh` → `~/.claude/statusline-command.sh`
+   symlink exists & executable; `bash opt/scripts/system/install_gemini_skills.sh` →
+   `~/.gemini/commands/gsl-status.toml` linked.
+7. **Shim fallback**: `mv ~/opt/bin/gsl ~/opt/bin/gsl.bak`, pipe a payload into
+   `bash ~/.claude/statusline-command.sh` → minimal bash line; restore binary.
+8. **Live Claude pickup**: start a Claude Code session; after an assistant turn the status
+   line renders (harness pipes the live payload → shim → `gsl render`).

--- a/docs/plans/gsl-status-line.md
+++ b/docs/plans/gsl-status-line.md
@@ -1,5 +1,26 @@
 # Plan: `gsl` — a Go status line for Claude Code (+ Gemini on-demand)
 
+## Revisions from multi-agent review (PR #21)
+
+A four-persona review (Architect, Researcher+Lead-Dev, Planner, QA) ran on this design.
+**Unanimous verdict: SOUND-WITH-CHANGES** — no architectural blockers. Four required
+changes (each a reviewer comment) are folded into the design below:
+
+1. **Adopt cobra + bubbletea** (was: stdlib-only). cobra for the CLI (`cmd.Execute()`,
+   logic in `internal/`, matching gss); bubbletea for the **preview TUI only — never in the
+   per-turn render hot path**. Licenses verified: cobra **Apache-2.0**, bubbletea **MIT** →
+   both allowed by `src/CLAUDE.md`; the license gate stays green.
+2. **`src/gsl`** (was: `src/statusline`) + module path `github.com/wenlock/dotfiles/gsl`,
+   cascaded through `build.sh` LDFLAGS and the `sync-skills.sh` case map.
+3. **First-class `gsl preview`** — `--once` (single snapshot, for CI/golden tests) **and** an
+   interactive bubbletea TUI (live-toggle segments/glyphs/theme, 1s clock tick), rendered
+   against representative sample-payload fixtures.
+4. **Concrete timeout/degrade budget** — `context.WithTimeout` + `exec.CommandContext`:
+   git ~800ms, `claude mcp list` ~500ms, total render soft ~150ms / hard ~500ms; on timeout
+   **degrade** (omit segment / use last MCP cache), **never block**.
+
+---
+
 ## Context
 
 The user wants a powerline-style status line for their AI CLIs, wired into `./install.sh`,
@@ -20,53 +41,83 @@ covered too. Research established:
   (`display.footer`, `hideCWD`, `hideModelInfo`, `hideContextSummary`) and a `/hooks` system.
   So a live custom line is realistically Claude-only; Gemini gets an on-demand command.
 - The repo strongly favors **Go tools in `src/`** (gss, tmux-mgr, wol) built via `build.sh`
-  to `~/opt/bin`, surfaced as a `SKILL.md` and linked by `sync-skills.sh`. The Claude settings
-  template already points `statusLine.command` at `bash ~/.claude/statusline-command.sh`
-  — a file that does not yet exist. **That shim is the missing hook.**
+  to `~/opt/bin`, surfaced as a `SKILL.md` and linked by `sync-skills.sh`. **gss already
+  depends on cobra** — so cobra is the established pattern, not a new dependency risk. The
+  Claude settings template already points `statusLine.command` at
+  `bash ~/.claude/statusline-command.sh` — a file that does not yet exist. **That shim is the
+  missing hook.**
 
-**Decisions (confirmed with the user):**
-1. Build a new stdlib-only Go binary named **`gsl`** (Go Status Line) at `src/statusline/`,
-   compiled to `~/opt/bin/gsl`.
+**Decisions (confirmed with the user; revised per review):**
+1. Build a new **cobra-based** Go binary named **`gsl`** (Go Status Line) at **`src/gsl/`**,
+   compiled to `~/opt/bin/gsl`. **bubbletea** powers the preview TUI only.
 2. Gemini: a **pretty on-demand `/gsl-status`** slash command (+ skill `gsl-status`) that runs
    the same binary in plain-text mode; document Gemini's built-in footer toggles.
 3. MCP segment: **best-effort cached** — instant "configured" count + an "active" count from
    `claude mcp list` refreshed at most once/60s.
 
-**Outcome:** one fast (~ms startup, zero-dep) binary renders a 3-part powerline status line
-— `dir+git` · `AI(context/model/MCP/rate-limits)` · `date/time` — live in Claude, on demand
-in Gemini, fully toggleable via a config file and a configuration skill.
+**Outcome:** one fast (~ms startup) binary renders a 3-part powerline status line —
+`dir+git` · `AI(context/model/MCP/rate-limits)` · `date/time` — live in Claude, on demand in
+Gemini, with a `gsl preview` to see and tune it, fully toggleable via a config file and a
+configuration skill.
+
+---
+
+## What it looks like (preview)
+
+Nerd-Font glyphs (representative; actual glyphs from `opt/profiles/.p10k.zsh`):
+
+```
+  ~/dotfiles   main +2 !1 ?3 ⇡2 ⇣1     Opus 4.7  42% 84k/200k   MCP 2/5   5h 12% · 7d 45%      Sat 05/24 15:30 PDT
+└──────── dirgit ────────┘ └──────────────────────── ai ────────────────────────┘ └──────── time ───────┘
+```
+
+ASCII fallback (`glyphs: ascii`):
+
+```
+[~/dotfiles] (main +2 !1 ?3 ^2 v1) | Opus 4.7 42% 84k/200k MCP 2/5 5h 12% 7d 45% | Sat 05/24 15:30 PDT
+```
+
+`gsl preview` renders this against fixture payloads (clean repo, dirty repo, high-context,
+rate-limited); `gsl preview` interactive lets you toggle each segment, switch glyphs/theme,
+and watch the clock tick before saving config.
 
 ---
 
 ## Approach
 
-### New tool: `src/statusline/` (module `github.com/wenlock/dotfiles/statusline`)
+### New tool: `src/gsl/` (module `github.com/wenlock/dotfiles/gsl`)
 
 Mirror the `src/gss` conventions: `build.sh` (goenv-aware `go`, version stamped via
-`-X .../internal/version.*` from a `VERSION` file, output to `~/opt/bin/gsl`, then run
-`scripts/check-deps.sh`), an `os/exec` **seam** confined to specific packages and enforced by
-`check-deps.sh`, a `skill/SKILL.md`, Apache-2.0 `LICENSE`. **Stdlib only** (JSON, time, os/exec)
-— no cobra, no external deps — so `go.mod` stays require-free and the license gate is trivially
-green (per `src/CLAUDE.md` license + TDD rules).
+`-X github.com/wenlock/dotfiles/gsl/internal/version.*` from a `VERSION` file, output to
+`~/opt/bin/gsl`, then run `scripts/check-deps.sh`), an `os/exec` **seam** confined to
+`internal/git` + `internal/mcp` and enforced by `check-deps.sh`, a `skill/SKILL.md`,
+Apache-2.0 `LICENSE`. **cobra** for dispatch (`cmd.Execute()` in `main.go`); **bubbletea**
+imported only by the preview package. `check-deps.sh` allows cobra/bubbletea in `cmd/` +
+`internal/preview`, and keeps `os/exec` out of everything except the two seams.
 
 ```
-src/statusline/
-  main.go  go.mod  VERSION  build.sh  README.md  LICENSE
-  cmd/            root.go (switch os.Args[1]) render.go status.go config.go version.go (+ _test)
+src/gsl/
+  main.go  go.mod  go.sum  VERSION  build.sh  README.md  LICENSE
+  cmd/            root.go (cobra root + Execute()) render.go status.go config.go
+                  preview.go version.go (+ _test)
   internal/
     version/      version.go        (copy gss pattern)
     payload/      payload.go        (defensive parse of Claude stdin JSON; all fields pointers)
     config/       config.go         (Config, Default(), Load/Save, toggle helpers)
-    git/          exec.go (Runner seam) status.go (GitInfo)  fake/runner.go
+    git/          exec.go (Runner seam, CommandContext) status.go (GitInfo)  fake/runner.go
     mcp/          detect.go cache.go (Configured instant + Active cached/60s)  fake/runner.go
     render/       segment.go glyphs.go render.go + seg_dirgit.go seg_ai.go seg_time.go
+    preview/      ui.go (bubbletea Model/Update/View) fixtures.go  (+ golden tests)
   skill/SKILL.md  scripts/check-deps.sh  docs/design.md
 ```
 
-**Subcommands** (manual `flag.FlagSet` dispatch):
+**Subcommands** (cobra command tree):
 - `gsl render` (default) — read JSON payload on stdin, print powerline line(s). Claude's path.
 - `gsl status` — no stdin; pretty on-demand render (Gemini `/gsl-status` + CLI). Payload-only
   segments self-omit.
+- `gsl preview [--once]` — render against sample fixtures; default is an interactive bubbletea
+  TUI (toggle segments/glyphs/theme, 1s clock tick); `--once` prints one frame and exits
+  (CI/golden-test friendly).
 - `gsl config get|set|enable|disable|toggle [<segment>]` — drives the configuration skill.
 - `gsl version [--json]`.
 
@@ -74,7 +125,7 @@ src/statusline/
 1. **dirgit** — `~`-abbreviated cwd basename + branch + p10k-style counts: staged `+N`,
    unstaged `!N`, untracked `?N`, stashes, ahead `⇡N`, behind `⇣N`. One
    `git -C <dir> status --porcelain=v2 --branch` + `git stash list`, via the `git.Runner` seam
-   (~1s timeout). Mirrors `opt/profiles/.p10k.zsh` `my_git_formatter` glyph semantics.
+   (`CommandContext`, ~800ms timeout). Mirrors `opt/profiles/.p10k.zsh` `my_git_formatter`.
 2. **ai** — from the Claude payload: `model.display_name`, `context_window.used_percentage`
    + tokens vs `context_window_size`, MCP `active/configured`, and rate-limit usage for the
    5-hour and 7-day windows (`rate_limits.five_hour`/`seven_day` + `resets_at`). Returns
@@ -82,12 +133,28 @@ src/statusline/
 3. **time** — current time in a configurable tz (default `America/Los_Angeles`/PST) with
    Nerd-Font calendar + clock glyphs: day-of-week, month/day, `HH:MM`, tz abbreviation.
 
+### Performance budget & graceful degradation (review comment #4)
+
+All subprocess work goes through the seams with `context.WithTimeout` + `exec.CommandContext`:
+
+| Call | Timeout | On timeout/error |
+| --- | --- | --- |
+| `git status …` + `git stash list` | ~800ms | omit git detail (show cwd only) or last value |
+| `claude mcp list` (active count) | ~500ms | fall back to last MCP cache, else configured-only |
+| **whole `gsl render`** | soft ~150ms / hard ~500ms | emit partial line (never block) |
+
+The render passes a parent context to every segment; a segment that exceeds its deadline is
+skipped, the rest still render. Timeout behaviour is unit-tested with fake runners that sleep
+past the deadline (no real hang), and an end-to-end check injects a slow `git`/`claude` on
+`PATH` to prove the line returns within budget.
+
 **MCP detection** (`internal/mcp`): `ConfiguredCount(cwd)` parses `~/.claude.json`
 (top-level `mcpServers` + `projects.<cwd>.mcpServers`) and `./.mcp.json`, honoring
 `CLAUDE_CONFIG_DIR` — instant, no subprocess. `ActiveCount(...)` reads a cache at
 `${XDG_CACHE_HOME:-~/.cache}/gsl/mcp.json`; if older than 60s it runs `claude mcp list`
-through the `mcp.Runner` seam with a 2s timeout, parses connected vs failed markers, and
-rewrites the cache; on timeout/error it falls back to the last cache (never blocks the line).
+through the `mcp.Runner` seam with the timeout above, parses connected vs failed markers, and
+rewrites the cache; a cache hit (<60s) spawns **no** subprocess (asserted via a spy runner in
+tests).
 
 **Config + on/off** (`internal/config`): JSON at `${XDG_CONFIG_HOME:-~/.config}/gsl/config.json`,
 with `enabled` (master), an ordered `segments[]` (each `{type, enabled, options}`), `timezone`,
@@ -105,14 +172,14 @@ the harness `statusLine.command` key (hard off = remove it) and `config.enabled`
 - **`opt/scripts/system/install_claude_skills.sh`**: after the commands-linking block, add a
   guarded `ln -sf "$BASE_DIR/ai/claude/statusline-command.sh" "$CLAUDE_HOME/statusline-command.sh"`
   (same backup-if-not-symlink guard used for settings.json/aliases.sh) + `chmod +x`.
-- **`opt/scripts/system/sync-skills.sh`**: line 97 build loop → add `"statusline"`; the name
-  `case` (lines 114-116) → add `statusline) dest_name="gsl-status" ;;` so the skill links to
+- **`opt/scripts/system/sync-skills.sh`**: line 97 build loop → add `"gsl"`; the name
+  `case` (lines 114-116) → add `gsl) dest_name="gsl-status" ;;` so the skill links to
   `~/.claude/skills/gsl-status` and `~/.agents/skills/gsl-status`.
 - **NEW `ai/gemini/commands/gsl-status.toml`** (mirror `ai/gemini/commands/gss.toml`):
   `description` + a pretty `prompt` blurb with `!{gsl status}` substitution and `{{args}}`.
   Auto-linked — `install_gemini_skills.sh` already globs `ai/gemini/commands/*.toml`
   (line 56), no script edit needed.
-- **No edits required** to: `.gitignore` (`!src/**` already tracks `src/statusline/**`; the
+- **No edits required** to: `.gitignore` (`!src/**` already tracks `src/gsl/**`; the
   binary lives outside the repo), `install.sh` (already runs sync-skills + both install
   scripts), `Makefile` (`make bin` auto-discovers `src/*/build.sh`), and
   `ai/claude/settings.json.template` (the existing `Bash($HOME/opt/bin/*:*)` allow rule already
@@ -122,7 +189,7 @@ the harness `statusLine.command` key (hard off = remove it) and `config.enabled`
 
 | Action | Path |
 | --- | --- |
-| NEW (tool tree) | `src/statusline/**` — Go source, `build.sh`, `VERSION`, `skill/SKILL.md`, `scripts/check-deps.sh`, tests |
+| NEW (tool tree) | `src/gsl/**` — cobra Go source, `build.sh`, `VERSION`, `internal/preview` (bubbletea), `skill/SKILL.md`, `scripts/check-deps.sh`, tests |
 | NEW | `ai/claude/statusline-command.sh` (shim) |
 | NEW | `ai/gemini/commands/gsl-status.toml` |
 | EDIT | `opt/scripts/system/install_claude_skills.sh` (symlink shim) |
@@ -132,9 +199,10 @@ the harness `statusLine.command` key (hard off = remove it) and `config.enabled`
 
 - `src/gss/build.sh` — copy the goenv-aware, version-stamping build script verbatim, swapping
   names/paths to `gsl`.
+- `src/gss/cmd/root.go` — cobra root + `Execute()` shape.
 - `src/gss/internal/git` + its `fake/` runner — the `os/exec` seam + fakeable Runner pattern
   for both `git` and `mcp`; `src/gss/scripts/check-deps.sh` — copy and adjust the seam
-  allowlist to `internal/git` + `internal/mcp`.
+  allowlist to `internal/git` + `internal/mcp` (and allow cobra/bubbletea in `cmd/`/`preview`).
 - `src/gss/internal/version` — version var + `Get()` fallback pattern.
 - `opt/profiles/.p10k.zsh` `my_git_formatter` — authoritative glyph semantics
   (`⇡`/`⇣` ahead/behind, `+`/`!`/`?` staged/unstaged/untracked) to mirror.
@@ -144,34 +212,62 @@ the harness `statusLine.command` key (hard off = remove it) and `config.enabled`
 
 ---
 
+## Execution plan (checkpoints → gss feature worker stack)
+
+Conservative sizing; the value is the sequencing. CP1↔CP2 are mostly parallelizable after the
+seams land; CP3 depends on both; CP4 is final.
+
+- **CP1 — Scaffolding & core.** `src/gsl` tree; cobra root + `Execute()`; `build.sh` +
+  `scripts/check-deps.sh` (from gss, seam allowlist adjusted); `internal/{version,payload,config}`
+  and the `git`/`mcp` seam interfaces + `fake/` runners. Gate: `go build ./...`, check-deps
+  green, no panic on missing config.
+- **CP2 — Detection & render.** `internal/git` (porcelain v2 + timeout), `internal/mcp`
+  (configured instant + active cached/timeout + spy-tested cache hit), `internal/render`
+  (3 segments, glyphs, powerline join, per-segment deadline).
+- **CP3 — CLI, preview & wiring.** `cmd/{render,status,config,version,preview}`;
+  `internal/preview` bubbletea TUI + `--once` golden snapshot; `ai/claude/statusline-command.sh`
+  shim + `install_claude_skills.sh` symlink; `sync-skills.sh` build loop + `gsl) gsl-status`
+  case; `ai/gemini/commands/gsl-status.toml`; `skill/SKILL.md`.
+- **CP4 — Docs & finalize.** `README.md`, `SKILL.md` polish, fold final decisions into this doc.
+
+---
+
 ## Verification
 
-1. **Build**: `bash src/statusline/build.sh` → `gsl built and installed to ~/opt/bin/gsl`,
+1. **Build**: `bash src/gsl/build.sh` → `gsl built and installed to ~/opt/bin/gsl`,
    check-deps passes. (`make bin` also works.)
-2. **Tests/coverage** (TDD, >60% per pkg per `src/CLAUDE.md`):
-   `cd src/statusline && go test ./... -cover`. Seams faked via `git/fake` + `mcp/fake`;
-   payload fixtures under `internal/payload/testdata/`. Cases per package:
+2. **Tests/coverage** (TDD, ≥60% per pkg per `src/CLAUDE.md`; targets: payload ~95, git 70,
+   mcp 60, config 70, render 75, cmd 80, preview 60):
+   `cd src/gsl && go test ./... -cover`. Seams faked via `git/fake` + `mcp/fake`; payload
+   fixtures under `internal/payload/testdata/`. Cases per package:
    - payload: full fixture; malformed JSON → error; **empty stdin → empty struct, no error**;
      `used_percentage:null` → nil; `seven_day` absent but `five_hour` present.
    - git: scripted porcelain=v2 (staged/unstaged/untracked, ahead 2/behind 1, stashes); clean
-     repo → zeros; not-a-repo error; detached HEAD.
+     repo → zeros; not-a-repo error; detached HEAD; **timeout (fake sleeps past deadline) →
+     degrades, no hang**.
    - mcp: configured count from temp `~/.claude.json` + `.mcp.json` (CLAUDE_CONFIG_DIR honored);
-     active from fake `claude mcp list` (mixed ✓/✗); **cache hit <60s ⇒ Runner not called**;
+     active from fake `claude mcp list` (mixed ✓/✗); **cache hit <60s ⇒ spy runner NOT called**;
      stale cache + timeout ⇒ last value.
-   - render/config: segment ordering + disable; master `enabled=false` ⇒ empty output;
-     tz render + bad-tz→UTC fallback; nerdfont vs ascii glyphs; Default()/Load-missing/round-trip.
+   - render: segment ordering + disable; master `enabled=false` ⇒ empty output; tz render +
+     bad-tz→UTC fallback; nerdfont vs ascii glyphs; **golden line at fixed time + fixed payload**.
+   - preview: `--once` golden frame; bubbletea model toggle/tick transitions.
+   - config: Default(); Load-missing → defaults; round-trip; toggle; bad-tz fallback.
 3. **Render (Claude path)**: pipe a sample payload —
-   `printf '%s' '{"cwd":"'"$PWD"'","model":{"display_name":"Sonnet"},"context_window":{"used_percentage":42,"total_input_tokens":84000,"context_window_size":200000},"rate_limits":{"five_hour":{"used_percentage":12.5,"resets_at":"2026-05-24T20:00:00Z"}}}' | ~/opt/bin/gsl render`
+   `printf '%s' '{"cwd":"'"$PWD"'","model":{"display_name":"Opus 4.7"},"context_window":{"used_percentage":42,"total_input_tokens":84000,"context_window_size":200000},"rate_limits":{"five_hour":{"used_percentage":12.5,"resets_at":"2026-05-24T20:00:00Z"}}}' | ~/opt/bin/gsl render`
    → one powerline line: dir+git, AI(model/ctx%/tokens/MCP/5h+7d), time.
 4. **On-demand (Gemini/CLI)**: `~/opt/bin/gsl status` (no stdin) → dir+git+time, AI omitted.
-5. **Toggle**: `gsl config disable time` → time gone; `gsl config enable time` restores;
+5. **Preview**: `gsl preview --once` → one rendered frame; `gsl preview` → interactive TUI,
+   toggle a segment, watch the clock tick, `q` to exit.
+6. **Toggle**: `gsl config disable time` → time gone; `gsl config enable time` restores;
    `gsl config disable` (master) → empty output.
-6. **Wiring**: `bash opt/scripts/system/sync-skills.sh --build` builds gsl + links
+7. **Timeout proof**: prepend a `PATH` dir with a `git` (and `claude`) that `sleep 5` →
+   `time ~/opt/bin/gsl status` returns within the render budget with graceful degradation.
+8. **Wiring**: `bash opt/scripts/system/sync-skills.sh --build` builds gsl + links
    `~/.claude/skills/gsl-status` and `~/.agents/skills/gsl-status`;
    `bash opt/scripts/system/install_claude_skills.sh` → `~/.claude/statusline-command.sh`
    symlink exists & executable; `bash opt/scripts/system/install_gemini_skills.sh` →
    `~/.gemini/commands/gsl-status.toml` linked.
-7. **Shim fallback**: `mv ~/opt/bin/gsl ~/opt/bin/gsl.bak`, pipe a payload into
+9. **Shim fallback**: `mv ~/opt/bin/gsl ~/opt/bin/gsl.bak`, pipe a payload into
    `bash ~/.claude/statusline-command.sh` → minimal bash line; restore binary.
-8. **Live Claude pickup**: start a Claude Code session; after an assistant turn the status
-   line renders (harness pipes the live payload → shim → `gsl render`).
+10. **Live Claude pickup**: start a Claude Code session; after an assistant turn the status
+    line renders (harness pipes the live payload → shim → `gsl render`).

--- a/docs/plans/gsl-status-line.md
+++ b/docs/plans/gsl-status-line.md
@@ -21,6 +21,25 @@ changes (each a reviewer comment) are folded into the design below:
    the sum — every per-call deadline sits below the ceiling and can actually fire. On timeout
    **degrade** (omit segment / use last MCP cache), **never block**.
 
+## Follow-up requirement: `repo` segment (PR# + worktree awareness)
+
+After the review, the user added a fifth requirement: a **fourth segment** — `repo` — between
+`dirgit` and `ai`, surfacing repo/worktree context the existing segments don't:
+
+- a **🏠 root / 🌳 worktree indicator** (blue / magenta; ASCII `[root]` / `[wt]`) showing whether
+  the current checkout is the canonical repo root or a linked git worktree;
+- in a worktree, the **gss feature name** it belongs to (e.g. `gsl`) — info `dirgit` doesn't show
+  (it shows the worktree's own dir basename + branch); non-gss worktrees fall back to the dir name;
+- the active **PR number** (`PR#21`, tinted by PR state), resolved **instantly from the gss
+  registry** with `gh pr view` as a cached network fallback;
+- a **worktree count** (`⑂N`, shown when N ≥ 2; ASCII `wtN`) — "how many worktrees do I have going",
+  in the spirit of the MCP `active/configured` count.
+
+All of it is one instant `registry.json` read plus two fast git calls (`rev-parse`,
+`git worktree list`); only the `gh` fallback touches the network, and it is cached/timed out like
+`claude mcp list`. The segment self-omits parts that don't apply, so a plain non-git dir shows
+nothing extra. Details fold into the sections below.
+
 ---
 
 ## Context
@@ -56,32 +75,47 @@ covered too. Research established:
    the same binary in plain-text mode; document Gemini's built-in footer toggles.
 3. MCP segment: **best-effort cached** — instant "configured" count + an "active" count from
    `claude mcp list` refreshed at most once/60s.
+4. `repo` segment: **🏠/🌳 root-vs-worktree indicator + gss feature name + PR# + worktree count**,
+   sourced from the gss `registry.json` (instant) and local git, with a cached `gh pr view`
+   fallback for the PR number on non-gss branches.
 
-**Outcome:** one fast (~ms startup) binary renders a 3-part powerline status line —
-`dir+git` · `AI(context/model/MCP/rate-limits)` · `date/time` — live in Claude, on demand in
-Gemini, with a `gsl preview` to see and tune it, fully toggleable via a config file and a
-configuration skill.
+**Outcome:** one fast (~ms startup) binary renders a 4-part powerline status line —
+`dir+git` · `repo(root/worktree · PR# · worktree-count)` · `AI(context/model/MCP/rate-limits)` ·
+`date/time` — live in Claude, on demand in Gemini, with a `gsl preview` to see and tune it, fully
+toggleable via a config file and a configuration skill.
 
 ---
 
 ## What it looks like (preview)
 
-Nerd-Font glyphs (representative; actual glyphs from `opt/profiles/.p10k.zsh`):
+Nerd-Font glyphs (representative; actual glyphs from `opt/profiles/.p10k.zsh`). The `repo`
+segment (2nd) renders differently at the repo root vs inside a linked worktree:
 
 ```
-  ~/dotfiles   main +2 !1 ?3 ⇡2 ⇣1     Opus 4.7  42% 84k/200k   MCP 2/5   5h 12% · 7d 45%      Sat 05/24 15:30 PDT
-└──────── dirgit ────────┘ └──────────────────────── ai ────────────────────────┘ └──────── time ───────┘
+root checkout:
+  ~/dotfiles   main +2 !1 ?3 ⇡2 ⇣1    🏠 PR#42 ⑂4    Opus 4.7  42% 84k/200k  MCP 2/5  5h 12% · 7d 45%   Sat 05/24 15:30 PDT
+└──────── dirgit ────────┘ └─── repo ───┘ └──────────────────────── ai ────────────────────────┘ └──────── time ───────┘
+
+inside a worktree:
+  …/gsl/…/plan   feature/gsl… +1     🌳 gsl PR#21 ⑂4    Opus 4.7  42% 84k/200k  MCP 2/5  5h 12% · 7d 45%   Sat 05/24 15:30 PDT
+└──────── dirgit ─────────┘ └────── repo ──────┘ └──────────────────────── ai ────────────────────────┘ └──────── time ───────┘
 ```
+
+`repo` glyphs: 🏠 = repo root (blue), 🌳 = linked worktree (magenta); `gsl` = the gss feature the
+worktree belongs to; `PR#21` is tinted by PR state (draft dim / open normal); `⑂4` = 4 worktrees
+exist. Parts self-omit: no PR ⇒ no `PR#`, a lone main checkout ⇒ no `⑂N`, a non-git dir ⇒ the whole
+`repo` segment disappears.
 
 ASCII fallback (`glyphs: ascii`):
 
 ```
-[~/dotfiles] (main +2 !1 ?3 ^2 v1) | Opus 4.7 42% 84k/200k MCP 2/5 5h 12% 7d 45% | Sat 05/24 15:30 PDT
+[~/dotfiles] (main +2 !1 ?3 ^2 v1) | [root] PR#42 wt4 | Opus 4.7 42% 84k/200k MCP 2/5 5h 12% 7d 45% | Sat 05/24 15:30 PDT
+[~/…/plan]   (feature/gsl… +1)     | [wt] gsl PR#21 wt4 | Opus 4.7 42% 84k/200k MCP 2/5 5h 12% 7d 45% | Sat 05/24 15:30 PDT
 ```
 
 `gsl preview` renders this against fixture payloads (clean repo, dirty repo, high-context,
-rate-limited); `gsl preview` interactive lets you toggle each segment, switch glyphs/theme,
-and watch the clock tick before saving config.
+rate-limited, **root vs worktree**); `gsl preview` interactive lets you toggle each segment, switch
+glyphs/theme, and watch the clock tick before saving config.
 
 ---
 
@@ -92,10 +126,10 @@ and watch the clock tick before saving config.
 Mirror the `src/gss` conventions: `build.sh` (goenv-aware `go`, version stamped via
 `-X github.com/wenlock/dotfiles/gsl/internal/version.*` from a `VERSION` file, output to
 `~/opt/bin/gsl`, then run `scripts/check-deps.sh`), an `os/exec` **seam** confined to
-`internal/git` + `internal/mcp` and enforced by `check-deps.sh`, a `skill/SKILL.md`,
-Apache-2.0 `LICENSE`. **cobra** for dispatch (`cmd.Execute()` in `main.go`); **bubbletea**
-imported only by the preview package. `check-deps.sh` allows cobra/bubbletea in `cmd/` +
-`internal/preview`, and keeps `os/exec` out of everything except the two seams.
+`internal/git`, `internal/mcp`, and `internal/gh` and enforced by `check-deps.sh`, a
+`skill/SKILL.md`, Apache-2.0 `LICENSE`. **cobra** for dispatch (`cmd.Execute()` in `main.go`);
+**bubbletea** imported only by the preview package. `check-deps.sh` allows cobra/bubbletea in
+`cmd/` + `internal/preview`, and keeps `os/exec` out of everything except the three seams.
 
 ```
 src/gsl/
@@ -106,9 +140,13 @@ src/gsl/
     version/      version.go        (copy gss pattern)
     payload/      payload.go        (defensive parse of Claude stdin JSON; all fields pointers)
     config/       config.go         (Config, Default(), Load/Save, toggle helpers)
-    git/          exec.go (Runner seam, CommandContext) status.go (GitInfo)  fake/runner.go
+    git/          exec.go (Runner seam, CommandContext) status.go (GitInfo)
+                  worktree.go (IsLinked, Count, Toplevel)  fake/runner.go
     mcp/          detect.go cache.go (Configured instant + Active cached/60s)  fake/runner.go
-    render/       segment.go glyphs.go render.go + seg_dirgit.go seg_ai.go seg_time.go
+    repo/         detect.go (root/worktree via git) registry.go (gss registry.json reader)
+                  pr.go (PR# from registry → gh fallback)
+    gh/           exec.go (Runner seam, CommandContext) pr.go (gh pr view, cached/60s)  fake/runner.go
+    render/       segment.go glyphs.go render.go + seg_dirgit.go seg_repo.go seg_ai.go seg_time.go
     preview/      ui.go (bubbletea Model/Update/View) fixtures.go  (+ golden tests)
   skill/SKILL.md  scripts/check-deps.sh  docs/design.md
 ```
@@ -128,11 +166,18 @@ src/gsl/
    unstaged `!N`, untracked `?N`, stashes, ahead `⇡N`, behind `⇣N`. One
    `git -C <dir> status --porcelain=v2 --branch` + `git stash list`, via the `git.Runner` seam
    (`CommandContext`, ~800ms timeout). Mirrors `opt/profiles/.p10k.zsh` `my_git_formatter`.
-2. **ai** — from the Claude payload: `model.display_name`, `context_window.used_percentage`
+2. **repo** — repo/worktree context, all from local git + the gss registry (no payload needed,
+   so it renders in Claude *and* Gemini/CLI mode). Left→right, each part self-omitting:
+   **🏠 root / 🌳 worktree** indicator (root if `git rev-parse --git-dir` ==
+   `--git-common-dir`, else linked worktree); in a worktree the **gss feature name**; the
+   **PR number** (`repo.PR()` → registry first, `gh` fallback); and the **worktree count**
+   (`git worktree list`, shown when ≥ 2). Glyphs honor `glyphs` (🏠/🌳/⑂ vs `[root]`/`[wt]`/`wtN`);
+   colors root=blue / worktree=magenta (themeable). Self-omits entirely outside a git repo.
+3. **ai** — from the Claude payload: `model.display_name`, `context_window.used_percentage`
    + tokens vs `context_window_size`, MCP `active/configured`, and rate-limit usage for the
    5-hour and 7-day windows (`rate_limits.five_hour`/`seven_day` + `resets_at`). Returns
    `("", false)` (self-omits) when there is no payload (Gemini/CLI mode) or a field is null.
-3. **time** — current time in a configurable tz (default `America/Los_Angeles`/PST) with
+4. **time** — current time in a configurable tz (default `America/Los_Angeles`/PST) with
    Nerd-Font calendar + clock glyphs: day-of-week, month/day, `HH:MM`, tz abbreviation.
 
 ### Performance budget & graceful degradation (review comment #4)
@@ -142,6 +187,9 @@ All subprocess work goes through the seams with `context.WithTimeout` + `exec.Co
 | Call | Timeout | On timeout/error |
 | --- | --- | --- |
 | `git status …` + `git stash list` | ~800ms | omit git detail (show cwd only) or last value |
+| `git rev-parse` + `git worktree list` (repo seg) | ~800ms (shared git budget) | omit worktree indicator/count |
+| `~/.config/gss/worktrees/registry.json` read (PR# + name) | none (instant file read) | parse error ⇒ fall through to `gh` |
+| `gh pr view` (PR# fallback only) | ~800ms | last PR cache, else omit `PR#` |
 | `claude mcp list` (active count) | ~500ms | fall back to last MCP cache, else configured-only |
 | **whole `gsl render`** | soft ~150ms / hard ~1000ms | emit partial line (never block) |
 
@@ -161,10 +209,25 @@ through the `mcp.Runner` seam with the timeout above, parses connected vs failed
 rewrites the cache; a cache hit (<60s) spawns **no** subprocess (asserted via a spy runner in
 tests).
 
+**Repo/worktree detection** (`internal/repo` + `internal/git/worktree.go`): root-vs-worktree is
+`git rev-parse --path-format=absolute --git-common-dir` vs `--git-dir` — equal ⇒ root, differ ⇒
+linked worktree (verified against this repo). Worktree count is `git worktree list --porcelain`
+(count `^worktree ` lines), via the `git.Runner` seam under the shared git budget. Feature name +
+PR number come from `repo.PR(branch, toplevel)`: read `${XDG_CONFIG_HOME:-~/.config}/gss/worktrees/
+registry.json` (guard on `schema_version`), match the current `--show-toplevel` (or branch) to a
+worker row, and take `pr_url` (parse the trailing number) + `pr_state` + the parent feature `name`
+— **instant, no subprocess**. Only when the registry is absent / the branch isn't found does it
+fall back to `internal/gh`: `gh pr view --json number,state` through the `gh.Runner` seam, cached at
+`${XDG_CACHE_HOME:-~/.cache}/gsl/pr-<branch>.json` for 60s (cache hit ⇒ no subprocess, spy-tested),
+timed out as above; no PR / no `gh` / no remote ⇒ the `PR#` part self-omits.
+
 **Config + on/off** (`internal/config`): JSON at `${XDG_CONFIG_HOME:-~/.config}/gsl/config.json`,
 with `enabled` (master), an ordered `segments[]` (each `{type, enabled, options}`), `timezone`,
-time/date formats, `glyphs` (`nerdfont`|`ascii`), powerline separators, and `theme`. **Missing
-file ⇒ sane defaults** (the binary works with zero config). Two on/off layers, both honored:
+time/date formats, `glyphs` (`nerdfont`|`ascii`), powerline separators, and `theme`. The `repo`
+segment's `options` carry `show_pr` (bool), `show_count` (bool), and `name`
+(`feature`|`worker`|`branch`|`off`, default `feature`); its colors live in `theme`
+(`repo_root`/`repo_worktree`, default blue/magenta). **Missing file ⇒ sane defaults** (the binary
+works with zero config; `repo` enabled by default). Two on/off layers, both honored:
 the harness `statusLine.command` key (hard off = remove it) and `config.enabled` (soft off:
 `gsl render` prints empty stdout) plus per-segment toggles — all reachable via `gsl config …`.
 
@@ -194,7 +257,7 @@ the harness `statusLine.command` key (hard off = remove it) and `config.enabled`
 
 | Action | Path |
 | --- | --- |
-| NEW (tool tree) | `src/gsl/**` — cobra Go source, `build.sh`, `VERSION`, `internal/preview` (bubbletea), `skill/SKILL.md`, `scripts/check-deps.sh`, tests |
+| NEW (tool tree) | `src/gsl/**` — cobra Go source, `build.sh`, `VERSION`, `internal/{repo,gh}` (worktree + PR# detection), `internal/preview` (bubbletea), `skill/SKILL.md`, `scripts/check-deps.sh`, tests |
 | NEW | `ai/claude/statusline-command.sh` (shim) |
 | NEW | `ai/gemini/commands/gsl-status.toml` |
 | EDIT | `opt/scripts/system/install_claude_skills.sh` (symlink shim) |
@@ -206,8 +269,12 @@ the harness `statusLine.command` key (hard off = remove it) and `config.enabled`
   names/paths to `gsl`.
 - `src/gss/cmd/root.go` — cobra root + `Execute()` shape.
 - `src/gss/internal/git` + its `fake/` runner — the `os/exec` seam + fakeable Runner pattern
-  for both `git` and `mcp`; `src/gss/scripts/check-deps.sh` — copy and adjust the seam
-  allowlist to `internal/git` + `internal/mcp` (and allow cobra/bubbletea in `cmd/`/`preview`).
+  reused for `git`, `mcp`, and `gh`; `src/gss/scripts/check-deps.sh` — copy and adjust the seam
+  allowlist to `internal/git` + `internal/mcp` + `internal/gh` (and allow cobra/bubbletea in
+  `cmd/`/`preview`).
+- `gss feature list --json` / `~/.config/gss/worktrees/registry.json` — the worker rows
+  (`branch`, `worktree`, `pr_url`, `pr_state`, parent `name`) the `internal/repo` registry reader
+  parses; guard on the top-level `schema_version`.
 - `src/gss/internal/version` — version var + `Get()` fallback pattern.
 - `opt/profiles/.p10k.zsh` `my_git_formatter` — authoritative glyph semantics
   (`⇡`/`⇣` ahead/behind, `+`/`!`/`?` staged/unstaged/untracked) to mirror.
@@ -226,9 +293,11 @@ seams land; CP3 depends on both; CP4 is final.
   `scripts/check-deps.sh` (from gss, seam allowlist adjusted); `internal/{version,payload,config}`
   and the `git`/`mcp` seam interfaces + `fake/` runners. Gate: `go build ./...`, check-deps
   green, no panic on missing config.
-- **CP2 — Detection & render.** `internal/git` (porcelain v2 + timeout), `internal/mcp`
-  (configured instant + active cached/timeout + spy-tested cache hit), `internal/render`
-  (3 segments, glyphs, powerline join, per-segment deadline).
+- **CP2 — Detection & render.** `internal/git` (porcelain v2 + timeout + `worktree.go`),
+  `internal/mcp` (configured instant + active cached/timeout + spy-tested cache hit),
+  `internal/repo` (root/worktree detect + registry reader) and `internal/gh` (cached PR# fallback
+  + spy-tested cache hit), `internal/render` (**4 segments** incl. `seg_repo.go`, glyphs,
+  powerline join, per-segment deadline).
 - **CP3 — CLI, preview & wiring.** `cmd/{render,status,config,version,preview}`;
   `internal/preview` bubbletea TUI + `--once` golden snapshot; `ai/claude/statusline-command.sh`
   shim + `install_claude_skills.sh` symlink; `sync-skills.sh` build loop + `gsl) gsl-status`
@@ -242,9 +311,10 @@ seams land; CP3 depends on both; CP4 is final.
 1. **Build**: `bash src/gsl/build.sh` → `gsl built and installed to ~/opt/bin/gsl`,
    check-deps passes. (`make bin` also works.)
 2. **Tests/coverage** (TDD, ≥60% per pkg per `src/CLAUDE.md`; targets: payload ~95, git 70,
-   mcp 60, config 70, render 75, cmd 80, preview 60):
-   `cd src/gsl && go test ./... -cover`. Seams faked via `git/fake` + `mcp/fake`; payload
-   fixtures under `internal/payload/testdata/`. Cases per package:
+   mcp 60, repo 70, gh 60, config 70, render 75, cmd 80, preview 60):
+   `cd src/gsl && go test ./... -cover`. Seams faked via `git/fake` + `mcp/fake` + `gh/fake`;
+   payload fixtures under `internal/payload/testdata/`, registry fixtures under
+   `internal/repo/testdata/`. Cases per package:
    - payload: full fixture; malformed JSON → error; **empty stdin → empty struct, no error**;
      `used_percentage:null` → nil; `seven_day` absent but `five_hour` present.
    - git: scripted porcelain=v2 (staged/unstaged/untracked, ahead 2/behind 1, stashes); clean
@@ -253,26 +323,41 @@ seams land; CP3 depends on both; CP4 is final.
    - mcp: configured count from temp `~/.claude.json` + `.mcp.json` (CLAUDE_CONFIG_DIR honored);
      active from fake `claude mcp list` (mixed ✓/✗); **cache hit <60s ⇒ spy runner NOT called**;
      stale cache + timeout ⇒ last value.
-   - render: segment ordering + disable; master `enabled=false` ⇒ empty output; tz render +
-     bad-tz→UTC fallback; nerdfont vs ascii glyphs; **golden line at fixed time + fixed payload**.
+   - repo: root detect (`--git-dir`==`--git-common-dir`) vs linked-worktree (differ), via fake
+     `git rev-parse`; worktree count from fake `git worktree list --porcelain` (1, 4); registry
+     parse from fixture `registry.json` — match by toplevel **and** by branch, `pr_url`→number,
+     `pr_state` + feature `name`; worker with no `pr_url`; **bumped `schema_version` ⇒ ignored**
+     (falls through to gh); missing registry ⇒ gh fallback.
+   - gh: PR# from fake `gh pr view` (open/draft/none); **cache hit <60s ⇒ spy NOT called**;
+     timeout/`gh` absent/no remote ⇒ omit.
+   - render: segment ordering + disable; master `enabled=false` ⇒ empty output; **repo: 🏠 root vs
+     🌳 worktree glyph + color, PR#/count omission, `name` modes (feature/worker/branch/off)**; tz
+     render + bad-tz→UTC fallback; nerdfont vs ascii glyphs; **golden line at fixed time + fixed
+     payload, for both root and worktree**.
    - preview: `--once` golden frame; bubbletea model toggle/tick transitions.
    - config: Default(); Load-missing → defaults; round-trip; toggle; bad-tz fallback.
 3. **Render (Claude path)**: pipe a sample payload —
    `printf '%s' '{"cwd":"'"$PWD"'","model":{"display_name":"Opus 4.7"},"context_window":{"used_percentage":42,"total_input_tokens":84000,"context_window_size":200000},"rate_limits":{"five_hour":{"used_percentage":12.5,"resets_at":"2026-05-24T20:00:00Z"}}}' | ~/opt/bin/gsl render`
-   → one powerline line: dir+git, AI(model/ctx%/tokens/MCP/5h+7d), time.
-4. **On-demand (Gemini/CLI)**: `~/opt/bin/gsl status` (no stdin) → dir+git+time, AI omitted.
-5. **Preview**: `gsl preview --once` → one rendered frame; `gsl preview` → interactive TUI,
-   toggle a segment, watch the clock tick, `q` to exit.
-6. **Toggle**: `gsl config disable time` → time gone; `gsl config enable time` restores;
-   `gsl config disable` (master) → empty output.
-7. **Timeout proof**: prepend a `PATH` dir with a `git` (and `claude`) that `sleep 5` →
+   → one powerline line: dir+git, repo(root/worktree·PR#·count), AI(model/ctx%/tokens/MCP/5h+7d), time.
+4. **On-demand (Gemini/CLI)**: `~/opt/bin/gsl status` (no stdin) → dir+git+repo+time, AI omitted
+   (repo renders without a payload).
+5. **Repo segment (root vs worktree)**: run `~/opt/bin/gsl status` from the repo root → `🏠` +
+   any PR# for the current branch + `⑂N`; run it from inside a gss worktree
+   (`~/.config/gss/worktrees/.../plan`) → `🌳 <feature>` + `PR#<n>` (from `registry.json`, no
+   network) + `⑂N`. Move/rename the registry → PR# falls back to a cached `gh pr view`; on a plain
+   repo with no PR → `PR#` self-omits; on a lone main checkout → `⑂N` self-omits.
+6. **Preview**: `gsl preview --once` → one rendered frame; `gsl preview` → interactive TUI,
+   toggle a segment (incl. `repo`), watch the clock tick, `q` to exit.
+7. **Toggle**: `gsl config disable time` → time gone; `gsl config disable repo` → repo segment
+   gone; `gsl config enable …` restores; `gsl config disable` (master) → empty output.
+8. **Timeout proof**: prepend a `PATH` dir with a `git` (and `claude`/`gh`) that `sleep 5` →
    `time ~/opt/bin/gsl status` returns within the render budget with graceful degradation.
-8. **Wiring**: `bash opt/scripts/system/sync-skills.sh --build` builds gsl + links
+9. **Wiring**: `bash opt/scripts/system/sync-skills.sh --build` builds gsl + links
    `~/.claude/skills/gsl-status` and `~/.agents/skills/gsl-status`;
    `bash opt/scripts/system/install_claude_skills.sh` → `~/.claude/statusline-command.sh`
    symlink exists & executable; `bash opt/scripts/system/install_gemini_skills.sh` →
    `~/.gemini/commands/gsl-status.toml` linked.
-9. **Shim fallback**: `mv ~/opt/bin/gsl ~/opt/bin/gsl.bak`, pipe a payload into
-   `bash ~/.claude/statusline-command.sh` → minimal bash line; restore binary.
-10. **Live Claude pickup**: start a Claude Code session; after an assistant turn the status
+10. **Shim fallback**: `mv ~/opt/bin/gsl ~/opt/bin/gsl.bak`, pipe a payload into
+    `bash ~/.claude/statusline-command.sh` → minimal bash line; restore binary.
+11. **Live Claude pickup**: start a Claude Code session; after an assistant turn the status
     line renders (harness pipes the live payload → shim → `gsl render`).

--- a/docs/plans/gsl-status-line.md
+++ b/docs/plans/gsl-status-line.md
@@ -16,7 +16,9 @@ changes (each a reviewer comment) are folded into the design below:
    interactive bubbletea TUI (live-toggle segments/glyphs/theme, 1s clock tick), rendered
    against representative sample-payload fixtures.
 4. **Concrete timeout/degrade budget** — `context.WithTimeout` + `exec.CommandContext`:
-   git ~800ms, `claude mcp list` ~500ms, total render soft ~150ms / hard ~500ms; on timeout
+   git ~800ms, `claude mcp list` ~500ms, total render soft ~150ms / hard ~1000ms. Segments
+   render **concurrently**, so the hard cap bounds the slowest single call (git ~800ms), not
+   the sum — every per-call deadline sits below the ceiling and can actually fire. On timeout
    **degrade** (omit segment / use last MCP cache), **never block**.
 
 ---
@@ -141,9 +143,12 @@ All subprocess work goes through the seams with `context.WithTimeout` + `exec.Co
 | --- | --- | --- |
 | `git status …` + `git stash list` | ~800ms | omit git detail (show cwd only) or last value |
 | `claude mcp list` (active count) | ~500ms | fall back to last MCP cache, else configured-only |
-| **whole `gsl render`** | soft ~150ms / hard ~500ms | emit partial line (never block) |
+| **whole `gsl render`** | soft ~150ms / hard ~1000ms | emit partial line (never block) |
 
-The render passes a parent context to every segment; a segment that exceeds its deadline is
+The hard cap (~1000ms) sits above the slowest per-call deadline (git ~800ms) so each per-call
+timeout can actually fire before the parent context cancels it. The render passes a parent
+context to every segment and runs the segments **concurrently** (so wall-clock ≈ the slowest
+single call, not the sum); a segment that exceeds its deadline — or the parent ceiling — is
 skipped, the rest still render. Timeout behaviour is unit-tested with fake runners that sleep
 past the deadline (no real hang), and an end-to-end check injects a slow `git`/`claude` on
 `PATH` to prove the line returns within budget.


### PR DESCRIPTION
> **Update (impl shipped):** Implemented end-to-end in **#27** (all CP1–CP4, ready-for-review). DoD checkboxes + a "Shipped" note folded into the plan docs in this PR.

Publish the gsl status-line implementation plan under docs/plans/

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **gsl**.

- **#21 — edward-raigosa/plan (base: `main`)** ← you are here
- (no PR yet) — edward-raigosa/impl (base: `main`)

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->

