### PR TITLE
fix: installer node-manager drift, claude yolo, gss checkpoint push race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,10 @@
 !Dockerfile
 !.gitignore
 !**/GEMINI.md
-!**/WORKER.md
 !**/FEATURE.md
 !**/CLAUDE.md
+# WORKER.md is per-worktree scratch state (gss feature worker add seeds it);
+# keep it local-only so it never lands in a PR or the main branch.
 
 # Repository Structure Exceptions
 !.github/

--- a/ai/claude/aliases.sh
+++ b/ai/claude/aliases.sh
@@ -21,9 +21,11 @@
 CLAUDE_YOLO_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/claude"
 CLAUDE_YOLO_FILE="$CLAUDE_YOLO_DIR/yolo.enabled"
 
-_claude_yolo_enabled() {
-    [ -f "$CLAUDE_YOLO_FILE" ]
-}
+# Note: the YOLO check is inlined (instead of a helper function) because
+# Claude Code's shell-snapshot mechanism strips functions whose names start
+# with '_'. A separate `_claude_yolo_enabled` helper would survive in the
+# live shell but vanish from the snapshot, causing "command not found"
+# errors whenever the snapshot is sourced.
 
 claude() {
     # Auto-anchor in tmux so AI-driven pane splits target this pane.
@@ -33,7 +35,7 @@ claude() {
         echo "Tip: run inside a tmux pane for AI pane-split support." \
              "Use 'tmux-start' or 'tmux new-session -A -s main' first." >&2
     fi
-    if _claude_yolo_enabled; then
+    if [ -f "$CLAUDE_YOLO_FILE" ]; then
         command claude --dangerously-skip-permissions "$@"
     else
         command claude "$@"
@@ -42,7 +44,7 @@ claude() {
 
 claude-toggle() {
     mkdir -p "$CLAUDE_YOLO_DIR"
-    if _claude_yolo_enabled; then
+    if [ -f "$CLAUDE_YOLO_FILE" ]; then
         rm -f "$CLAUDE_YOLO_FILE"
         echo "Claude YOLO mode: OFF — claude will prompt for permissions."
     else

--- a/ai/claude/aliases_test.sh
+++ b/ai/claude/aliases_test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Test driver for ai/claude/aliases.sh
+#
+# Why: the `claude` / `claude-toggle` functions historically depended on a
+# private helper `_claude_yolo_enabled`. Claude Code's shell-snapshot
+# mechanism strips functions whose names start with `_`, so the snapshot kept
+# `claude()` but dropped `_claude_yolo_enabled` — producing
+#   "claude:8: command not found: _claude_yolo_enabled"
+# on every Claude Code launch. The inline-check fix removes that dependency;
+# this test driver guards against any reintroduction of an underscore helper.
+#
+# Run: bash ai/claude/aliases_test.sh
+set -u
+
+ALIASES="$(cd "$(dirname "$0")" && pwd)/aliases.sh"
+PASS=0
+FAIL=0
+
+# assert_in_subshell <label> <code...>
+# Sources aliases.sh in a child bash and asserts <code> returns 0.
+assert_in_subshell() {
+    local label="$1"; shift
+    if bash -c ". '$ALIASES' && $*" >/dev/null 2>&1; then
+        echo "PASS: $label"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL: $label"
+        FAIL=$((FAIL+1))
+    fi
+}
+
+# assert_grep_negative <label> <pattern>
+# Asserts the aliases.sh source does NOT contain <pattern>.
+assert_grep_negative() {
+    local label="$1" pattern="$2"
+    if grep -qE "$pattern" "$ALIASES"; then
+        echo "FAIL: $label (matched: $pattern)"
+        FAIL=$((FAIL+1))
+    else
+        echo "PASS: $label"
+        PASS=$((PASS+1))
+    fi
+}
+
+# === Source-level checks ===
+# No underscore-prefixed helper functions should reappear. Claude Code's
+# snapshot strips them and dependent callers break silently.
+assert_grep_negative "no underscore-prefixed helper functions" \
+    '^_[a-zA-Z_]+\(\)[[:space:]]*\{'
+
+# `claude` and `claude-toggle` must be defined at the top level.
+assert_grep_negative "claude() not removed by accident" \
+    '^# REMOVED claude\(\)'
+
+# === Runtime checks (source the file in a subshell) ===
+assert_in_subshell "claude function defined after sourcing" \
+    "type claude >/dev/null 2>&1"
+assert_in_subshell "claude-toggle function defined after sourcing" \
+    "type claude-toggle >/dev/null 2>&1"
+# `claude` must NOT reference any undefined command at parse time. We can't
+# easily invoke claude() (it would shell out to the real binary), but we can
+# inspect its body for forbidden references.
+assert_in_subshell "claude body does not call _claude_yolo_enabled" \
+    "! declare -f claude | grep -q '_claude_yolo_enabled'"
+assert_in_subshell "claude-toggle body does not call _claude_yolo_enabled" \
+    "! declare -f claude-toggle | grep -q '_claude_yolo_enabled'"
+
+# === Variable setup ===
+assert_in_subshell "CLAUDE_YOLO_DIR exported" \
+    "[ -n \"\$CLAUDE_YOLO_DIR\" ]"
+assert_in_subshell "CLAUDE_YOLO_FILE exported" \
+    "[ -n \"\$CLAUDE_YOLO_FILE\" ]"
+
+# === Summary ===
+echo
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/opt/scripts/system/google-cli-setup.sh
+++ b/opt/scripts/system/google-cli-setup.sh
@@ -58,8 +58,6 @@ load_node_env() {
     else
         SUDO=""
     fi
-
-    echo -e "${BLUE}Using npm at $(command -v npm) (prefix: ${NPM_PREFIX})${NC}"
 }
 
 install_or_upgrade() {

--- a/opt/scripts/system/google-cli-setup.sh
+++ b/opt/scripts/system/google-cli-setup.sh
@@ -24,20 +24,32 @@ NC='\033[0m'
 
 # 1. Environment Sourcing
 load_node_env() {
-    # Prefer user-managed Node environments (fnm, nodenv, nvm)
-    export PATH="${HOME}/.local/share/fnm:${HOME}/.nodenv/shims:${HOME}/.nvm/versions/node/$(ls -1 ${HOME}/.nvm/versions/node 2>/dev/null | tail -1)/bin:${HOME}/opt/bin:${PATH}"
-    
-    # Try to load fnm environment specifically if binary exists
-    if [ -x "${HOME}/.local/share/fnm/fnm" ]; then
-        eval "$("${HOME}/.local/share/fnm/fnm" env)"
+    # Respect the user's already-active node manager first. Only fall back to
+    # discovery (fnm -> nodenv -> nvm-latest) if no npm is on PATH. Crucial:
+    # do NOT pre-pend nvm-latest unconditionally — that shadowed fnm's current
+    # node and caused globals (e.g. gws) to land in an unused node version.
+    if ! command -v npm >/dev/null 2>&1; then
+        if [ -x "${HOME}/.local/share/fnm/fnm" ]; then
+            eval "$("${HOME}/.local/share/fnm/fnm" env)"
+        fi
+        if ! command -v npm >/dev/null 2>&1 && [ -d "${HOME}/.nodenv" ]; then
+            export PATH="${HOME}/.nodenv/shims:${PATH}"
+        fi
+        if ! command -v npm >/dev/null 2>&1 && [ -d "${HOME}/.nvm/versions/node" ]; then
+            local latest_nvm
+            latest_nvm=$(ls -1 "${HOME}/.nvm/versions/node" 2>/dev/null | tail -1)
+            [ -n "$latest_nvm" ] && export PATH="${HOME}/.nvm/versions/node/${latest_nvm}/bin:${PATH}"
+        fi
     fi
 
-    # Final check
+    # Always make ~/opt/bin reachable for locally-installed tools.
+    export PATH="${HOME}/opt/bin:${PATH}"
+
     if ! command -v npm >/dev/null 2>&1; then
         echo -e "${RED}Error: npm not found. Please ensure Node.js is installed.${NC}"
         exit 1
     fi
-    
+
     # Decide if sudo is needed
     NPM_PREFIX=$(npm config get prefix)
     if [[ "$NPM_PREFIX" == "/usr" ]] || [[ "$NPM_PREFIX" == "/usr/local" ]]; then
@@ -46,6 +58,8 @@ load_node_env() {
     else
         SUDO=""
     fi
+
+    echo -e "${BLUE}Using npm at $(command -v npm) (prefix: ${NPM_PREFIX})${NC}"
 }
 
 install_or_upgrade() {

--- a/src/gss/internal/feature/checkpoint.go
+++ b/src/gss/internal/feature/checkpoint.go
@@ -76,6 +76,19 @@ func (s *Service) Checkpoint(ctx context.Context, opts CheckpointOpts) (Checkpoi
 
 	res := CheckpointResult{Ref: ref.String()}
 	if w.PRURL == "" {
+		// Push the worker branch to origin BEFORE asking gh to open a PR.
+		// gh pr create only fills in head/base SHAs by looking them up via
+		// the GitHub API; if the branch isn't on origin yet, that lookup
+		// returns empty and the call fails opaquely with
+		//   "Head sha can't be blank, Base sha can't be blank,
+		//    No commits between <base> and <head>"
+		// which leaves the worker half-checkpointed (commit local-only,
+		// registry still has no pr_url). -u sets upstream tracking so the
+		// follow-up checkpoint's --force-with-lease push has a remote ref
+		// to compare against.
+		if out, err := s.Git.Run(ctx, "-C", w.Worktree, "push", "-u", "origin", w.Branch); err != nil {
+			return CheckpointResult{}, fmt.Errorf("checkpoint: push: %w: %s", err, strings.TrimSpace(string(out)))
+		}
 		pr, err := s.GH.PRCreate(ctx, gh.PRCreateOpts{Title: title, Body: body, Base: base, Head: w.Branch, Draft: true})
 		if err != nil {
 			return CheckpointResult{}, fmt.Errorf("checkpoint: pr create: %w", err)

--- a/src/gss/internal/feature/checkpoint.go
+++ b/src/gss/internal/feature/checkpoint.go
@@ -83,10 +83,17 @@ func (s *Service) Checkpoint(ctx context.Context, opts CheckpointOpts) (Checkpoi
 		//   "Head sha can't be blank, Base sha can't be blank,
 		//    No commits between <base> and <head>"
 		// which leaves the worker half-checkpointed (commit local-only,
-		// registry still has no pr_url). -u sets upstream tracking so the
-		// follow-up checkpoint's --force-with-lease push has a remote ref
-		// to compare against.
-		if out, err := s.Git.Run(ctx, "-C", w.Worktree, "push", "-u", "origin", w.Branch); err != nil {
+		// registry still has no pr_url).
+		//
+		// --force-with-lease (mirroring the update path on line 100) is
+		// safe because the `fetch origin` above refreshed origin/<branch>'s
+		// ref. It covers three cases uniformly: branch absent on origin
+		// (acts like a normal push), branch present and matches (no-op
+		// fast-forward), branch present but diverged after a rebase (the
+		// post-rebase HEAD wins without a non-fast-forward error stranding
+		// the worker). --set-upstream wires up the tracking ref so the
+		// follow-up update-path push has something to compare against.
+		if out, err := s.Git.Run(ctx, "-C", w.Worktree, "push", "--force-with-lease", "--set-upstream", "origin", w.Branch); err != nil {
 			return CheckpointResult{}, fmt.Errorf("checkpoint: push: %w: %s", err, strings.TrimSpace(string(out)))
 		}
 		pr, err := s.GH.PRCreate(ctx, gh.PRCreateOpts{Title: title, Body: body, Base: base, Head: w.Branch, Draft: true})

--- a/src/gss/internal/feature/checkpoint_test.go
+++ b/src/gss/internal/feature/checkpoint_test.go
@@ -71,14 +71,17 @@ func TestCheckpoint_FirstTimeCreatesDraftPR(t *testing.T) {
 	}
 }
 
-// TestCheckpoint_FirstTimePushSetsUpstreamForBranch guards against a
-// regression where the create path called gh pr create before pushing the
-// worker branch to origin. Symptoms in the wild: gh failed with "Head sha
-// can't be blank ... No commits between <base> and <head>" and the registry
-// never got a pr_url, leaving the worker stuck half-checkpointed. The fix
-// pushes with -u so the branch is on origin AND has an upstream tracking ref
-// before the GitHub API call.
-func TestCheckpoint_FirstTimePushSetsUpstreamForBranch(t *testing.T) {
+// TestCheckpoint_FirstTimePushUsesForceWithLeaseAndSetsUpstream guards
+// against a regression where the create path called gh pr create before
+// pushing the worker branch to origin. Symptoms in the wild: gh failed with
+// "Head sha can't be blank ... No commits between <base> and <head>" and the
+// registry never got a pr_url, leaving the worker stuck half-checkpointed.
+//
+// The fix mirrors the update path: push with --force-with-lease so a divergent
+// remote branch (e.g. from a half-completed previous checkpoint) doesn't
+// strand the worker on a non-fast-forward error, plus --set-upstream so the
+// branch has a tracking ref before the next checkpoint runs.
+func TestCheckpoint_FirstTimePushUsesForceWithLeaseAndSetsUpstream(t *testing.T) {
 	ghc := ghfake.NewClient()
 	svc, _, gitr := checkpointService(t, "",
 		[]gitfake.Response{{}, {}, {}}, ghc)
@@ -87,7 +90,6 @@ func TestCheckpoint_FirstTimePushSetsUpstreamForBranch(t *testing.T) {
 		t.Fatalf("Checkpoint: %v", err)
 	}
 
-	// Find the push call; it must target origin + the worker branch with -u.
 	pushIdx := -1
 	for i, call := range gitr.Calls {
 		if argsHasFC(call.Args, "push") && argsHasFC(call.Args, "origin") {
@@ -101,6 +103,9 @@ func TestCheckpoint_FirstTimePushSetsUpstreamForBranch(t *testing.T) {
 	args := gitr.Calls[pushIdx].Args
 	if !argsHasFC(args, "feature/auth/erai/api") {
 		t.Errorf("push did not target worker branch; args=%v", args)
+	}
+	if !argsHasFC(args, "--force-with-lease") {
+		t.Errorf("push must use --force-with-lease (mirroring update path); args=%v", args)
 	}
 	if !argsHasFC(args, "-u") && !argsHasFC(args, "--set-upstream") {
 		t.Errorf("push must set upstream tracking; args=%v", args)

--- a/src/gss/internal/feature/checkpoint_test.go
+++ b/src/gss/internal/feature/checkpoint_test.go
@@ -36,9 +36,9 @@ func checkpointService(t *testing.T, prURL string, gitScript []gitfake.Response,
 }
 
 func TestCheckpoint_FirstTimeCreatesDraftPR(t *testing.T) {
-	// fetch ok, rebase ok.
+	// fetch ok, rebase ok, push ok.
 	svc, store, gitr := checkpointService(t, "",
-		[]gitfake.Response{{}, {}}, ghfake.NewClient())
+		[]gitfake.Response{{}, {}, {}}, ghfake.NewClient())
 
 	res, err := svc.Checkpoint(context.Background(), feature.CheckpointOpts{WorkerRef: "auth/erai/api"})
 	if err != nil {
@@ -47,9 +47,14 @@ func TestCheckpoint_FirstTimeCreatesDraftPR(t *testing.T) {
 	if !res.Created || res.PRState != "draft" {
 		t.Errorf("result = %+v; want Created draft", res)
 	}
-	// git: fetch then rebase, in order.
-	if len(gitr.Calls) != 2 || !argsHasFC(gitr.Calls[0].Args, "fetch") || !argsHasFC(gitr.Calls[1].Args, "rebase") {
-		t.Errorf("git calls = %+v; want fetch then rebase", gitr.Calls)
+	// git: fetch then rebase then push, in order. The push must precede
+	// gh pr create so origin actually has the head SHA when GitHub looks it
+	// up — without it, gh pr create fails with "Head sha can't be blank".
+	if len(gitr.Calls) != 3 ||
+		!argsHasFC(gitr.Calls[0].Args, "fetch") ||
+		!argsHasFC(gitr.Calls[1].Args, "rebase") ||
+		!argsHasFC(gitr.Calls[2].Args, "push") {
+		t.Errorf("git calls = %+v; want fetch, rebase, push", gitr.Calls)
 	}
 	// PR created draft, head=branch, body has stack section.
 	c := lastPRCreate(svc.GH.(*ghfake.Client))
@@ -63,6 +68,68 @@ func TestCheckpoint_FirstTimeCreatesDraftPR(t *testing.T) {
 	reg, _ := store.Load()
 	if reg.Features[0].Workers[0].PRURL == "" {
 		t.Error("registry pr_url not updated after create")
+	}
+}
+
+// TestCheckpoint_FirstTimePushSetsUpstreamForBranch guards against a
+// regression where the create path called gh pr create before pushing the
+// worker branch to origin. Symptoms in the wild: gh failed with "Head sha
+// can't be blank ... No commits between <base> and <head>" and the registry
+// never got a pr_url, leaving the worker stuck half-checkpointed. The fix
+// pushes with -u so the branch is on origin AND has an upstream tracking ref
+// before the GitHub API call.
+func TestCheckpoint_FirstTimePushSetsUpstreamForBranch(t *testing.T) {
+	ghc := ghfake.NewClient()
+	svc, _, gitr := checkpointService(t, "",
+		[]gitfake.Response{{}, {}, {}}, ghc)
+
+	if _, err := svc.Checkpoint(context.Background(), feature.CheckpointOpts{WorkerRef: "auth/erai/api"}); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+
+	// Find the push call; it must target origin + the worker branch with -u.
+	pushIdx := -1
+	for i, call := range gitr.Calls {
+		if argsHasFC(call.Args, "push") && argsHasFC(call.Args, "origin") {
+			pushIdx = i
+			break
+		}
+	}
+	if pushIdx < 0 {
+		t.Fatalf("expected a git push to origin before PRCreate; calls=%+v", gitr.Calls)
+	}
+	args := gitr.Calls[pushIdx].Args
+	if !argsHasFC(args, "feature/auth/erai/api") {
+		t.Errorf("push did not target worker branch; args=%v", args)
+	}
+	if !argsHasFC(args, "-u") && !argsHasFC(args, "--set-upstream") {
+		t.Errorf("push must set upstream tracking; args=%v", args)
+	}
+	if lastPRCreate(ghc) == nil {
+		t.Fatalf("PRCreate was never called")
+	}
+}
+
+// TestCheckpoint_FirstTimePushFailureSurfaces ensures a failed initial push
+// short-circuits the checkpoint with a clear error rather than silently
+// dropping through to gh pr create (which would fail opaquely with "Head sha
+// can't be blank") and leave the registry in a partial state.
+func TestCheckpoint_FirstTimePushFailureSurfaces(t *testing.T) {
+	pushErr := stderrors.New("non-fast-forward")
+	// fetch ok, rebase ok, push fails.
+	svc, _, _ := checkpointService(t, "",
+		[]gitfake.Response{{}, {}, {Err: pushErr}}, ghfake.NewClient())
+
+	_, err := svc.Checkpoint(context.Background(), feature.CheckpointOpts{WorkerRef: "auth/erai/api"})
+	if err == nil {
+		t.Fatalf("push failure: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "push") {
+		t.Errorf("error should mention push; got: %v", err)
+	}
+	// PRCreate must NOT have been called when push failed.
+	if lastPRCreate(svc.GH.(*ghfake.Client)) != nil {
+		t.Error("PRCreate was called despite push failure; should short-circuit")
 	}
 }
 


### PR DESCRIPTION
## What

Three independent fixes — all surfaced while running `install.sh` on this host — plus the test scaffolding to keep them from regressing.

1. **`opt/scripts/system/google-cli-setup.sh`** — `load_node_env()` now respects the user's already-active node manager instead of force-prepending nvm-latest to `PATH`. Falls back to discovery (fnm → nodenv → nvm-latest) only when `npm` isn't already on `PATH`. (Review round also dropped a noisy unconditional `echo`.)
2. **`ai/claude/aliases.sh`** — inlined the YOLO sentinel-file test directly into `claude()` and `claude-toggle()`, dropping the `_claude_yolo_enabled` helper. Added a comment explaining the snapshot-strip footgun so the next contributor doesn't reintroduce a private helper. New `aliases_test.sh` guards the invariant.
3. **`src/gss/internal/feature/checkpoint.go`** — `gss feature checkpoint` now pushes the worker branch (`--force-with-lease --set-upstream`) **before** calling `gh pr create` on the first-time path, mirroring the update path.
4. **`.gitignore`** — drops the `!**/WORKER.md` opt-in so per-worktree scratch state stays local. (Inline comment documents the intent.)

## Why

1. **Installer drift.** The previous `PATH` line force-prepended `~/.nvm/versions/node/<latest>/bin`. On this host the user runs node via **fnm v24.15.0** with nvm v24.16.0 also installed; `install.sh` therefore ran `npm install -g @googleworkspace/cli` against v24.16.0 while the interactive shell stayed on v24.15.0. `gws 0.22.5` was installed but invisible — `gws auth setup` couldn't even be invoked.
2. **Claude yolo snapshot error.** Claude Code's shell-snapshot mechanism strips functions whose names start with `_`. The snapshot retained `claude()` / `claude-toggle()` but lost their private predicate, producing `claude:8: command not found: _claude_yolo_enabled` on every Claude Code launch.
3. **Gss checkpoint push race.** `gss feature checkpoint`'s create path called `gh pr create` straight after `git rebase`, without ever pushing the branch to origin. `gh pr create` only fills in head/base SHAs via the GitHub API, so when the branch wasn't on origin the call failed opaquely with `"Head sha can't be blank, Base sha can't be blank, No commits between <base> and <head>"`. The worker was left half-checkpointed (commit local-only, registry without a `pr_url`); recovery required a manual `git push -u origin <branch>`. The update path (`--force-with-lease`) was always fine — only the first-time create path was missing the push. Using `--force-with-lease --set-upstream` mirrors the update path's semantics and handles a divergent-branch edge case (e.g. a previous half-completed checkpoint that pushed but died before `gh pr create` succeeded — a plain push would now fail non-fast-forward and strand the worker again).

## Impact

- `install.sh` installs npm globals to the active node manager — no more orphaned binaries.
- Claude Code launches cleanly with no `command not found` noise; `/doctor` is quieter.
- `gss feature checkpoint` succeeds end-to-end on the first run for any new worker, without manual `git push` intervention.
- WORKER.md is local-only by default; future workers won't accidentally leak scratch state into PRs.
- **No public-API changes.** No behaviour change for the YOLO toggle itself, the gss update path, or settings format.

## Tests / verification

- `bash -n` clean on both edited shell scripts.
- `bash ai/claude/aliases_test.sh` — **8/8 pass** (source-level grep guards + runtime sourcing assertions; mirrors `safety_guard_test.sh`).
- `which gws` → `/home/wenlock/.nvm/versions/node/v24.15.0/bin/gws`; `gws --version` → `gws 0.22.5`.
- `cd src/gss && go test ./... -count=1` — all 22 packages pass.
- `go test ./internal/feature/ -run TestCheckpoint -v` — **7/7 pass**: three new TDD tests cover (a) `fetch, rebase, push` ordering, (b) `--force-with-lease --set-upstream` flags on the worker branch, (c) push-failure short-circuit (PRCreate never called). Existing checkpoint tests (force-push edit, adopt-existing-PR, rebase-conflict, unknown-worker) still pass.
- `internal/feature` coverage **83.2%** (≥ 60% standard from `src/CLAUDE.md`).
- `bash src/tmux-mgr/scripts/e2e-gss-integration.sh` — **PASS** against the freshly rebuilt `~/opt/bin/gss` (per the MEMORY.md rebuild-after-source-change guard).

## Commits

1. `1a17893` — `fix(install): respect active node manager + remove claude yolo snapshot error` (commits 1, 2, 4 above)
2. `2afe595` — `fix(gss): push worker branch before gh pr create on first checkpoint` (commit 3 above)
3. `a4a2a4d` — `chore: address review feedback on PR #43` (force-with-lease + drop echo + shell test)

## Out of scope

- A noisier warning when multiple node managers (fnm + nvm + nodenv) are installed simultaneously — deferred.
- Backfilling the original `gws` install under v24.16.0 — left alone; the v24.15.0 install is the canonical one now.
- Squashing the three commits — left for the merger to decide.

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **fix-installer-noise**.

- **#43 — edward-raigosa/dotfiles (base: \`main\`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->