### PR TITLE
gss-pr-adopt: fix

### DIFF
--- a/src/gss/internal/feature/audit.go
+++ b/src/gss/internal/feature/audit.go
@@ -31,7 +31,8 @@ type Finding struct {
 	Remedy   string `json:"remedy,omitempty"`
 	Repaired bool   `json:"repaired,omitempty"`
 
-	fix string // internal: target base branch for a registry-local repair
+	fix      string // internal: target value for a registry-local repair (base branch, pr_state, or — for pr-missing-url — the pr_url)
+	fixState string // internal: target pr_state for a pr-missing-url backfill
 }
 
 // Observer supplies the read-only observations the audit needs. It exposes
@@ -44,6 +45,11 @@ type Observer interface {
 	BranchExists(ctx context.Context, branch string) bool
 	BaseReachable(ctx context.Context, branch, base string) bool
 	PRView(ctx context.Context, num int) (gh.PR, bool) // ok == false on 404
+	// PROpenForBranch returns the open PR whose head is branch, if any. It
+	// lets audit catch the inverse of pr-404: a worker with no recorded
+	// pr_url that nonetheless has a live PR on GitHub (the drift that makes
+	// checkpoint try to create a duplicate). ok == false means no open PR.
+	PROpenForBranch(ctx context.Context, branch string) (gh.PR, bool)
 }
 
 // AuditOpts configures Audit.
@@ -186,6 +192,16 @@ func runAudit(ctx context.Context, reg registry.Registry, obs Observer, only str
 							Remedy: "audit --repair reconciles pr_state to the observed value", fix: obsd})
 					}
 				}
+			} else if pr, ok := obs.PROpenForBranch(ctx, w.Branch); ok && pr.URL != "" {
+				// Inverse of pr-404: the registry row has no pr_url but an open
+				// PR already exists for this head branch. Left unrepaired, the
+				// next checkpoint takes the create path and fails with "a pull
+				// request for branch ... already exists", silently dropping the
+				// commit. Repair backfills pr_url/pr_state from the observed PR.
+				fs = append(fs, Finding{Worker: ref, Check: "pr-missing-url", Severity: SevWarn,
+					Detail: fmt.Sprintf("no pr_url recorded but open PR %s exists for %s", pr.URL, w.Branch),
+					Remedy: "audit --repair backfills pr_url/pr_state from the observed PR",
+					fix:    pr.URL, fixState: observedPRState(pr)})
 			}
 			// NOTE: spawned_by is intentionally NOT validated here. Resolution
 			// #8 makes it informational-only — never the basis for a control
@@ -218,6 +234,9 @@ func applyRepairs(r *registry.Registry, findings []Finding) int {
 			ok = removeWorkerByRef(r, f.Worker)
 		case "pr-404":
 			ok = mutateWorker(r, f.Worker, func(w *registry.Worker) { w.PRURL = ""; w.PRState = "" })
+		case "pr-missing-url":
+			url, state := f.fix, f.fixState
+			ok = mutateWorker(r, f.Worker, func(w *registry.Worker) { w.PRURL = url; w.PRState = state })
 		case "pr-base-diverged", "stale-base":
 			target := f.fix
 			ok = mutateWorker(r, f.Worker, func(w *registry.Worker) { w.BaseBranch = target })
@@ -328,4 +347,8 @@ func (o *systemObserver) PRView(ctx context.Context, num int) (gh.PR, bool) {
 	}
 	pr, err := o.gh.PRView(ctx, num)
 	return pr, err == nil
+}
+
+func (o *systemObserver) PROpenForBranch(ctx context.Context, branch string) (gh.PR, bool) {
+	return openPRForBranch(ctx, o.gh, branch)
 }

--- a/src/gss/internal/feature/audit_test.go
+++ b/src/gss/internal/feature/audit_test.go
@@ -17,10 +17,11 @@ import (
 // by default; a test marks negatives by adding to the maps. PRs default to a
 // base matching the worker (seeded by healthyObserver); absent => 404.
 type fakeObserver struct {
-	missingWorktrees map[string]bool // worktree path -> missing
-	missingBranches  map[string]bool // branch -> missing
-	unreachable      map[string]bool // branch -> base unreachable
-	prs              map[int]gh.PR   // present PRs; absent => 404
+	missingWorktrees map[string]bool  // worktree path -> missing
+	missingBranches  map[string]bool  // branch -> missing
+	unreachable      map[string]bool  // branch -> base unreachable
+	prs              map[int]gh.PR    // present PRs; absent => 404
+	openByBranch     map[string]gh.PR // head branch -> open PR; absent => none
 }
 
 func (o *fakeObserver) WorktreeExists(p string) bool                  { return !o.missingWorktrees[p] }
@@ -32,6 +33,10 @@ func (o *fakeObserver) PRView(_ context.Context, n int) (gh.PR, bool) {
 	pr, ok := o.prs[n]
 	return pr, ok
 }
+func (o *fakeObserver) PROpenForBranch(_ context.Context, b string) (gh.PR, bool) {
+	pr, ok := o.openByBranch[b]
+	return pr, ok
+}
 
 // healthyObserver seeds a clean observer: every worker's worktree+branch
 // present, base reachable, and (if it has a PR) the PR exists with a matching
@@ -39,7 +44,7 @@ func (o *fakeObserver) PRView(_ context.Context, n int) (gh.PR, bool) {
 func healthyObserver(workers []registry.Worker) *fakeObserver {
 	o := &fakeObserver{
 		missingWorktrees: map[string]bool{}, missingBranches: map[string]bool{},
-		unreachable: map[string]bool{}, prs: map[int]gh.PR{},
+		unreachable: map[string]bool{}, prs: map[int]gh.PR{}, openByBranch: map[string]gh.PR{},
 	}
 	for _, w := range workers {
 		if w.PRURL != "" {
@@ -203,6 +208,63 @@ func TestAuditStaleBaseAndRepair(t *testing.T) {
 	}
 	if reg, _ := store.Load(); reg.Features[0].Workers[0].BaseBranch != "main" {
 		t.Errorf("repair should reset stale base to default main; got %q", reg.Features[0].Workers[0].BaseBranch)
+	}
+}
+
+func TestAuditPRMissingURLAndRepair(t *testing.T) {
+	// Worker has no pr_url, but an open PR exists on GitHub for its branch.
+	// This is the silent-drift state that makes checkpoint try (and fail) to
+	// create a duplicate PR; audit should surface it, and repair backfills the
+	// pr_url/pr_state from the observed PR.
+	workers := []registry.Worker{aw("api", "main", "")}
+	workers[0].PRState = "" // no recorded PR at all
+	obs := healthyObserver(workers)
+	obs.openByBranch["feature/auth/erai/api"] = gh.PR{
+		Number: 13, Base: "main", Head: "feature/auth/erai/api",
+		State: "OPEN", IsDraft: true, URL: "https://github.com/o/r/pull/13",
+	}
+	svc, store := auditService(t, workers, obs)
+
+	rep, _ := svc.Audit(context.Background(), feature.AuditOpts{})
+	f := findFinding(rep.Findings, "pr-missing-url")
+	if f == nil || f.Severity != feature.SevWarn {
+		t.Fatalf("want pr-missing-url warn; got %+v", rep.Findings)
+	}
+	// read-only must not have mutated the registry.
+	if reg, _ := store.Load(); reg.Features[0].Workers[0].PRURL != "" {
+		t.Error("read-only audit backfilled pr_url")
+	}
+
+	rep2, err := svc.Audit(context.Background(), feature.AuditOpts{Repair: true})
+	if err != nil {
+		t.Fatalf("Audit --repair: %v", err)
+	}
+	if rep2.Repaired != 1 {
+		t.Errorf("repaired = %d; want 1", rep2.Repaired)
+	}
+	reg, _ := store.Load()
+	w := reg.Features[0].Workers[0]
+	if w.PRURL != "https://github.com/o/r/pull/13" {
+		t.Errorf("repair should backfill pr_url; got %q", w.PRURL)
+	}
+	if w.PRState != "draft" {
+		t.Errorf("repair should backfill pr_state from the observed PR; got %q", w.PRState)
+	}
+}
+
+func TestAuditNoPRMissingURLWhenURLPresent(t *testing.T) {
+	// A worker that already records its PR must not trigger pr-missing-url
+	// even though an open PR exists for its branch.
+	workers := []registry.Worker{aw("api", "main", "https://github.com/o/r/pull/42")}
+	obs := healthyObserver(workers)
+	obs.openByBranch["feature/auth/erai/api"] = gh.PR{
+		Number: 42, Base: "main", Head: "feature/auth/erai/api",
+		State: "OPEN", IsDraft: true, URL: "https://github.com/o/r/pull/42",
+	}
+	svc, _ := auditService(t, workers, obs)
+	rep, _ := svc.Audit(context.Background(), feature.AuditOpts{})
+	if findFinding(rep.Findings, "pr-missing-url") != nil {
+		t.Errorf("worker with a recorded pr_url must not flag pr-missing-url; got %+v", rep.Findings)
 	}
 }
 

--- a/src/gss/internal/feature/checkpoint.go
+++ b/src/gss/internal/feature/checkpoint.go
@@ -60,6 +60,20 @@ func (s *Service) Checkpoint(ctx context.Context, opts CheckpointOpts) (Checkpoi
 	body := renderPRBody(feat, ref)
 	title := fmt.Sprintf("%s: %s", ref.Feature, ref.Purpose) // first H1 of WORKER.md
 
+	// Adopt-existing-PR: a registry row may have no pr_url yet an open PR
+	// already exists on GitHub for this head branch (opened on another
+	// machine, or the url was never recorded). Taking the create path then
+	// fails with "a pull request for branch ... already exists" and drops the
+	// commit on the floor. So before creating, look for an open PR on the head
+	// branch and, if found, adopt its url/state here so we fall through to the
+	// update path (push + edit) and the commit actually reaches the PR.
+	if w.PRURL == "" {
+		if existing, ok := openPRForBranch(ctx, s.GH, w.Branch); ok {
+			w.PRURL = existing.URL
+			w.PRState = observedPRState(existing)
+		}
+	}
+
 	res := CheckpointResult{Ref: ref.String()}
 	if w.PRURL == "" {
 		pr, err := s.GH.PRCreate(ctx, gh.PRCreateOpts{Title: title, Body: body, Base: base, Head: w.Branch, Draft: true})
@@ -134,6 +148,22 @@ func renderPRBody(f registry.Feature, here identity.WorkerRef) string {
 		})
 	}
 	return stack.RenderBody(desc, view)
+}
+
+// openPRForBranch returns the open PR whose head is branch, if one exists.
+// It is best-effort: a gh error (auth, network, no such repo) is swallowed
+// and reported as "not found", so checkpoint degrades to its prior create
+// behaviour rather than failing on a transient list error. Used to adopt a
+// PR that exists on GitHub but isn't recorded in the registry row yet.
+func openPRForBranch(ctx context.Context, c gh.Client, branch string) (gh.PR, bool) {
+	if branch == "" {
+		return gh.PR{}, false
+	}
+	prs, err := c.PRList(ctx, gh.PRFilter{State: "open", Head: branch, Limit: 1})
+	if err != nil || len(prs) == 0 {
+		return gh.PR{}, false
+	}
+	return prs[0], true
 }
 
 var prURLNumRe = regexp.MustCompile(`/pull/(\d+)`)

--- a/src/gss/internal/feature/checkpoint_test.go
+++ b/src/gss/internal/feature/checkpoint_test.go
@@ -105,6 +105,63 @@ func TestCheckpoint_ExistingPRForcePushesAndEdits(t *testing.T) {
 	}
 }
 
+func TestCheckpoint_AdoptsExistingOpenPRWhenRegistryHasNoURL(t *testing.T) {
+	// The registry row has NO pr_url, but an open PR already exists on GitHub
+	// for the head branch (e.g. created on another machine, or the registry
+	// lost the url). Checkpoint must adopt that PR — push + edit — instead of
+	// calling gh pr create (which would fail "a pull request ... already
+	// exists" and silently drop the commit).
+	ghc := ghfake.NewClient()
+	ghc.SeedPR(gh.PR{Number: 9, Head: "feature/auth/erai/api", State: "OPEN", IsDraft: true, URL: "https://github.com/o/r/pull/9"})
+	// fetch ok, rebase ok, force-push ok.
+	svc, store, gitr := checkpointService(t, "",
+		[]gitfake.Response{{}, {}, {}}, ghc)
+
+	res, err := svc.Checkpoint(context.Background(), feature.CheckpointOpts{WorkerRef: "auth/erai/api"})
+	if err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if res.Created {
+		t.Error("existing open PR: result.Created = true; want false (adopt + edit path)")
+	}
+	if res.PRURL != "https://github.com/o/r/pull/9" {
+		t.Errorf("res.PRURL = %q; want the adopted PR url", res.PRURL)
+	}
+	// PRCreate must NOT have been called.
+	if lastPRCreate(ghc) != nil {
+		t.Error("an existing open PR must be adopted, not re-created")
+	}
+	// A push must have happened — the whole point is the commit reaches origin.
+	pushed := false
+	for _, call := range gitr.Calls {
+		if argsHasFC(call.Args, "push") {
+			pushed = true
+		}
+	}
+	if !pushed {
+		t.Errorf("expected a git push to the existing PR's branch; calls=%+v", gitr.Calls)
+	}
+	// PREdit on the adopted PR number.
+	edited := false
+	for _, call := range ghc.Calls() {
+		if call.Verb == ghfake.VerbPREdit && call.Num == 9 {
+			edited = true
+		}
+	}
+	if !edited {
+		t.Error("expected gh PREdit on the adopted PR #9")
+	}
+	// Registry backfilled with the adopted pr_url/pr_state.
+	reg, _ := store.Load()
+	w := reg.Features[0].Workers[0]
+	if w.PRURL != "https://github.com/o/r/pull/9" {
+		t.Errorf("registry pr_url = %q; want the adopted PR url", w.PRURL)
+	}
+	if w.PRState == "" {
+		t.Error("registry pr_state not backfilled after adopting the PR")
+	}
+}
+
 func TestCheckpoint_RebaseConflictAborts(t *testing.T) {
 	// fetch ok, rebase fails, abort ok.
 	svc, _, gitr := checkpointService(t, "",


### PR DESCRIPTION
Adopt existing open PR for head branch on checkpoint; audit flags missing pr_url

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **gss-pr-adopt**.

- **#28 — edward-raigosa/fix (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
