### PR TITLE
feat(system): interactive Windows customization and app provisioning

### DIFF
--- a/opt/Desktop/Apps/scripts/apps.json
+++ b/opt/Desktop/Apps/scripts/apps.json
@@ -1,5 +1,10 @@
 [
   {
+    "Name": "Windows Terminal",
+    "Id": "Microsoft.WindowsTerminal",
+    "Match": "Windows Terminal"
+  },
+  {
     "Name": "Discord",
     "Id": "Discord.Discord",
     "Match": "Discord"

--- a/opt/Desktop/Apps/scripts/apps.json
+++ b/opt/Desktop/Apps/scripts/apps.json
@@ -1,0 +1,80 @@
+[
+  {
+    "Name": "Discord",
+    "Id": "Discord.Discord",
+    "Match": "Discord"
+  },
+  {
+    "Name": "Slack",
+    "Id": "SlackTechnologies.Slack",
+    "Match": "Slack"
+  },
+  {
+    "Name": "Obsidian",
+    "Id": "Obsidian.Obsidian",
+    "Match": "Obsidian"
+  },
+  {
+    "Name": "OBS Studio",
+    "Id": "OBSProject.OBSStudio",
+    "Match": "OBS Studio"
+  },
+  {
+    "Name": "Spotify",
+    "Id": "Spotify.Spotify",
+    "Match": "Spotify"
+  },
+  {
+    "Name": "Apple iTunes",
+    "Id": "Apple.iTunes",
+    "Match": "iTunes"
+  },
+  {
+    "Name": "Antigravity",
+    "Id": "Google.Antigravity",
+    "Match": "^Antigravity(?! IDE)"
+  },
+  {
+    "Name": "Antigravity IDE",
+    "Id": "Google.AntigravityIDE",
+    "Match": "Antigravity IDE"
+  },
+  {
+    "Name": "Cursor",
+    "Id": "Anysphere.Cursor",
+    "Match": "Cursor"
+  },
+  {
+    "Name": "Claude",
+    "Id": "Anthropic.Claude",
+    "Match": "^Claude($| )",
+    "Appx": "Claude"
+  },
+  {
+    "Name": "GitHub Desktop",
+    "Id": "GitHub.GitHubDesktop",
+    "Match": "GitHub Desktop"
+  },
+  {
+    "Name": "Docker Desktop",
+    "Id": "Docker.DockerDesktop",
+    "Match": "Docker Desktop"
+  },
+  {
+    "Name": "AutoHotkey v2",
+    "Id": "AutoHotkey.AutoHotkey",
+    "Match": "AutoHotkey"
+  },
+  {
+    "Name": "Google Chrome",
+    "Id": "Google.Chrome",
+    "Match": "Google Chrome",
+    "Exe": "chrome.exe"
+  },
+  {
+    "Name": "Mozilla Firefox",
+    "Id": "Mozilla.Firefox",
+    "Match": "Mozilla Firefox",
+    "Exe": "firefox.exe"
+  }
+]

--- a/opt/Desktop/Apps/scripts/setup-apps.ps1
+++ b/opt/Desktop/Apps/scripts/setup-apps.ps1
@@ -248,6 +248,9 @@ function Configure-Terminal {
     Copy-Item $path "$path.bak-$(Get-Date -Format yyyyMMdd-HHmmss)" -Force
     $json = Get-Content $path -Raw | ConvertFrom-Json
 
+    # --- global settings ---
+    $json.focusFollowMouse = $true
+
     # --- schemes (idempotent by name) ---
     $schemeObjs = $SchemeDefs | ForEach-Object { [pscustomobject]$_ }
     $mineNames  = $schemeObjs.name
@@ -400,11 +403,8 @@ if ($wslOk) {
 # [4/6] Font
 Install-UbuntuMono
 
-# [5/6] Windows Terminal
-Configure-Terminal
-
-# [6/6] winget apps
-Write-Host "`n=== [6/6] Desktop apps (winget) ===" -ForegroundColor Cyan
+# [5/6] Desktop apps (winget)
+Write-Host "`n=== [5/6] Desktop apps (winget) ===" -ForegroundColor Cyan
 if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
     Write-Host "winget not available -- skipping app installs." -ForegroundColor Red
 } else {
@@ -437,3 +437,6 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
     }
     Write-Host "===================================================" -ForegroundColor Yellow
 }
+
+# [6/6] Windows Terminal configuration
+Configure-Terminal

--- a/opt/Desktop/Apps/scripts/setup-apps.ps1
+++ b/opt/Desktop/Apps/scripts/setup-apps.ps1
@@ -230,11 +230,29 @@ public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, IntPtr wPa
 # ---- Windows Terminal ------------------------------------------------------
 
 function Get-TerminalSettingsPath {
-    $candidates = @(
-        "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json"
-        "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe\LocalState\settings.json"
-    )
-    $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+    $stable  = "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json"
+    $preview = "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe\LocalState\settings.json"
+
+    # Prefer a settings.json Windows Terminal has already generated.
+    foreach ($p in @($stable, $preview)) { if (Test-Path $p) { return $p } }
+
+    # A freshly winget-installed Terminal only writes settings.json on first
+    # launch, so on a clean machine this step would otherwise find nothing and
+    # silently skip. Seed a minimal valid file when a WT package is present;
+    # Terminal merges its own defaults + dynamic profiles on launch and keeps
+    # the keys we set here.
+    $pkg = Get-AppxPackage -Name 'Microsoft.WindowsTerminal*' -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $pkg) { return $null }
+    $target = if ($pkg.Name -like '*Preview*') { $preview } else { $stable }
+    New-Item -ItemType Directory -Force -Path (Split-Path $target -Parent) | Out-Null
+    $seed = [pscustomobject]@{
+        '$schema' = 'https://aka.ms/terminal-profiles-schema'
+        profiles  = [pscustomobject]@{ defaults = [pscustomobject]@{}; list = @() }
+        schemes   = @()
+    }
+    [IO.File]::WriteAllText($target, ($seed | ConvertTo-Json -Depth 32), [Text.UTF8Encoding]::new($false))
+    Write-Host "Seeded minimal settings.json at $target (Terminal not yet launched)." -ForegroundColor DarkGray
+    return $target
 }
 
 function Configure-Terminal {

--- a/opt/Desktop/Apps/scripts/setup-apps.ps1
+++ b/opt/Desktop/Apps/scripts/setup-apps.ps1
@@ -249,7 +249,11 @@ function Configure-Terminal {
     $json = Get-Content $path -Raw | ConvertFrom-Json
 
     # --- global settings ---
-    $json.focusFollowMouse = $true
+    if ($null -eq $json.PSObject.Properties['focusFollowMouse']) {
+        $json | Add-Member -MemberType NoteProperty -Name "focusFollowMouse" -Value $true
+    } else {
+        $json.focusFollowMouse = $true
+    }
 
     # --- schemes (idempotent by name) ---
     $schemeObjs = $SchemeDefs | ForEach-Object { [pscustomobject]$_ }
@@ -431,9 +435,9 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
 
     Write-Host "`n=================== APP SUMMARY ===================" -ForegroundColor Yellow
     foreach ($name in $results.Keys) {
-        $status = $results[$name]
-        $color = if ($status -like 'FAILED*') { 'Red' } else { 'Green' }
-        Write-Host ("{0,-16} {1}" -f $name, $status) -ForegroundColor $color
+        $appStatus = $results[$name]
+        $color = if ($appStatus -like 'FAILED*') { 'Red' } else { 'Green' }
+        Write-Host ("{0,-16} {1}" -f $name, $appStatus) -ForegroundColor $color
     }
     Write-Host "===================================================" -ForegroundColor Yellow
 }

--- a/opt/Desktop/Apps/scripts/setup-apps.ps1
+++ b/opt/Desktop/Apps/scripts/setup-apps.ps1
@@ -54,24 +54,13 @@ $HistorySize  = 100000
 # Color schemes to publish, and the order in which a profile is made per distro.
 $Themes = 'Solarized Dark', 'Solarized Light', 'Ocean', 'Green', 'GitHub Dark'
 
-# Friendly name => @{ Id = winget id; Match = regex vs registry DisplayName;
-#   optional Exe (App Paths fallback) / Appx (Store-package fallback) }
-$apps = [ordered]@{
-    'Discord'         = @{ Id = 'Discord.Discord';         Match = 'Discord' }
-    'Slack'           = @{ Id = 'SlackTechnologies.Slack'; Match = 'Slack' }
-    'Obsidian'        = @{ Id = 'Obsidian.Obsidian';       Match = 'Obsidian' }
-    'OBS Studio'      = @{ Id = 'OBSProject.OBSStudio';    Match = 'OBS Studio' }
-    'Spotify'         = @{ Id = 'Spotify.Spotify';         Match = 'Spotify' }
-    'Apple iTunes'    = @{ Id = 'Apple.iTunes';            Match = 'iTunes' }
-    'Antigravity'     = @{ Id = 'Google.Antigravity';      Match = '^Antigravity(?! IDE)' }
-    'Antigravity IDE' = @{ Id = 'Google.AntigravityIDE';   Match = 'Antigravity IDE' }
-    'Cursor'          = @{ Id = 'Anysphere.Cursor';        Match = 'Cursor' }
-    'Claude'          = @{ Id = 'Anthropic.Claude';        Match = '^Claude($| )'; Appx = 'Claude' }
-    'GitHub Desktop'  = @{ Id = 'GitHub.GitHubDesktop';    Match = 'GitHub Desktop' }
-    'Docker Desktop'  = @{ Id = 'Docker.DockerDesktop';    Match = 'Docker Desktop' }
-    'Google Chrome'   = @{ Id = 'Google.Chrome';           Match = 'Google Chrome';   Exe = 'chrome.exe' }
-    'Mozilla Firefox' = @{ Id = 'Mozilla.Firefox';         Match = 'Mozilla Firefox'; Exe = 'firefox.exe' }
+# Load application configuration from apps.json
+$appsPath = Join-Path $PSScriptRoot 'apps.json'
+if (-not (Test-Path $appsPath)) {
+    Write-Host "ERROR: apps.json not found at $appsPath" -ForegroundColor Red
+    exit 1
 }
+$apps = Get-Content $appsPath -Raw | ConvertFrom-Json
 
 # Color-scheme palettes (Windows Terminal "schemes" entries).
 $SchemeDefs = @(
@@ -357,14 +346,18 @@ if ($Status) {
 
     Write-Host "`n===== Apps =====" -ForegroundColor Cyan
     $reg = Get-UninstallEntries
-    $report = foreach ($name in $apps.Keys) {
-        $app     = $apps[$name]
+    $appCount = $apps.Count
+    $currentIndex = 0
+    $report = foreach ($app in $apps) {
+        $currentIndex++
+        Write-Host ("[{0}/{1}] Querying {2} ({3})..." -f $currentIndex, $appCount, $app.Name, $app.Id) -ForegroundColor DarkGray
+        
         $version = Get-WingetVersion -Id $app.Id
         $installed = [bool]$version
         $location = '-'
         if ($installed) { $location = Resolve-AppLocation -App $app -Version $version -Reg $reg }
         [pscustomobject]@{
-            App       = $name
+            App       = $app.Name
             Installed = if ($installed) { 'Yes' } else { 'No' }
             Version   = if ($installed) { $version } else { '-' }
             Location  = $location
@@ -416,19 +409,24 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
     Write-Host "winget not available -- skipping app installs." -ForegroundColor Red
 } else {
     $results = [ordered]@{}
-    foreach ($name in $apps.Keys) {
-        $id = $apps[$name].Id
-        if (Test-AppInstalled -Id $id) {
-            Write-Host "$name ($id) already installed -- skipping." -ForegroundColor DarkGray
-            $results[$name] = 'Already installed'
+    $appCount = $apps.Count
+    $currentIndex = 0
+
+    foreach ($app in $apps) {
+        $currentIndex++
+        Write-Host ("[{0}/{1}] Checking {2} ({3})..." -f $currentIndex, $appCount, $app.Name, $app.Id) -ForegroundColor Cyan
+        
+        if (Test-AppInstalled -Id $app.Id) {
+            Write-Host "$($app.Name) ($($app.Id)) already installed -- skipping." -ForegroundColor DarkGray
+            $results[$app.Name] = 'Already installed'
             continue
         }
-        Write-Host "Installing $name ($id)..." -ForegroundColor Cyan
-        winget install --id $id -e --source winget `
+        Write-Host "Installing $($app.Name) ($($app.Id))..." -ForegroundColor Cyan
+        winget install --id $app.Id -e --source winget `
             --accept-package-agreements --accept-source-agreements --disable-interactivity
         $code = $LASTEXITCODE
-        if ($code -eq 0 -or $code -eq -1978335189) { $results[$name] = 'Installed' }
-        else { $results[$name] = "FAILED (exit $code)" }
+        if ($code -eq 0 -or $code -eq -1978335189) { $results[$app.Name] = 'Installed' }
+        else { $results[$app.Name] = "FAILED (exit $code)" }
     }
 
     Write-Host "`n=================== APP SUMMARY ===================" -ForegroundColor Yellow

--- a/opt/bin/install_windows.sh
+++ b/opt/bin/install_windows.sh
@@ -55,3 +55,48 @@ fi
 # ---------------------------------------------------------------------------
 echo "Deploying opt/Desktop -> ${win_desktop}"
 cp -r "${BASE_DIR}/opt/Desktop/." "${win_desktop}/"
+
+# ---------------------------------------------------------------------------
+# Interactive Windows Customization (WSL only)
+# ---------------------------------------------------------------------------
+SENTINEL_DIR="${HOME}/.config/dotfiles"
+SENTINEL_FILE="${SENTINEL_DIR}/.skip_windows_setup"
+
+if [ -f "$SENTINEL_FILE" ]; then
+    exit 0
+fi
+
+echo ""
+echo "Windows Desktop Customization detected."
+echo "Would you like to run the PowerShell setup scripts to configure Windows Terminal,"
+echo "install desktop apps (Discord, Slack, AutoHotkey, etc.), and set up macOS-style hotkeys?"
+echo ""
+echo "Options:"
+echo "  [y] Yes, run setup now."
+echo "  [n] No, skip for now (will ask again next time)."
+echo "  [s] Skip and never ask again (creates sentinel file)."
+echo ""
+read -rp "Choice [y/n/s]: " choice
+
+case "$choice" in
+    y|Y)
+        echo "Starting Windows customization... (this may take a few minutes)"
+        # Use the absolute path and redirection to avoid the pipe-hang issue discovered earlier.
+        # Run setup-apps.ps1 first to ensure all apps (including AutoHotkey) are installed.
+        "$ps_exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "${BASE_DIR}/opt/Desktop/Apps/scripts/setup-apps.ps1" > /tmp/setup_apps.log 2>&1
+        cat /tmp/setup_apps.log
+        
+        # Then setup the macOS-style hotkeys (AutoHotkey)
+        echo "Registering macOS-style hotkeys (may trigger a Windows UAC prompt)..."
+        "$ps_exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "${BASE_DIR}/opt/Desktop/Apps/scripts/setup-autostart.ps1" > /tmp/setup_autostart.log 2>&1
+        cat /tmp/setup_autostart.log
+        ;;
+    s|S)
+        echo "Creating sentinel file at $SENTINEL_FILE. Will not ask again."
+        mkdir -p "$SENTINEL_DIR"
+        echo "User chose to skip Windows setup on $(date)" > "$SENTINEL_FILE"
+        ;;
+    *)
+        echo "Skipping Windows customization for now."
+        ;;
+esac

--- a/opt/profiles/.zshrc
+++ b/opt/profiles/.zshrc
@@ -166,6 +166,22 @@ fi
 # export MANPATH="/usr/local/man:$MANPATH"
 fpath+=${ZSH_CUSTOM:-${ZSH:-~/.oh-my-zsh}/custom}/plugins/zsh-completions/src
 
+# Shadow dangling completion symlinks before oh-my-zsh runs compinit. Vendor
+# packages such as Docker Desktop on WSL leave _* symlinks in root-owned $fpath
+# dirs that dangle when their backing mount is gone; compinit then errors
+# ("no such file or directory") reading the broken link. An empty stub earlier
+# in $fpath makes compinit skip it. Rebuilt each startup, so the real
+# completion is used again once its target returns.
+_comp_shadow="${XDG_CACHE_HOME:-$HOME/.cache}/zsh/compshadow"
+rm -rf "$_comp_shadow" 2>/dev/null
+for _comp_f in ${^fpath}/_*(N@); do
+  [[ -e $_comp_f ]] && continue                 # symlink target resolves: leave it
+  [[ -d $_comp_shadow ]] || mkdir -p "$_comp_shadow"
+  : > "$_comp_shadow/${_comp_f:t}"
+done
+[[ -d $_comp_shadow ]] && fpath=("$_comp_shadow" $fpath)
+unset _comp_f _comp_shadow
+
 source $ZSH/oh-my-zsh.sh
 
 # oh-my-zsh's git plugin defines `alias gss='git status -s'` which shadows


### PR DESCRIPTION
Integrates Windows desktop customization into the `install.sh` workflow, provisions Windows Terminal, enables focus-follows-mouse (reliably, including on a clean machine), and quiets a zsh completion startup error.

## What
- **Interactive install step** (`install_windows.sh`): prompts during installation to run the Windows-side PowerShell setup, with a "never ask again" sentinel at `~/.config/dotfiles/.skip_windows_setup`.
- **App provisioning** (`apps.json` + `setup-apps.ps1`): decoupled the Windows app list into `apps.json`; added Windows Terminal and AutoHotkey v2 to the default set.
- **Windows Terminal config**: writes color schemes + per-distro profiles and sets the global `focusFollowMouse=true`. Phase order ensures Terminal is winget-installed *before* it is configured.
- **Fresh-install fix**: `Get-TerminalSettingsPath` seeds a minimal valid `settings.json` when a WT package is installed but the file doesn't exist yet, so configuration applies on a clean machine instead of being silently skipped.
- **zsh compinit fix** (`opt/profiles/.zshrc`): shadows dangling `_*` completion symlinks before oh-my-zsh runs `compinit`, eliminating the `compinit:527: no such file or directory: .../_docker` startup error.

## Why
- A freshly winget-installed Windows Terminal only generates `settings.json` on **first launch**. With Terminal installed in the same run and never launched, `Configure-Terminal` found no file and silently skipped — so `focusFollowMouse` (and the schemes/profiles) never got written on a clean machine.
- WSL→Windows PowerShell calls were refactored to use absolute paths + output redirection to avoid pipe-hangs.
- Docker Desktop's WSL integration drops a `_docker` symlink into the root-owned `/usr/share/zsh/vendor-completions` dir pointing into `/mnt/wsl/docker-desktop/...`; when Docker Desktop isn't running the link dangles and `compinit`'s full scan errors reading it.

## Impact
- On a clean machine, focus-follows-mouse and the Terminal themes/profiles apply on the first install run.
- On a machine where Terminal was already launched, behavior is unchanged (the existing `settings.json` is used; the seed path is never taken).
- The zsh fix shadows the broken symlink with an empty stub in `$XDG_CACHE_HOME/zsh/compshadow` (prepended to `$fpath`). It is rebuilt each startup, so once Docker Desktop is running the real `_docker` completion is used again. No effect when nothing dangles (the shadow dir isn't created and `$fpath` is untouched).

## Testing
- PowerShell: `setup-apps.ps1` syntax parse clean; simulated the missing-`settings.json` path against a scratch dir — seed is valid JSON, `focusFollowMouse=true` written, `Configure-Terminal` schemes/profiles mutations succeed.
- zsh: reproduced `compinit:527` against the live dangling symlink; confirmed the empty-stub shadow suppresses it; `zsh -n .zshrc` syntax clean; verified a real interactive startup (forced full `compinit`) no longer emits the error and the everyday cached path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)