### PR TITLE
docs(gsl): plan — structured JSON logging via logrus + lumberjack (#32)

### DIFF
--- a/docs/plans/gsl-issue-32-structured-logging.md
+++ b/docs/plans/gsl-issue-32-structured-logging.md
@@ -1,0 +1,1047 @@
+# gsl Structured JSON Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a structured JSON logger (logrus + lumberjack) to gsl that records payload-parse errors, per-segment timeouts/degradations, and subprocess failures to a rotating file under `${XDG_STATE_HOME:-~/.local/state}/gsl/gsl.log`, keeping it strictly off the hot path so a logging failure never breaks the status line.
+
+**Architecture:** A new `internal/logging` package owns all logger construction: state-dir resolution with XDG fallback, logrus JSON formatter wiring, lumberjack rotation (MaxAge=7 days), and the `GSL_LOG_LEVEL` env-var parser; it exposes a single `*logrus.Logger` and a `Close()` func. `cmd/root.go` calls `logging.New()` once at startup and distributes the logger to the callers that need it (render pipeline, payload parse, config load) via dependency injection — no globals. Every call-site wraps log operations in a deferred recover so a panicking logger is silently swallowed.
+
+**Tech Stack:** Go, logrus (MIT), lumberjack (MIT)
+
+---
+
+Closes #32.
+
+## License Compliance
+
+Both new dependencies comply with the repo's third-party license policy defined in
+`src/CLAUDE.md` ("Allowed licenses (permissive)" — MIT is explicitly in the allowed set):
+
+| Dependency | Import path | License | Upstream LICENSE file |
+|---|---|---|---|
+| logrus | `github.com/sirupsen/logrus` | MIT | https://github.com/sirupsen/logrus/blob/master/LICENSE |
+| lumberjack | `gopkg.in/natefinch/lumberjack.v2` | MIT | https://github.com/natefinch/lumberjack/blob/v2/LICENSE |
+
+No transitive banned licenses are expected (logrus has no heavy dependencies beyond `golang.org/x/sys`
+on Linux; lumberjack is stdlib-only). Run `go-licenses check ./...` in CI to confirm.
+
+## go.mod / go.sum Changes
+
+Add these two `require` lines (exact versions pinned by `go get` in Task 1):
+
+```
+require (
+    github.com/sirupsen/logrus v1.9.3
+    gopkg.in/natefinch/lumberjack.v2 v2.2.1
+)
+```
+
+`go.sum` entries are generated automatically by `go mod tidy` — do not hand-edit them.
+
+---
+
+## Tasks
+
+### Task 1 — Add logrus + lumberjack to go.mod
+
+- [ ] From `src/gsl/`, run:
+
+  ```bash
+  go get github.com/sirupsen/logrus@v1.9.3
+  go get gopkg.in/natefinch/lumberjack.v2@v2.2.1
+  go mod tidy
+  ```
+
+  Expected output: no errors; `go.mod` gains the two `require` lines; `go.sum` gains their checksums.
+
+- [ ] Verify:
+
+  ```bash
+  grep -E "logrus|lumberjack" src/gsl/go.mod
+  ```
+
+  Expected output:
+
+  ```
+  github.com/sirupsen/logrus v1.9.3
+  gopkg.in/natefinch/lumberjack.v2 v2.2.1
+  ```
+
+- [ ] Commit: `feat(gsl): add logrus + lumberjack to go.mod (#32)`
+
+---
+
+### Task 2 — Write failing tests for `internal/logging` (TDD red phase)
+
+Create `src/gsl/internal/logging/logging_test.go` with the following complete content:
+
+```go
+package logging_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/wenlock/dotfiles/gsl/internal/logging"
+)
+
+// TestNew_defaultsToInfo verifies that New() with no GSL_LOG_LEVEL set
+// returns a logger at Info level.
+func TestNew_defaultsToInfo(t *testing.T) {
+	t.Setenv("GSL_LOG_LEVEL", "")
+	dir := t.TempDir()
+	l, close, err := logging.New(dir)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer close()
+	if l.Level != logrus.InfoLevel {
+		t.Errorf("want InfoLevel, got %v", l.Level)
+	}
+}
+
+// TestNew_respectsGSL_LOG_LEVEL verifies that GSL_LOG_LEVEL=debug is honoured.
+func TestNew_respectsGSL_LOG_LEVEL(t *testing.T) {
+	t.Setenv("GSL_LOG_LEVEL", "debug")
+	dir := t.TempDir()
+	l, close, err := logging.New(dir)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer close()
+	if l.Level != logrus.DebugLevel {
+		t.Errorf("want DebugLevel, got %v", l.Level)
+	}
+}
+
+// TestNew_invalidLevelDefaultsToInfo verifies that an unrecognised
+// GSL_LOG_LEVEL value silently falls back to Info.
+func TestNew_invalidLevelDefaultsToInfo(t *testing.T) {
+	t.Setenv("GSL_LOG_LEVEL", "bogus")
+	dir := t.TempDir()
+	l, close, err := logging.New(dir)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer close()
+	if l.Level != logrus.InfoLevel {
+		t.Errorf("want InfoLevel fallback, got %v", l.Level)
+	}
+}
+
+// TestNew_createsLogDir verifies that New() creates the state dir when absent.
+func TestNew_createsLogDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "state")
+	_, close, err := logging.New(dir)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer close()
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("expected state dir to be created, got stat error: %v", err)
+	}
+}
+
+// TestNew_writerIsJSON verifies that the logger formatter is JSONFormatter.
+func TestNew_writerIsJSON(t *testing.T) {
+	dir := t.TempDir()
+	l, close, err := logging.New(dir)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer close()
+	if _, ok := l.Formatter.(*logrus.JSONFormatter); !ok {
+		t.Errorf("expected JSONFormatter, got %T", l.Formatter)
+	}
+}
+
+// TestNew_logFileInsideDir verifies that the log file is placed inside dir.
+func TestNew_logFileInsideDir(t *testing.T) {
+	dir := t.TempDir()
+	l, close, err := logging.New(dir)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	l.Info("probe")
+	close()
+	logPath := filepath.Join(dir, "gsl.log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Errorf("expected log file at %s, got stat error: %v", logPath, err)
+	}
+}
+
+// TestStateDir_XDG verifies that StateDir returns an XDG-respecting path.
+func TestStateDir_XDG(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "/tmp/xdg-state")
+	got := logging.StateDir()
+	want := "/tmp/xdg-state/gsl"
+	if got != want {
+		t.Errorf("StateDir() = %q, want %q", got, want)
+	}
+}
+
+// TestStateDir_fallback verifies that StateDir falls back to ~/.local/state/gsl
+// when XDG_STATE_HOME is unset.
+func TestStateDir_fallback(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	got := logging.StateDir()
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".local", "state", "gsl")
+	if got != want {
+		t.Errorf("StateDir() = %q, want %q", got, want)
+	}
+}
+
+// TestClose_idempotent verifies that calling close() more than once does not
+// panic or error.
+func TestClose_idempotent(t *testing.T) {
+	dir := t.TempDir()
+	_, close, err := logging.New(dir)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	// First call should be safe.
+	close()
+	// Second call must not panic (lumberjack Close is idempotent).
+	close()
+}
+```
+
+- [ ] Run tests to confirm they fail (package does not exist yet):
+
+  ```bash
+  cd src/gsl && go test ./internal/logging/... 2>&1 | head -5
+  ```
+
+  Expected output contains: `cannot find package` or `no Go files`
+
+- [ ] Commit: `test(gsl/logging): red-phase tests for internal/logging (#32)`
+
+---
+
+### Task 3 — Implement `internal/logging` (TDD green phase)
+
+Create `src/gsl/internal/logging/logging.go` with the following complete content:
+
+```go
+// Package logging constructs the gsl structured logger.
+//
+// Call New(stateDir) once at program start. It returns a configured
+// *logrus.Logger that writes JSON-formatted entries to
+// <stateDir>/gsl.log via lumberjack (7-day rotation) and a close
+// function that flushes/closes the underlying writer.
+//
+// Non-fatal contract: every error from New() is handled by the caller
+// (cmd/root.go). Once a logger is handed out, callers MUST wrap their
+// log calls in a deferred recover if they are on the hot path; see
+// safeLog in cmd/root.go for the pattern.
+//
+// GSL_LOG_LEVEL controls verbosity: "debug", "info" (default), "warn",
+// "error". Unrecognised values silently default to "info".
+package logging
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// StateDir returns the directory where gsl should write its log file.
+// It respects XDG_STATE_HOME, falling back to ~/.local/state/gsl.
+func StateDir() string {
+	base := os.Getenv("XDG_STATE_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			// Last-resort fallback: use /tmp (log loss OK; never break status line).
+			return filepath.Join("/tmp", "gsl")
+		}
+		base = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(base, "gsl")
+}
+
+// New constructs and returns a *logrus.Logger that writes to
+// <stateDir>/gsl.log, plus a close function the caller MUST invoke on
+// program exit (or defer in cmd/root.go).
+//
+// stateDir is created (with mode 0o700) if it does not exist.
+// GSL_LOG_LEVEL is read to set the log level; unknown values default to Info.
+//
+// On any setup error, New returns a no-op (discard) logger so callers are
+// never left with a nil logger.
+func New(stateDir string) (l *logrus.Logger, close func(), err error) {
+	l = logrus.New()
+	l.Formatter = &logrus.JSONFormatter{}
+	l.SetLevel(levelFromEnv())
+
+	if mkErr := os.MkdirAll(stateDir, 0o700); mkErr != nil {
+		// Cannot create state dir: swallow, return discard logger.
+		l.SetOutput(io.Discard)
+		return l, func() {}, mkErr
+	}
+
+	lj := &lumberjack.Logger{
+		Filename: filepath.Join(stateDir, "gsl.log"),
+		MaxSize:  10,   // megabytes per file before rotation
+		MaxAge:   7,    // days to retain old log files
+		MaxBackups: 3,  // number of old log files to keep
+		Compress: false, // keep it simple; no gzip
+	}
+	l.SetOutput(lj)
+
+	return l, func() { _ = lj.Close() }, nil
+}
+
+// levelFromEnv reads GSL_LOG_LEVEL and converts it to a logrus.Level.
+// Returns logrus.InfoLevel for missing or unrecognised values.
+func levelFromEnv() logrus.Level {
+	raw := os.Getenv("GSL_LOG_LEVEL")
+	if raw == "" {
+		return logrus.InfoLevel
+	}
+	lvl, err := logrus.ParseLevel(raw)
+	if err != nil {
+		return logrus.InfoLevel
+	}
+	return lvl
+}
+```
+
+- [ ] Run tests — all must pass (green):
+
+  ```bash
+  cd src/gsl && go test ./internal/logging/... -v 2>&1
+  ```
+
+  Expected output: all `--- PASS` lines, `PASS` at end, zero failures.
+
+- [ ] Check coverage:
+
+  ```bash
+  cd src/gsl && go test ./internal/logging/... -cover 2>&1
+  ```
+
+  Expected output: `coverage: >60%` (target >80% given the small surface).
+
+- [ ] Commit: `feat(gsl/logging): implement internal/logging package (#32)`
+
+---
+
+### Task 4 — Wire logger into `cmd/root.go` (init + safeLog helper)
+
+Read the current `cmd/root.go` carefully before editing. The final file must look like this (complete replacement):
+
+```go
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/wenlock/dotfiles/gsl/internal/logging"
+)
+
+// log is the package-level logger, initialised in rootCmd's PersistentPreRunE
+// and accessible to all cmd subpackage functions. It is never nil after init.
+var log *logrus.Logger
+
+var rootCmd = &cobra.Command{
+	Use:   "gsl",
+	Short: "gsl is a Go Status Line tool",
+	Long: `gsl renders a powerline-style status line for Claude Code (piped a JSON
+payload on stdin after every assistant turn) and an on-demand line for
+Gemini/CLI.
+
+Segments: dirgit, repo, ai, time — configurable via ~/.config/gsl/config.json`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		l, closeFn, err := logging.New(logging.StateDir())
+		// Even on error, l is a valid discard logger (non-fatal contract).
+		log = l
+		// Register close via AddCleanup so the log file is flushed on exit.
+		// cobra does not have AddCleanup; we register via a deferred close in Execute().
+		_ = closeFn // stored below via closeLog
+		closeLog = closeFn
+		if err != nil {
+			// Log dir creation failure is a soft warning, not fatal.
+			log.WithError(err).Warn("gsl: logging setup failed; logging disabled")
+		}
+		return nil
+	},
+}
+
+// closeLog holds the lumberjack close function so Execute() can flush on exit.
+var closeLog func() = func() {}
+
+// Execute runs the root command. Called by main.
+func Execute() {
+	defer func() { closeLog() }()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// safeLog calls fn(log) in a deferred-recover wrapper so a panicking logger
+// is silently swallowed and never propagates to the status-line hot path.
+// Usage:
+//
+//	safeLog(func(l *logrus.Logger) { l.WithField("field", val).Warn("msg") })
+func safeLog(fn func(l *logrus.Logger)) {
+	defer func() { recover() }() //nolint:errcheck
+	if log != nil {
+		fn(log)
+	}
+}
+```
+
+- [ ] Write failing test first (`cmd/root_logging_test.go`):
+
+  ```go
+  package cmd
+
+  import (
+  	"testing"
+  )
+
+  // TestSafeLog_doesNotPanicOnNilLogger verifies the non-fatal contract:
+  // a nil log must not panic.
+  func TestSafeLog_doesNotPanicOnNilLogger(t *testing.T) {
+  	orig := log
+  	log = nil
+  	defer func() { log = orig }()
+  	// Must not panic.
+  	safeLog(func(l *logrus.Logger) { l.Info("should not be called") })
+  }
+
+  // TestSafeLog_doesNotPanicOnPanicingFn verifies that a panicking log fn
+  // is silently recovered.
+  func TestSafeLog_doesNotPanicOnPanicingFn(t *testing.T) {
+  	safeLog(func(_ *logrus.Logger) { panic("test-induced panic") })
+  }
+  ```
+
+  > Note: add `"github.com/sirupsen/logrus"` to the import in the test file.
+
+- [ ] Run tests — expect failures on missing symbols:
+
+  ```bash
+  cd src/gsl && go test ./cmd/... -run TestSafeLog 2>&1 | head -10
+  ```
+
+- [ ] Apply the `cmd/root.go` replacement above.
+
+- [ ] Run tests again — all must pass:
+
+  ```bash
+  cd src/gsl && go test ./cmd/... -run TestSafeLog -v 2>&1
+  ```
+
+  Expected output: `--- PASS: TestSafeLog_doesNotPanicOnNilLogger`, `--- PASS: TestSafeLog_doesNotPanicOnPanicingFn`.
+
+- [ ] Commit: `feat(gsl): wire logger into cmd/root.go with safeLog helper (#32)`
+
+---
+
+### Task 5 — Log payload parse errors in `cmd/render.go`
+
+The current `cmd/render.go` writes to `os.Stderr`. Replace the stderr write with a structured log entry.
+
+Read the current `cmd/render.go` before editing. The updated `runRender` function must be:
+
+```go
+func runRender(cmd *cobra.Command, args []string) error {
+	// Parse payload from stdin; degrade gracefully on error.
+	p, err := payload.ParseReader(os.Stdin)
+	if err != nil {
+		// Bad JSON on stdin: log structured warning, continue with empty payload.
+		// Non-fatal: a logging failure must never break the status line.
+		safeLog(func(l *logrus.Logger) {
+			l.WithFields(logrus.Fields{
+				"event": "payload_parse_error",
+				"error": err.Error(),
+			}).Warn("gsl render: stdin parse error (degrading)")
+		})
+		p = payload.Payload{}
+	}
+
+	cwdHint := ""
+	if p.Cwd != nil && *p.Cwd != "" {
+		cwdHint = *p.Cwd
+	}
+
+	return runStatusLine(cmd, p, cwdHint)
+}
+```
+
+Also add the logrus import to `cmd/render.go`:
+
+```go
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/wenlock/dotfiles/gsl/internal/payload"
+)
+```
+
+Note: remove the `"fmt"` import since `fmt.Fprintf(os.Stderr, ...)` is replaced.
+
+- [ ] Write failing test first (`cmd/render_logging_test.go`):
+
+  ```go
+  package cmd
+
+  import (
+  	"strings"
+  	"testing"
+
+  	"github.com/sirupsen/logrus"
+  )
+
+  // TestRunRender_logsParseError verifies that a malformed JSON payload on stdin
+  // causes a structured Warn entry to be emitted instead of a panic or fatal.
+  func TestRunRender_logsParseError(t *testing.T) {
+  	var captured []logrus.Entry
+  	hook := &captureHook{entries: &captured}
+
+  	// Inject a real logger with our capture hook.
+  	l := logrus.New()
+  	l.AddHook(hook)
+  	l.SetLevel(logrus.WarnLevel)
+  	origLog := log
+  	log = l
+  	defer func() { log = origLog }()
+
+  	// Feed malformed JSON.
+  	cmd := renderCmd
+  	cmd.SetIn(strings.NewReader("{bad json"))
+  	if err := runRender(cmd, nil); err != nil {
+  		t.Fatalf("runRender returned error: %v", err)
+  	}
+
+  	if len(captured) == 0 {
+  		t.Fatal("expected at least one log entry for parse error, got none")
+  	}
+  	e := captured[0]
+  	if e.Level != logrus.WarnLevel {
+  		t.Errorf("want WarnLevel, got %v", e.Level)
+  	}
+  	if e.Data["event"] != "payload_parse_error" {
+  		t.Errorf("want event=payload_parse_error, got %v", e.Data["event"])
+  	}
+  }
+
+  // captureHook is a logrus hook that captures all fired entries for assertions.
+  type captureHook struct {
+  	entries *[]logrus.Entry
+  }
+
+  func (h *captureHook) Levels() []logrus.Level { return logrus.AllLevels }
+  func (h *captureHook) Fire(e *logrus.Entry) error {
+  	*h.entries = append(*h.entries, *e)
+  	return nil
+  }
+  ```
+
+- [ ] Run failing test:
+
+  ```bash
+  cd src/gsl && go test ./cmd/... -run TestRunRender_logsParseError 2>&1 | head -20
+  ```
+
+- [ ] Apply the `runRender` and import changes above.
+
+- [ ] Run all cmd tests — must pass:
+
+  ```bash
+  cd src/gsl && go test ./cmd/... -v 2>&1 | tail -20
+  ```
+
+- [ ] Commit: `feat(gsl): log payload parse errors via structured logger (#32)`
+
+---
+
+### Task 6 — Log config-load failures in `cmd/statusline.go`
+
+The current `cmd/statusline.go` `runStatusLine` function writes config-load failures to stderr. Replace with structured logging.
+
+Read the current `cmd/statusline.go`. The updated config-load block:
+
+```go
+cfg, err := config.Load(config.DefaultPath())
+if err != nil {
+    safeLog(func(l *logrus.Logger) {
+        l.WithFields(logrus.Fields{
+            "event": "config_load_error",
+            "path":  config.DefaultPath(),
+            "error": err.Error(),
+        }).Warn("gsl: config load failed (using defaults)")
+    })
+    cfg = config.Default()
+}
+```
+
+Also add `"github.com/sirupsen/logrus"` to the import block of `cmd/statusline.go` and remove `"fmt"` if it is only used for the old `fmt.Fprintf(os.Stderr, ...)` call. Keep `"fmt"` if it is used elsewhere in the file.
+
+- [ ] Write failing test first (`cmd/statusline_logging_test.go`):
+
+  ```go
+  package cmd
+
+  import (
+  	"path/filepath"
+  	"testing"
+
+  	"github.com/sirupsen/logrus"
+  )
+
+  // TestRunStatusLine_logsConfigError verifies that a bad config path emits a
+  // structured Warn entry and does not return an error (degrade path).
+  func TestRunStatusLine_logsConfigError(t *testing.T) {
+  	var captured []logrus.Entry
+  	hook := &captureHook{entries: &captured}
+  	l := logrus.New()
+  	l.AddHook(hook)
+  	l.SetLevel(logrus.WarnLevel)
+  	origLog := log
+  	log = l
+  	defer func() { log = origLog }()
+
+  	// Point DefaultPath to a directory (unreadable as a config file).
+  	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir()))
+  	// The file does not exist → Load returns Default(), no error; this test
+  	// only exercises the error path via an intentionally corrupt file.
+  	// We do not corrupt a real file here; instead, we verify the happy path
+  	// does NOT emit a warning (coverage of the if-branch via the error path
+  	// is exercised in config_test.go and integration scenarios).
+  	// This test validates the wiring compiles and the non-error path is silent.
+  	if err := runStatusLine(renderCmd, payload.Payload{}, ""); err != nil {
+  		t.Fatalf("runStatusLine returned error: %v", err)
+  	}
+  	for _, e := range captured {
+  		if e.Data["event"] == "config_load_error" {
+  			t.Errorf("unexpected config_load_error warning on clean config: %v", e)
+  		}
+  	}
+  }
+  ```
+
+  Add `"github.com/wenlock/dotfiles/gsl/internal/payload"` to the import.
+
+- [ ] Run test before edit to confirm compilation:
+
+  ```bash
+  cd src/gsl && go test ./cmd/... -run TestRunStatusLine_logsConfigError 2>&1 | head -10
+  ```
+
+- [ ] Apply the `runStatusLine` change above.
+
+- [ ] Run all cmd tests:
+
+  ```bash
+  cd src/gsl && go test ./cmd/... -v 2>&1 | tail -20
+  ```
+
+- [ ] Commit: `feat(gsl): log config load failures via structured logger (#32)`
+
+---
+
+### Task 7 — Log segment timeouts in `internal/render/render.go`
+
+The `Render` function in `internal/render/render.go` silently drops timed-out segments. We need to log a structured entry when a segment is dropped. Because `render` has no direct access to the logger (it is a library package), we inject it via `Deps`.
+
+#### 7a — Add `Logger` field to `Deps`
+
+Read `internal/render/render.go` before editing. Add this field to the `Deps` struct:
+
+```go
+// Logger is the structured logger for render-pipeline diagnostics.
+// When nil, segment drop events are silently swallowed (safe default for tests
+// that do not care about logging output).
+Logger *logrus.Logger
+```
+
+Add `"github.com/sirupsen/logrus"` to the import block of `render.go`.
+
+#### 7b — Update `BuildSegments` signature to thread Logger into `Render`
+
+`BuildSegments` does not need the Logger — it just returns `[]Segment`. `Render` is the one that needs it. Update `Render`'s signature:
+
+Current:
+```go
+func Render(ctx context.Context, cfg config.Config, st style.Style, segs []Segment) string {
+```
+
+New (no change to callers needed yet — `Deps.Logger` is threaded in Task 8):
+```go
+func Render(ctx context.Context, cfg config.Config, st style.Style, segs []Segment, logger *logrus.Logger) string {
+```
+
+> Design note: adding `logger *logrus.Logger` to `Render` keeps the logger off the Segment interface and avoids global state. Passing nil is always safe (no-op).
+
+#### 7c — Update the segment-drop path inside `Render`
+
+Inside the goroutine recover block and the context-deadline drop, add a safeLog-equivalent pattern:
+
+```go
+go func(idx int, s Segment) {
+    defer wg.Done()
+    defer func() {
+        if r := recover(); r != nil {
+            results[idx] = result{ok: false}
+            if logger != nil {
+                func() {
+                    defer func() { recover() }()
+                    logger.WithFields(logrus.Fields{
+                        "event":   "segment_panic",
+                        "segment": idx,
+                        "recover": fmt.Sprintf("%v", r),
+                    }).Warn("gsl render: segment panicked (dropped)")
+                }()
+            }
+        }
+    }()
+
+    sctx, cancel := context.WithTimeout(ctx, segmentDeadline)
+    defer cancel()
+
+    text, ok := s.Render(sctx, st)
+    if !ok && sctx.Err() != nil && logger != nil {
+        func() {
+            defer func() { recover() }()
+            logger.WithFields(logrus.Fields{
+                "event":   "segment_timeout",
+                "segment": idx,
+            }).Warn("gsl render: segment timed out (dropped)")
+        }()
+    }
+    results[idx] = result{text: text, ok: ok}
+}(i, seg)
+```
+
+Add `"fmt"` to imports of `render.go` if not already present.
+
+- [ ] Write failing tests (`internal/render/render_logging_test.go`):
+
+  ```go
+  package render_test
+
+  import (
+  	"context"
+  	"testing"
+  	"time"
+
+  	"github.com/sirupsen/logrus"
+  	"github.com/wenlock/dotfiles/gsl/internal/config"
+  	"github.com/wenlock/dotfiles/gsl/internal/render"
+  	"github.com/wenlock/dotfiles/gsl/internal/style"
+  )
+
+  // slowSegment blocks until ctx is cancelled (simulates a timeout).
+  type slowSegment struct{}
+
+  func (s *slowSegment) Render(ctx context.Context, st style.Style) (string, bool) {
+  	<-ctx.Done()
+  	return "", false
+  }
+
+  // panicSegment panics when rendered.
+  type panicSegment struct{}
+
+  func (s *panicSegment) Render(ctx context.Context, st style.Style) (string, bool) {
+  	panic("deliberate test panic")
+  }
+
+  // captureHook captures logrus entries for assertions.
+  type captureHook struct {
+  	entries []logrus.Entry
+  }
+
+  func (h *captureHook) Levels() []logrus.Level { return logrus.AllLevels }
+  func (h *captureHook) Fire(e *logrus.Entry) error {
+  	h.entries = append(h.entries, *e)
+  	return nil
+  }
+
+  // TestRender_logsSegmentTimeout verifies that a timed-out segment emits a
+  // "segment_timeout" Warn entry.
+  func TestRender_logsSegmentTimeout(t *testing.T) {
+  	hook := &captureHook{}
+  	l := logrus.New()
+  	l.AddHook(hook)
+  	l.SetLevel(logrus.WarnLevel)
+
+  	cfg := config.Default()
+  	st := style.ResolveConfig(nil, "", nil, false)
+  	segs := []render.Segment{&slowSegment{}}
+
+  	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+  	defer cancel()
+
+  	render.Render(ctx, cfg, st, segs, l)
+
+  	found := false
+  	for _, e := range hook.entries {
+  		if e.Data["event"] == "segment_timeout" {
+  			found = true
+  		}
+  	}
+  	if !found {
+  		t.Error("expected segment_timeout log entry, got none")
+  	}
+  }
+
+  // TestRender_logsSegmentPanic verifies that a panicking segment emits a
+  // "segment_panic" Warn entry.
+  func TestRender_logsSegmentPanic(t *testing.T) {
+  	hook := &captureHook{}
+  	l := logrus.New()
+  	l.AddHook(hook)
+  	l.SetLevel(logrus.WarnLevel)
+
+  	cfg := config.Default()
+  	st := style.ResolveConfig(nil, "", nil, false)
+  	segs := []render.Segment{&panicSegment{}}
+
+  	render.Render(context.Background(), cfg, st, segs, l)
+
+  	found := false
+  	for _, e := range hook.entries {
+  		if e.Data["event"] == "segment_panic" {
+  			found = true
+  		}
+  	}
+  	if !found {
+  		t.Error("expected segment_panic log entry, got none")
+  	}
+  }
+
+  // TestRender_nilLoggerIsSafe verifies that nil logger does not panic.
+  func TestRender_nilLoggerIsSafe(t *testing.T) {
+  	cfg := config.Default()
+  	st := style.ResolveConfig(nil, "", nil, false)
+  	segs := []render.Segment{&panicSegment{}}
+  	// Must not panic when logger is nil.
+  	render.Render(context.Background(), cfg, st, segs, nil)
+  }
+  ```
+
+- [ ] Run failing tests:
+
+  ```bash
+  cd src/gsl && go test ./internal/render/... -run "TestRender_logs|TestRender_nil" 2>&1 | head -20
+  ```
+
+- [ ] Apply the three sub-changes (Deps field, Render signature, goroutine body).
+
+- [ ] Update the one call-site of `Render` in `cmd/statusline.go` to pass `log`:
+
+  ```go
+  line := render.Render(ctx, cfg, st, segs, log)
+  ```
+
+- [ ] Run all render tests:
+
+  ```bash
+  cd src/gsl && go test ./internal/render/... -v 2>&1 | tail -30
+  ```
+
+- [ ] Run full suite to confirm no regressions:
+
+  ```bash
+  cd src/gsl && go test ./... 2>&1 | tail -20
+  ```
+
+- [ ] Commit: `feat(gsl): log segment timeouts and panics in render.Render (#32)`
+
+---
+
+### Task 8 — Log subprocess failures in git/gh/mcp seams
+
+The `git.SystemRunner.Run`, `gh.SystemRunner.Run`, and `mcp.SystemRunner.Run` methods currently return errors silently. We want to log subprocess failures. However, these packages must not take a hard dependency on logrus (it would create an import cycle risk and violate the "thin seam" design). Instead, we pass an optional `*logrus.Logger` to the `NewSystemRunner` constructors.
+
+#### Design
+
+```go
+// In internal/git/exec.go (and mirrors in gh/exec.go, mcp/exec.go):
+
+// NewSystemRunnerWithLogger returns a SystemRunner that logs subprocess
+// failures at Warn level using logger. Pass nil for no logging (same as
+// NewSystemRunner()).
+func NewSystemRunnerWithLogger(logger *logrus.Logger) *SystemRunner {
+    return &SystemRunner{Path: "git", logger: logger}
+}
+```
+
+Add a `logger *logrus.Logger` field to `SystemRunner` in each of the three packages. In `Run()`, after `cmd.Run()` returns a non-nil error, call:
+
+```go
+if err != nil {
+    if r.logger != nil {
+        func() {
+            defer func() { recover() }()
+            r.logger.WithFields(logrus.Fields{
+                "event":  "subprocess_failure",
+                "binary": bin,
+                "cmd":    name,
+                "error":  err.Error(),
+            }).Warn("gsl: subprocess failed")
+        }()
+    }
+    return buf.Bytes(), err
+}
+```
+
+- [ ] Write failing tests:
+
+  For each of `internal/git`, `internal/gh`, `internal/mcp`, create a `_logging_test.go` file. Example for `internal/git/exec_logging_test.go`:
+
+  ```go
+  package git_test
+
+  import (
+  	"context"
+  	"testing"
+
+  	"github.com/sirupsen/logrus"
+  	"github.com/wenlock/dotfiles/gsl/internal/git"
+  )
+
+  type captureHook struct {
+  	entries []logrus.Entry
+  }
+
+  func (h *captureHook) Levels() []logrus.Level { return logrus.AllLevels }
+  func (h *captureHook) Fire(e *logrus.Entry) error {
+  	h.entries = append(h.entries, *e)
+  	return nil
+  }
+
+  // TestSystemRunnerWithLogger_logsOnFailure verifies that a subprocess failure
+  // emits a "subprocess_failure" Warn entry when a logger is injected.
+  func TestSystemRunnerWithLogger_logsOnFailure(t *testing.T) {
+  	hook := &captureHook{}
+  	l := logrus.New()
+  	l.AddHook(hook)
+  	l.SetLevel(logrus.WarnLevel)
+
+  	// Use a non-existent binary to force failure.
+  	r := git.NewSystemRunnerWithLogger(l)
+  	r.Path = "/nonexistent/git-binary-for-test"
+  	_, _ = r.Run(context.Background(), "status")
+
+  	found := false
+  	for _, e := range hook.entries {
+  		if e.Data["event"] == "subprocess_failure" {
+  			found = true
+  		}
+  	}
+  	if !found {
+  		t.Error("expected subprocess_failure log entry, got none")
+  	}
+  }
+
+  // TestSystemRunnerWithLogger_nilLoggerIsSafe verifies that nil logger does not
+  // change existing Run behaviour (no panic, still returns error).
+  func TestSystemRunnerWithLogger_nilLoggerIsSafe(t *testing.T) {
+  	r := git.NewSystemRunnerWithLogger(nil)
+  	r.Path = "/nonexistent/git-binary-for-test"
+  	_, err := r.Run(context.Background(), "status")
+  	if err == nil {
+  		t.Error("expected error for non-existent binary")
+  	}
+  }
+  ```
+
+  Write equivalent files for `internal/gh/exec_logging_test.go` and `internal/mcp/exec_logging_test.go` (same pattern, adjust package names and constructor calls).
+
+- [ ] Run failing tests:
+
+  ```bash
+  cd src/gsl && go test ./internal/git/... ./internal/gh/... ./internal/mcp/... -run "TestSystemRunnerWithLogger" 2>&1 | head -30
+  ```
+
+- [ ] Apply changes to `internal/git/exec.go`, `internal/gh/exec.go`, `internal/mcp/exec.go`.
+
+- [ ] Update `cmd/statusline.go` to use the logger-aware constructors:
+
+  ```go
+  gitRunner := git.NewSystemRunnerWithLogger(log)
+  ghRunner  := gh.NewSystemRunnerWithLogger(log)
+  mcpRunner := mcp.NewSystemRunnerWithLogger(log)
+  ```
+
+- [ ] Run all tests:
+
+  ```bash
+  cd src/gsl && go test ./... -v 2>&1 | tail -40
+  ```
+
+- [ ] Commit: `feat(gsl): log subprocess failures in git/gh/mcp seams (#32)`
+
+---
+
+### Task 9 — Final integration verification
+
+- [ ] Build the binary (must compile cleanly):
+
+  ```bash
+  cd src/gsl && go build ./... 2>&1
+  ```
+
+  Expected: no output (clean build).
+
+- [ ] Run full test suite with coverage:
+
+  ```bash
+  cd src/gsl && go test ./... -cover 2>&1
+  ```
+
+  Expected: all packages PASS; `internal/logging` coverage >60% (target >80%);
+  no existing tests regressed.
+
+- [ ] Smoke-test log output with a sample payload:
+
+  ```bash
+  echo '{"bad json' | ./gsl render 2>/dev/null
+  cat "${XDG_STATE_HOME:-$HOME/.local/state}/gsl/gsl.log" | tail -5
+  ```
+
+  Expected: a JSON line containing `"event":"payload_parse_error"` and `"level":"warning"`.
+
+- [ ] Verify log rotation config is in effect (inspect lumberjack fields):
+
+  ```bash
+  cd src/gsl && grep -r "MaxAge" internal/logging/
+  ```
+
+  Expected: `MaxAge: 7` in `logging.go`.
+
+- [ ] Commit: `chore(gsl): verify issue #32 logging integration complete`
+
+---
+
+## Open Design Questions
+
+1. **`Render` signature change is a breaking API change for external consumers.** The current module path (`github.com/wenlock/dotfiles/gsl`) is a private binary tool, not a library, so no downstream callers are expected. Confirm before merging that no external code imports `render.Render` directly.
+
+2. **`captureHook` is redefined across test packages.** Each `_logging_test.go` file defines its own `captureHook` to avoid cross-package test dependencies. If this causes `duplicate type` errors within the same package, extract to an `internal/testutil` package. Do not export the hook from production code.
+
+3. **lumberjack `MaxSize` = 10 MB is a guess.** A gsl status-line invocation logs at most a few hundred bytes per call; 10 MB gives ~50 000 invocations between rotations. Tune down to 1 MB if log verbosity in practice is lower and disk is scarce.
+
+4. **`GSL_LOG_LEVEL` is parsed once at startup.** Dynamic level changes (e.g. `kill -USR1`) are not supported. This is intentional for simplicity — reopen the question if live debug toggling becomes a requirement.
+
+5. **Issue #34 (token usage history) will build on this logging infrastructure.** The `payload_parse_error` and context-window fields logged here will serve as the raw data source for #34's aggregation layer. When implementing #34, consider adding a `"event":"token_usage_snapshot"` log entry in `cmd/render.go` after successful payload parsing rather than a separate persistence layer, letting the logging rotation policy serve as the retention window.
+
+6. **`go-licenses` audit.** Before merging, run `go-licenses check ./...` to confirm no transitive banned license is dragged in by logrus's dependency on `golang.org/x/sys`. The sys package is BSD-3-Clause, which is in the allowed list.


### PR DESCRIPTION
gsl structured JSON logging via logrus + lumberjack (#32)

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **gsl-issues**.

- #36 — edward-raigosa/resets-at (base: `main`)
- #37 — edward-raigosa/parse-robust (base: `main`) ← parent of this PR
- **(no PR yet) — edward-raigosa/logging (base: `main`)** ← you are here
- (no PR yet) — edward-raigosa/tmux (base: `main`)
- (no PR yet) — edward-raigosa/tokens (base: `main`)
- (no PR yet) — edward-raigosa/nerdfont (base: `main`)

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
