### PR TITLE
fix(gsl/payload): tolerate numeric resets_at (#30)

### DIFF
--- a/src/gsl/internal/payload/payload.go
+++ b/src/gsl/internal/payload/payload.go
@@ -10,11 +10,85 @@
 package payload
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
+
+// NewResetTime wraps a time.Time as a ResetTime. Convenience constructor
+// for test fixtures and any future caller that needs to synthesize a
+// ResetTime from a known time value.
+func NewResetTime(t time.Time) ResetTime { return ResetTime{t: t} }
+
+// ResetTime is a rate-limit reset timestamp that tolerates BOTH wire shapes
+// Claude Code has shipped to date:
+//
+//   - An ISO-8601 / RFC3339 string ("2026-05-25T10:00:00Z") — the form the
+//     gsl payload schema originally assumed.
+//   - A Unix-epoch number — the form the live Claude Code statusLine command
+//     actually sends (see issue #30 for the captured payload). Numbers ≥ 1e12
+//     are interpreted as milliseconds; smaller magnitudes as seconds.
+//
+// Before this type existed the JSON decoder failed the whole payload on a
+// number-shaped resets_at and the AI segment vanished for the rest of the
+// session — the silent regression tracked as #30.
+//
+// String() returns the canonical RFC3339 representation, or "" for a
+// zero-valued ResetTime (absent / null source).
+type ResetTime struct {
+	t time.Time
+}
+
+// Time returns the underlying time.Time (zero value when absent/null).
+func (r ResetTime) Time() time.Time { return r.t }
+
+// String returns the canonical RFC3339 (UTC) representation, or "" when
+// the source was absent or null. This is what downstream renderers and
+// tests should compare against — never reach into the unexported field.
+func (r ResetTime) String() string {
+	if r.t.IsZero() {
+		return ""
+	}
+	return r.t.UTC().Format(time.RFC3339)
+}
+
+// UnmarshalJSON accepts a string (RFC3339) or a JSON number (epoch
+// seconds; epoch milliseconds when the magnitude is ≥ 1e12).
+func (r *ResetTime) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	if trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return fmt.Errorf("resets_at string: %w", err)
+		}
+		if s == "" {
+			return nil
+		}
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return fmt.Errorf("resets_at parse %q: %w", s, err)
+		}
+		r.t = t
+		return nil
+	}
+	var n float64
+	if err := json.Unmarshal(trimmed, &n); err != nil {
+		return fmt.Errorf("resets_at number: %w", err)
+	}
+	sec := int64(n)
+	nsec := int64((n - float64(sec)) * 1e9)
+	if sec >= 1_000_000_000_000 { // ≥ 1e12 → milliseconds
+		sec, nsec = sec/1000, (sec%1000)*1_000_000
+	}
+	r.t = time.Unix(sec, nsec).UTC()
+	return nil
+}
 
 // RateWindow holds the rate-limit data for one rolling window (five-hour or
 // seven-day). All fields are pointers to distinguish absent/null.
@@ -22,8 +96,10 @@ type RateWindow struct {
 	// UsedPercentage is the fraction of the window's quota consumed (0–100).
 	// Pointer so a JSON null value results in nil, not 0.
 	UsedPercentage *float64 `json:"used_percentage"`
-	// ResetsAt is the RFC3339 timestamp at which the window resets.
-	ResetsAt *string `json:"resets_at"`
+	// ResetsAt is the timestamp at which the window resets. Tolerates both
+	// the original string (RFC3339) form and the live numeric (epoch) form.
+	// See ResetTime for details and issue #30 for the motivating payload.
+	ResetsAt *ResetTime `json:"resets_at"`
 }
 
 // RateLimits groups the rate-limit windows present in the Claude payload.

--- a/src/gsl/internal/payload/payload_test.go
+++ b/src/gsl/internal/payload/payload_test.go
@@ -1,6 +1,7 @@
 package payload_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,7 +59,7 @@ func TestParseFullFixture(t *testing.T) {
 	if p.RateLimits.FiveHour.UsedPercentage == nil || *p.RateLimits.FiveHour.UsedPercentage != 25.0 {
 		t.Errorf("RateLimits.FiveHour.UsedPercentage: got %v, want 25.0", p.RateLimits.FiveHour.UsedPercentage)
 	}
-	if p.RateLimits.FiveHour.ResetsAt == nil || *p.RateLimits.FiveHour.ResetsAt != "2026-05-25T10:00:00Z" {
+	if p.RateLimits.FiveHour.ResetsAt == nil || p.RateLimits.FiveHour.ResetsAt.String() != "2026-05-25T10:00:00Z" {
 		t.Errorf("RateLimits.FiveHour.ResetsAt: got %v", p.RateLimits.FiveHour.ResetsAt)
 	}
 
@@ -76,6 +77,66 @@ func TestParseMalformedJSON(t *testing.T) {
 	_, err := payload.Parse([]byte(`{not valid json`))
 	if err == nil {
 		t.Error("Parse(malformed) should return an error, got nil")
+	}
+}
+
+// TestParseLiveNumericResetsAt is the regression test for issue #30: the
+// live Claude Code statusLine payload ships rate_limits.*.resets_at as a
+// Unix-epoch number, which used to nuke the entire AI segment because
+// json.Unmarshal failed the whole payload on the type mismatch.
+// ResetTime.UnmarshalJSON tolerates both shapes; this fixture proves it.
+func TestParseLiveNumericResetsAt(t *testing.T) {
+	data := readFixture(t, "live_numeric_resets.json")
+	p, err := payload.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse(live_numeric_resets.json) returned error: %v (this is the #30 regression)", err)
+	}
+	if p.RateLimits == nil || p.RateLimits.FiveHour == nil || p.RateLimits.FiveHour.ResetsAt == nil {
+		t.Fatalf("RateLimits.FiveHour.ResetsAt is nil; whole payload likely degraded (#30): %+v", p.RateLimits)
+	}
+	// 1779863400 → 2026-05-27T06:30:00Z (UTC).
+	want := "2026-05-27T06:30:00Z"
+	if got := p.RateLimits.FiveHour.ResetsAt.String(); got != want {
+		t.Errorf("five_hour.ResetsAt: got %q, want %q", got, want)
+	}
+	if p.RateLimits.SevenDay == nil || p.RateLimits.SevenDay.ResetsAt == nil {
+		t.Fatalf("RateLimits.SevenDay.ResetsAt is nil")
+	}
+	// 1780052400 → 2026-05-29T11:00:00Z (UTC).
+	want7 := "2026-05-29T11:00:00Z"
+	if got := p.RateLimits.SevenDay.ResetsAt.String(); got != want7 {
+		t.Errorf("seven_day.ResetsAt: got %q, want %q", got, want7)
+	}
+}
+
+// TestResetTime_NullAndAbsent verifies the corner cases that surrounding
+// pointers handle today: null → zero ResetTime, absent → nil pointer.
+func TestResetTime_NullAndAbsent(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string // String() output; "" means zero/absent
+	}{
+		{"absent", `{"used_percentage":50}`, ""},
+		{"null", `{"used_percentage":50,"resets_at":null}`, ""},
+		{"string", `{"used_percentage":50,"resets_at":"2026-05-25T10:00:00Z"}`, "2026-05-25T10:00:00Z"},
+		{"epoch_seconds", `{"used_percentage":50,"resets_at":1779863400}`, "2026-05-27T06:30:00Z"},
+		{"epoch_millis", `{"used_percentage":50,"resets_at":1779863400000}`, "2026-05-27T06:30:00Z"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var w payload.RateWindow
+			if err := json.Unmarshal([]byte(tc.in), &w); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			var got string
+			if w.ResetsAt != nil {
+				got = w.ResetsAt.String()
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/src/gsl/internal/payload/testdata/live_numeric_resets.json
+++ b/src/gsl/internal/payload/testdata/live_numeric_resets.json
@@ -1,0 +1,21 @@
+{
+  "cwd": "/home/user/project",
+  "model": {
+    "display_name": "Opus 4.7"
+  },
+  "context_window": {
+    "used_percentage": 42,
+    "total_input_tokens": 84000,
+    "context_window_size": 200000
+  },
+  "rate_limits": {
+    "five_hour": {
+      "used_percentage": 28.99,
+      "resets_at": 1779863400
+    },
+    "seven_day": {
+      "used_percentage": 32,
+      "resets_at": 1780052400
+    }
+  }
+}

--- a/src/gsl/internal/render/helpers_test.go
+++ b/src/gsl/internal/render/helpers_test.go
@@ -44,6 +44,17 @@ func fixedClock() func() time.Time {
 func strptr(s string) *string   { return &s }
 func f64ptr(v float64) *float64 { return &v }
 
+// resetTimePtr builds a *payload.ResetTime from an RFC3339 string for use
+// in fixtures. Panics on parse failure (test fixtures must use valid input).
+func resetTimePtr(s string) *payload.ResetTime {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic("resetTimePtr: invalid RFC3339 " + s + ": " + err.Error())
+	}
+	r := payload.NewResetTime(t)
+	return &r
+}
+
 // samplePayload returns a fully-populated Claude payload fixture used by the
 // AI-segment and golden tests.
 func samplePayload() payload.Payload {
@@ -56,7 +67,7 @@ func samplePayload() payload.Payload {
 			ContextWindowSize: f64ptr(200000),
 		},
 		RateLimits: &payload.RateLimits{
-			FiveHour: &payload.RateWindow{UsedPercentage: f64ptr(80), ResetsAt: strptr("2026-05-25T19:00:00Z")},
+			FiveHour: &payload.RateWindow{UsedPercentage: f64ptr(80), ResetsAt: resetTimePtr("2026-05-25T19:00:00Z")},
 			SevenDay: &payload.RateWindow{UsedPercentage: f64ptr(15)},
 		},
 	}


### PR DESCRIPTION
Fixes #30.

## What

Claude Code's `statusLine` command ships `rate_limits.{five_hour,seven_day}.resets_at` as a **Unix-epoch number**, but `internal/payload` declared it as `*string`. `json.Unmarshal` failed the whole payload on the type mismatch and the AI segment self-omitted for the rest of the session (it survived only the brief pre-first-API window where `rate_limits` is `null`).

## How

Introduces `payload.ResetTime` — a custom type with `UnmarshalJSON` that accepts **either** shape:

- An RFC3339 string (the original schema, preserved for backward compat).
- A JSON number. Magnitudes ≥ 1e12 are interpreted as milliseconds, smaller values as seconds.

`ResetTime.String()` returns the canonical RFC3339 (UTC) representation, so any future consumer has one display form regardless of which wire shape arrived. The field stays pointer-for-absence on `RateWindow` to preserve the existing absent/null/zero distinction.

## Verification — live integration

Discovered via the structured logging in PR #44 (companion PR for #32). Running the buggy binary against the actual Claude Code stdin produced:

```
{"error":"payload: parse: json: cannot unmarshal number into Go struct field
   RateWindow.rate_limits.five_hour.resets_at of type string",
 "event":"payload.parse_error","level":"warning",
 "msg":"stdin parse failed; degrading to empty payload"}
```

— exactly the symptom described in #30, captured in the wild.

With this PR applied + the binary reinstalled, the same payload now renders the full AI segment:

```
$ echo '{"cwd":"/tmp","model":{"display_name":"Opus 4.7"},"context_window":{...},"rate_limits":{"five_hour":{"used_percentage":28.99,"resets_at":1779863400},"seven_day":{"used_percentage":32,"resets_at":1780052400}}}' | gsl render
📁 tmp · 🏠 ⑂4 · 🤖 Opus 4.7 🧠 42% 84k/200k 5h 29% 7d 32% · ⏰ 2026-05-28 16:06:17 PDT
```

No `payload.parse_error` is emitted — the full payload parses, and the rate-limit windows render.

## Test plan

- [x] New regression test `TestParseLiveNumericResetsAt` — the captured numeric payload (taken from issue #30 verbatim) parses without error and yields the expected RFC3339 strings.
- [x] New table-driven `TestResetTime_NullAndAbsent` covers: absent field, JSON `null`, RFC3339 string, epoch seconds, epoch milliseconds.
- [x] Existing string-form fixture (`full.json`) and tests still pass — both shapes coexist.
- [x] `internal/render` fixture (`helpers_test.go`) updated to use the new constructor; render suite remains green.
- [x] Full `go test ./...` green; no coverage regression.
- [x] Live verification: built binary at `~/opt/bin/gsl`, fed the issue's captured payload, AI segment rendered (`🤖 Opus 4.7 🧠 42% 84k/200k 5h 29% 7d 32%`).

## Relationship to other issues

- **#32 / PR #44** — the structured logging PR. Without that observability, this bug stayed silent for months. With #44 in place, the regression would have been visible on the very first failing refresh.
- **#31** (broader "one bad field shouldn't nuke the whole payload") — this PR only fixes the specific `resets_at` shape. The deeper field-level resilience is still open.

## Commits

1. `fix(gsl/payload): tolerate numeric resets_at to stop nuking the AI segment` — single focused commit; adds `ResetTime` type, the captured live payload fixture, and the regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
