### PR TITLE
gsl-nerdfont: impl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -413,6 +413,35 @@ if [ -f "${BASE_DIR}/src/gsl/build.sh" ]; then
     fi
 fi
 
+# Configure the Nerd Font (MesloLGS Nerd Font) used by gsl's powerline style.
+# Runs AFTER the gsl build so both the gsl skill files (linked by sync-skills
+# above) and the freshly-built ~/opt/bin/gsl exist. OS-dispatch to the
+# gsl-packaged installers under src/gsl/scripts/.
+GSL_FONT_SCRIPTS="${BASE_DIR}/src/gsl/scripts"
+case "$(uname -s)" in
+  Darwin)
+    if [ -f "${GSL_FONT_SCRIPTS}/install_nerd_font_macos.sh" ]; then
+      echo "Configuring Nerd Font (macOS)..."
+      bash "${GSL_FONT_SCRIPTS}/install_nerd_font_macos.sh" || \
+        echo "WARNING: macOS Nerd Font setup reported problems; continuing."
+    fi
+    ;;
+  Linux)
+    if [ ! -f "$NIX_MANAGED_FILE" ] && [ -f "${GSL_FONT_SCRIPTS}/install_nerd_font_linux.sh" ]; then
+      echo "Configuring Nerd Font (Linux/WSL)..."
+      bash "${GSL_FONT_SCRIPTS}/install_nerd_font_linux.sh" || \
+        echo "WARNING: Linux Nerd Font setup reported problems; continuing."
+    fi
+    ;;
+esac
+
+# Prove the installed font covers every codepoint gsl renders (non-fatal).
+if [ -f "${GSL_FONT_SCRIPTS}/check-font-glyphs.sh" ] && command -v go >/dev/null 2>&1; then
+  echo "Validating gsl glyph coverage..."
+  bash "${GSL_FONT_SCRIPTS}/check-font-glyphs.sh" || \
+    echo "WARNING: glyph-coverage check failed; gsl powerline glyphs may not render."
+fi
+
 # install fnm
 if ! command -v fnm &> /dev/null; then
   echo "Installing fnm..."

--- a/opt/Desktop/Apps/scripts/setup-apps.ps1
+++ b/opt/Desktop/Apps/scripts/setup-apps.ps1
@@ -48,7 +48,7 @@ $Distros      = [ordered]@{
 
 $DistroUser   = 'wenlock'        # Linux user to ensure on newly-created distros
 $GitHubLink   = 'C:\Users\edwar\GitHub'  # Windows folder (a symlink) to expose in WSL
-$TerminalFont = 'Ubuntu Mono'
+$TerminalFont = 'MesloLGS NF'
 $HistorySize  = 100000
 
 # Color schemes to publish, and the order in which a profile is made per distro.
@@ -168,63 +168,20 @@ function Get-WslReport {
 }
 
 # ---- Fonts -----------------------------------------------------------------
-
-function Install-UbuntuMono {
-    Write-Host "`n=== [4/6] Ubuntu Mono font ===" -ForegroundColor Cyan
-    $fontDir = "$env:LOCALAPPDATA\Microsoft\Windows\Fonts"
-    $regKey  = 'HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts'
-    New-Item -ItemType Directory -Force -Path $fontDir | Out-Null
-
-    $base = 'https://github.com/google/fonts/raw/main/ufl/ubuntumono'
-    $faces = @(
-        @{ File = 'UbuntuMono-Regular.ttf';    Reg = 'Ubuntu Mono (TrueType)' }
-        @{ File = 'UbuntuMono-Bold.ttf';       Reg = 'Ubuntu Mono Bold (TrueType)' }
-        @{ File = 'UbuntuMono-Italic.ttf';     Reg = 'Ubuntu Mono Italic (TrueType)' }
-        @{ File = 'UbuntuMono-BoldItalic.ttf'; Reg = 'Ubuntu Mono Bold Italic (TrueType)' }
-    )
-
-    # Drop the stale registry entry whose file no longer exists.
-    $existing = Get-ItemProperty $regKey -ErrorAction SilentlyContinue
-    if ($existing) {
-        foreach ($p in $existing.PSObject.Properties) {
-            if ($p.Name -match 'Ubuntu Mono' -and $p.Value -and -not (Test-Path $p.Value)) {
-                Remove-ItemProperty -Path $regKey -Name $p.Name -ErrorAction SilentlyContinue
-            }
-        }
+# Font install/activation now lives in the gsl skill so it stays in sync with
+# the codepoints gsl renders. setup-apps.ps1 only delegates.
+function Install-NerdFont {
+    Write-Host "`n=== [4/6] Nerd Font (MesloLGS NF) ===" -ForegroundColor Cyan
+    # setup-apps.ps1 sits at opt/Desktop/Apps/scripts/; the gsl script is at
+    # src/gsl/scripts/ — four levels up, then into src/gsl/scripts.
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
+    $fontScript = Join-Path $repoRoot 'src\gsl\scripts\install_nerd_font_windows.ps1'
+    if (-not (Test-Path $fontScript)) {
+        Write-Host "Nerd Font installer not found at $fontScript -- skipping." -ForegroundColor Yellow
+        return
     }
-
-    $installed = @()
-    foreach ($f in $faces) {
-        $dest = Join-Path $fontDir $f.File
-        if (-not (Test-Path $dest)) {
-            try {
-                Invoke-WebRequest -Uri "$base/$($f.File)" -OutFile $dest -UseBasicParsing
-                Write-Host "Downloaded $($f.File)" -ForegroundColor Green
-            } catch {
-                Write-Host "Failed to download $($f.File): $($_.Exception.Message)" -ForegroundColor Red
-                continue
-            }
-        } else {
-            Write-Host "$($f.File) already present -- skipping download." -ForegroundColor DarkGray
-        }
-        New-ItemProperty -Path $regKey -Name $f.Reg -Value $dest -PropertyType String -Force | Out-Null
-        $installed += $dest
-    }
-
-    # The registry value alone only activates the font at next logon. Register it
-    # with the running session via GDI and broadcast WM_FONTCHANGE so newly-
-    # launched apps (e.g. a fresh Windows Terminal) can find it immediately.
-    $sig = @'
-[DllImport("gdi32.dll", CharSet=CharSet.Unicode)]
-public static extern int AddFontResourceW(string lpFileName);
-[DllImport("user32.dll", CharSet=CharSet.Auto)]
-public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam, uint fuFlags, uint uTimeout, out IntPtr lpdwResult);
-'@
-    $api = Add-Type -MemberDefinition $sig -Name FontApi -Namespace Win32 -PassThru
-    foreach ($p in $installed) { [void]$api::AddFontResourceW($p) }
-    $res = [IntPtr]::Zero
-    [void]$api::SendMessageTimeout([IntPtr]0xffff, 0x001D, [IntPtr]::Zero, [IntPtr]::Zero, 2, 2000, [ref]$res)
-    Write-Host "Activated Ubuntu Mono for this session (restart Terminal to pick it up)." -ForegroundColor Green
+    $family = & $fontScript
+    if ($family) { $script:TerminalFont = $family }
 }
 
 # ---- Windows Terminal ------------------------------------------------------
@@ -423,7 +380,7 @@ if ($wslOk) {
 }
 
 # [4/6] Font
-Install-UbuntuMono
+Install-NerdFont
 
 # [5/6] Desktop apps (winget)
 Write-Host "`n=== [5/6] Desktop apps (winget) ===" -ForegroundColor Cyan

--- a/src/gsl/.gitignore
+++ b/src/gsl/.gitignore
@@ -1,0 +1,2 @@
+# Build artifacts — compiled binaries produced by go build / tests
+/glyphcheck

--- a/src/gsl/cmd/glyphcheck/main.go
+++ b/src/gsl/cmd/glyphcheck/main.go
@@ -1,0 +1,51 @@
+// Command glyphcheck verifies that a font file contains a glyph for every
+// Private-Use-Area codepoint the gsl powerline style emits. Exit 0 = all
+// covered; exit 1 = one or more missing (printed to stderr).
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/image/font/sfnt"
+)
+
+// codepoints are the exact runes from internal/style/builtins.go (powerlineStyle).
+var codepoints = []rune{
+	0xE0A0, 0xE0B0, 0xE0B1, 0xF017, 0xF055, 0xF071, 0xF07B, 0xF126,
+	0xF128, 0xF135, 0xF175, 0xF176, 0xF1C0, 0xF1E6, 0xF408, 0xF47E, 0xF48E,
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: glyphcheck <font.ttf>")
+		os.Exit(2)
+	}
+	data, err := os.ReadFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read %s: %v\n", os.Args[1], err)
+		os.Exit(2)
+	}
+	f, err := sfnt.Parse(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse %s: %v\n", os.Args[1], err)
+		os.Exit(2)
+	}
+	var b sfnt.Buffer
+	var missing []rune
+	for _, r := range codepoints {
+		g, err := f.GlyphIndex(&b, r)
+		if err != nil || g == 0 {
+			missing = append(missing, r)
+		}
+	}
+	if len(missing) > 0 {
+		for _, r := range missing {
+			fmt.Fprintf(os.Stderr, "MISSING U+%04X\n", r)
+		}
+		fmt.Fprintf(os.Stderr, "FAIL: %d/%d gsl codepoints missing in %s\n",
+			len(missing), len(codepoints), os.Args[1])
+		os.Exit(1)
+	}
+	fmt.Printf("OK: all %d gsl codepoints present in %s\n", len(codepoints), os.Args[1])
+}

--- a/src/gsl/go.mod
+++ b/src/gsl/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	golang.org/x/image v0.41.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
-	golang.org/x/text v0.3.8 // indirect
+	golang.org/x/text v0.37.0 // indirect
 )

--- a/src/gsl/go.mod
+++ b/src/gsl/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/image v0.41.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
@@ -28,7 +29,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/image v0.41.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 )

--- a/src/gsl/go.sum
+++ b/src/gsl/go.sum
@@ -52,12 +52,16 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/image v0.41.0 h1:8wS72eGJMJaBxK6okTzd4WaXumUlTVlb753MlsSvTCo=
+golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=

--- a/src/gsl/go.sum
+++ b/src/gsl/go.sum
@@ -58,8 +58,6 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
-golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
-golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/src/gsl/scripts/check-font-glyphs.sh
+++ b/src/gsl/scripts/check-font-glyphs.sh
@@ -11,8 +11,12 @@ MODULE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 case "$(uname -s)" in
   Darwin) font="$(/usr/bin/find "${HOME}/Library/Fonts" /Library/Fonts \
             -iname 'MesloLGS NF Regular.ttf' 2>/dev/null | head -1)" ;;
-  *)      font="$(fc-list 2>/dev/null | grep -i 'MesloLGS NF Regular' \
-            | head -1 | cut -d: -f1)" ;;
+  *)
+    command -v fc-list >/dev/null 2>&1 || { echo "FAIL: fc-list not found (install fontconfig)"; exit 1; }
+    font="$(fc-list 2>/dev/null | grep -i 'MesloLGS NF Regular' \
+            | head -1 | cut -d: -f1)"
+    font="${font%% }"
+    ;;
 esac
 if [ -z "${font:-}" ] || [ ! -f "$font" ]; then
   echo "FAIL: MesloLGS NF Regular not found. Run the OS font installer first."

--- a/src/gsl/scripts/check-font-glyphs.sh
+++ b/src/gsl/scripts/check-font-glyphs.sh
@@ -7,19 +7,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MODULE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Locate a MesloLGS NF Regular face per platform.
+# Locate a MesloLGS Nerd Font Regular face per platform.
 case "$(uname -s)" in
   Darwin) font="$(/usr/bin/find "${HOME}/Library/Fonts" /Library/Fonts \
-            -iname 'MesloLGS NF Regular.ttf' 2>/dev/null | head -1)" ;;
+            -iname 'MesloLGSNerdFont-Regular.ttf' 2>/dev/null | head -1)" ;;
   *)
     command -v fc-list >/dev/null 2>&1 || { echo "FAIL: fc-list not found (install fontconfig)"; exit 1; }
-    font="$(fc-list 2>/dev/null | grep -i 'MesloLGS NF Regular' \
-            | head -1 | cut -d: -f1)"
+    font="$(fc-list 2>/dev/null | grep -i 'MesloLGS Nerd Font' \
+            | grep -i 'Regular' | head -1 | cut -d: -f1)"
     font="${font%% }"
     ;;
 esac
 if [ -z "${font:-}" ] || [ ! -f "$font" ]; then
-  echo "FAIL: MesloLGS NF Regular not found. Run the OS font installer first."
+  echo "FAIL: MesloLGSNerdFont-Regular not found. Run the OS font installer first."
   exit 1
 fi
 

--- a/src/gsl/scripts/check-font-glyphs.sh
+++ b/src/gsl/scripts/check-font-glyphs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# check-font-glyphs.sh — prove the installed MesloLGS NF covers every codepoint
+# gsl's powerline style emits. Locates the font per-OS, builds + runs the
+# glyphcheck Go helper. Citable from CI.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Locate a MesloLGS NF Regular face per platform.
+case "$(uname -s)" in
+  Darwin) font="$(/usr/bin/find "${HOME}/Library/Fonts" /Library/Fonts \
+            -iname 'MesloLGS NF Regular.ttf' 2>/dev/null | head -1)" ;;
+  *)      font="$(fc-list 2>/dev/null | grep -i 'MesloLGS NF Regular' \
+            | head -1 | cut -d: -f1)" ;;
+esac
+if [ -z "${font:-}" ] || [ ! -f "$font" ]; then
+  echo "FAIL: MesloLGS NF Regular not found. Run the OS font installer first."
+  exit 1
+fi
+
+echo "== glyph-coverage check against: $font =="
+( cd "$MODULE_DIR" && go run ./cmd/glyphcheck "$font" )

--- a/src/gsl/scripts/check-font-glyphs_test.sh
+++ b/src/gsl/scripts/check-font-glyphs_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Self-test for check-font-glyphs.sh and the glyphcheck binary.
+# Network-free: skips coverage test if MesloLGS NF is not installed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+pass=0
+fail=0
+
+assert_exit() {
+  local want="$1"; shift
+  local desc="$1"; shift
+  "$@" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" = "$want" ]; then
+    echo "ok   - $desc (exit $got)"; pass=$((pass + 1))
+  else
+    echo "FAIL - $desc (want exit $want, got $got)"; fail=$((fail + 1))
+  fi
+}
+
+# Build glyphcheck once for this test run.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+( cd "$MODULE_DIR" && go build -o "$tmp/glyphcheck" ./cmd/glyphcheck ) >/dev/null 2>&1 \
+  || { echo "FAIL: could not build glyphcheck"; exit 1; }
+
+# 1) Wrong arg count → exit 2
+assert_exit 2 "no args → usage exit 2" "$tmp/glyphcheck"
+assert_exit 2 "too many args → usage exit 2" "$tmp/glyphcheck" a b
+
+# 2) Non-existent file → exit 2
+assert_exit 2 "missing file → exit 2" "$tmp/glyphcheck" "/nonexistent/font.ttf"
+
+# 3) A font without PUA glyphs → exit 1 (missing codepoints)
+# Find any system font that does NOT have MesloLGS NF in its name.
+stub_font=""
+for candidate in \
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf" \
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf" \
+    "/System/Library/Fonts/Helvetica.ttc" \
+    "/System/Library/Fonts/Arial.ttf"; do
+  if [ -f "$candidate" ]; then
+    stub_font="$candidate"
+    break
+  fi
+done
+if [ -n "$stub_font" ]; then
+  assert_exit 1 "non-PUA font reports missing codepoints (exit 1)" "$tmp/glyphcheck" "$stub_font"
+else
+  echo "skip - no system font found for negative test"
+fi
+
+# 4) If MesloLGS NF is installed, check coverage (exit 0).
+meslo_font=""
+case "$(uname -s)" in
+  Darwin) meslo_font="$(/usr/bin/find "${HOME}/Library/Fonts" /Library/Fonts \
+            -iname 'MesloLGS NF Regular.ttf' 2>/dev/null | head -1)" ;;
+  *)      raw="$(fc-list 2>/dev/null | grep -i 'MesloLGS NF Regular' | head -1 | cut -d: -f1)"; meslo_font="${raw%% }" ;;
+esac
+if [ -n "${meslo_font:-}" ] && [ -f "$meslo_font" ]; then
+  assert_exit 0 "MesloLGS NF Regular covers all 17 codepoints (exit 0)" "$tmp/glyphcheck" "$meslo_font"
+else
+  echo "skip - MesloLGS NF not installed; run install_nerd_font_<os>.sh first"
+fi
+
+echo "----"
+echo "check-font-glyphs_test: $pass passed, $fail failed"
+[ "$fail" = "0" ]

--- a/src/gsl/scripts/check-font-glyphs_test.sh
+++ b/src/gsl/scripts/check-font-glyphs_test.sh
@@ -52,17 +52,17 @@ else
   echo "skip - no system font found for negative test"
 fi
 
-# 4) If MesloLGS NF is installed, check coverage (exit 0).
+# 4) If MesloLGS Nerd Font is installed, check coverage (exit 0).
 meslo_font=""
 case "$(uname -s)" in
   Darwin) meslo_font="$(/usr/bin/find "${HOME}/Library/Fonts" /Library/Fonts \
-            -iname 'MesloLGS NF Regular.ttf' 2>/dev/null | head -1)" ;;
-  *)      raw="$(fc-list 2>/dev/null | grep -i 'MesloLGS NF Regular' | head -1 | cut -d: -f1)"; meslo_font="${raw%% }" ;;
+            -iname 'MesloLGSNerdFont-Regular.ttf' 2>/dev/null | head -1)" ;;
+  *)      raw="$(fc-list 2>/dev/null | grep -i 'MesloLGS Nerd Font' | grep -i 'Regular' | head -1 | cut -d: -f1)"; meslo_font="${raw%% }" ;;
 esac
 if [ -n "${meslo_font:-}" ] && [ -f "$meslo_font" ]; then
-  assert_exit 0 "MesloLGS NF Regular covers all 17 codepoints (exit 0)" "$tmp/glyphcheck" "$meslo_font"
+  assert_exit 0 "MesloLGS Nerd Font Regular covers all 17 codepoints (exit 0)" "$tmp/glyphcheck" "$meslo_font"
 else
-  echo "skip - MesloLGS NF not installed; run install_nerd_font_<os>.sh first"
+  echo "skip - MesloLGS Nerd Font not installed; run install_nerd_font_<os>.sh first"
 fi
 
 echo "----"

--- a/src/gsl/scripts/install_nerd_font_linux.sh
+++ b/src/gsl/scripts/install_nerd_font_linux.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# install_nerd_font_linux.sh — gsl-packaged Linux/WSL Nerd Font installer.
+# Installs the pinned MesloLGS NF faces into ~/.local/share/fonts and runs
+# fc-cache. In WSL, also invokes the Windows host installer so Windows Terminal
+# can render the font. Safe to re-run (idempotent).
+set -euo pipefail
+
+NERD_FONTS_VERSION="v3.4.0"
+NERD_FONTS_ASSET="Meslo.zip"
+NERD_FONTS_URL_BASE="https://github.com/ryanoasis/nerd-fonts/releases/download/${NERD_FONTS_VERSION}"
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+missing=0
+for tool in curl unzip fc-cache; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "ERROR: required tool '$tool' not found."
+    echo "  Install it: sudo apt-get install -y fontconfig unzip curl"
+    missing=1
+  fi
+done
+[ "$missing" -eq 0 ] || exit 1
+
+# ── Install Linux-side fonts ─────────────────────────────────────────────────
+font_dir="${HOME}/.local/share/fonts/MesloLGS"
+mkdir -p "$font_dir"
+# Capture fc-list output to avoid SIGPIPE breaking pipefail when grep exits early.
+_fc_list="$(fc-list 2>/dev/null)"
+if echo "$_fc_list" | grep -qi "MesloLGS Nerd Font"; then
+  echo "MesloLGS Nerd Font already installed; skipping download."
+else
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  echo "Downloading ${NERD_FONTS_ASSET} (${NERD_FONTS_VERSION})..."
+  curl -fsSL -o "${tmp}/${NERD_FONTS_ASSET}" "${NERD_FONTS_URL_BASE}/${NERD_FONTS_ASSET}"
+  # Extract the four MesloLGS NerdFont faces (Regular, Bold, Italic, BoldItalic).
+  # The v3.x archive uses no-space names: MesloLGSNerdFont-{style}.ttf
+  unzip -o -q "${tmp}/${NERD_FONTS_ASSET}" \
+    'MesloLGSNerdFont-Regular.ttf' \
+    'MesloLGSNerdFont-Bold.ttf' \
+    'MesloLGSNerdFont-Italic.ttf' \
+    'MesloLGSNerdFont-BoldItalic.ttf' \
+    -d "$font_dir"
+  fc-cache -f "$font_dir"
+  echo "Installed MesloLGS Nerd Font into ${font_dir} and refreshed font cache."
+fi
+
+echo "Verify: fc-list | grep -i MesloLGS"
+
+# ── WSL: also install on the Windows host for Windows Terminal ───────────────
+# Windows Terminal renders WSL sessions using the host font stack; the font
+# must exist on Windows even when gsl runs in the Linux layer.
+if grep -qi microsoft /proc/version 2>/dev/null; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  WIN_INSTALLER_LINUX="${SCRIPT_DIR}/install_nerd_font_windows.ps1"
+  if [ ! -f "$WIN_INSTALLER_LINUX" ]; then
+    echo "WARNING: Windows installer not found at ${WIN_INSTALLER_LINUX}; skipping Windows host install."
+  elif ! command -v powershell.exe >/dev/null 2>&1; then
+    echo "WARNING: powershell.exe not in PATH; skipping Windows host install."
+  else
+    WIN_INSTALLER_WIN="$(wslpath -w "$WIN_INSTALLER_LINUX")"
+    echo "Installing MesloLGS NF on Windows host via PowerShell..."
+    powershell.exe -ExecutionPolicy Bypass -NonInteractive -WindowStyle Hidden \
+      -File "$WIN_INSTALLER_WIN"
+    echo "Windows host font install complete. Restart Windows Terminal to apply."
+  fi
+fi

--- a/src/gsl/scripts/install_nerd_font_macos.sh
+++ b/src/gsl/scripts/install_nerd_font_macos.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# install_nerd_font_macos.sh — gsl-packaged macOS Nerd Font installer.
+# 1. Preflight base requirements (brew, python3, curl, unzip).
+# 2. Install the pinned MesloLGS NF faces into ~/Library/Fonts.
+# 3. Write an iTerm2 Dynamic Profile (loads live, survives quit) and
+#    best-effort Terminal.app config.
+# Safe to re-run (idempotent).
+set -euo pipefail
+
+NERD_FONTS_VERSION="v3.4.0"
+NERD_FONTS_ASSET="Meslo.zip"
+NERD_FONTS_URL_BASE="https://github.com/ryanoasis/nerd-fonts/releases/download/${NERD_FONTS_VERSION}"
+FONT_FAMILY="MesloLGS NF"
+FONT_SIZE=13
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+missing=0
+for tool in brew python3 curl unzip; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "ERROR: required tool '$tool' not found."
+    case "$tool" in
+      brew) echo "  Install Homebrew from https://brew.sh/ then re-run." ;;
+      *)    echo "  Install '$tool' (e.g. 'brew install $tool') then re-run." ;;
+    esac
+    missing=1
+  fi
+done
+[ "$missing" -eq 0 ] || exit 1
+
+# ── Install font faces from the pinned release ───────────────────────────────
+font_dir="${HOME}/Library/Fonts"
+mkdir -p "$font_dir"
+if system_profiler SPFontsDataType 2>/dev/null | grep -qi "MesloLGS NF"; then
+  echo "MesloLGS NF already present in system fonts; skipping download."
+else
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  echo "Downloading ${NERD_FONTS_ASSET} (${NERD_FONTS_VERSION})..."
+  curl -fsSL -o "${tmp}/${NERD_FONTS_ASSET}" "${NERD_FONTS_URL_BASE}/${NERD_FONTS_ASSET}"
+  unzip -o -q "${tmp}/${NERD_FONTS_ASSET}" 'MesloLGS NF *.ttf' -d "$tmp"
+  cp "${tmp}"/MesloLGS\ NF\ *.ttf "$font_dir"/
+  echo "Installed MesloLGS NF faces into ${font_dir}."
+fi
+
+# ── iTerm2 Dynamic Profile (loads live; NOT overwritten on quit) ─────────────
+# Replaces the old com.googlecode.iterm2.plist patching that lost writes when
+# iTerm2 was running. DynamicProfiles are read live by a running iTerm2.
+dyn_dir="${HOME}/Library/Application Support/iTerm2/DynamicProfiles"
+mkdir -p "$dyn_dir"
+cat > "${dyn_dir}/gsl-nerd-font.json" <<JSON
+{
+  "Profiles": [
+    {
+      "Name": "gsl Nerd Font",
+      "Guid": "gsl-nerd-font",
+      "Normal Font": "${FONT_FAMILY} ${FONT_SIZE}",
+      "Non Ascii Font": "${FONT_FAMILY} ${FONT_SIZE}",
+      "Use Non-ASCII Font": true
+    }
+  ]
+}
+JSON
+echo "Wrote iTerm2 Dynamic Profile: ${dyn_dir}/gsl-nerd-font.json"
+echo "  In iTerm2: Preferences → Profiles → select 'gsl Nerd Font' (or set it as Default)."
+
+# ── Terminal.app (best effort; weaker PUA fallback than iTerm2) ──────────────
+# Terminal.app renders fewer Nerd Font PUA glyphs than iTerm2 (no broad PUA
+# fallback). iTerm2 is the recommended terminal for full gsl rendering.
+osascript <<OSASCRIPT 2>/dev/null && echo "Terminal.app default font set." || \
+  echo "NOTE: Terminal.app font update skipped (Terminal not scriptable here)."
+tell application "Terminal"
+  set font name of settings set "Basic" to "${FONT_FAMILY}"
+  set font size of settings set "Basic" to ${FONT_SIZE}
+end tell
+OSASCRIPT
+
+echo ""
+echo "Done. Restart iTerm2 (or open a new window/tab) to apply the new font."
+echo "Verify: system_profiler SPFontsDataType | grep -i meslo"

--- a/src/gsl/scripts/install_nerd_font_macos.sh
+++ b/src/gsl/scripts/install_nerd_font_macos.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 NERD_FONTS_VERSION="v3.4.0"
 NERD_FONTS_ASSET="Meslo.zip"
 NERD_FONTS_URL_BASE="https://github.com/ryanoasis/nerd-fonts/releases/download/${NERD_FONTS_VERSION}"
-FONT_FAMILY="MesloLGS NF"
+FONT_FAMILY="MesloLGS Nerd Font"
 FONT_SIZE=13
 
 # ── Preflight ────────────────────────────────────────────────────────────────
@@ -30,16 +30,16 @@ done
 # ── Install font faces from the pinned release ───────────────────────────────
 font_dir="${HOME}/Library/Fonts"
 mkdir -p "$font_dir"
-if system_profiler SPFontsDataType 2>/dev/null | grep -qi "MesloLGS NF"; then
-  echo "MesloLGS NF already present in system fonts; skipping download."
+if system_profiler SPFontsDataType 2>/dev/null | grep -qi "MesloLGS Nerd Font"; then
+  echo "MesloLGS Nerd Font already present in system fonts; skipping download."
 else
   tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
   echo "Downloading ${NERD_FONTS_ASSET} (${NERD_FONTS_VERSION})..."
   curl -fsSL -o "${tmp}/${NERD_FONTS_ASSET}" "${NERD_FONTS_URL_BASE}/${NERD_FONTS_ASSET}"
-  unzip -o -q "${tmp}/${NERD_FONTS_ASSET}" 'MesloLGS NF *.ttf' -d "$tmp"
-  cp "${tmp}"/MesloLGS\ NF\ *.ttf "$font_dir"/
-  echo "Installed MesloLGS NF faces into ${font_dir}."
+  unzip -o -q "${tmp}/${NERD_FONTS_ASSET}" 'MesloLGSNerdFont-*.ttf' -d "$tmp"
+  cp "${tmp}"/MesloLGSNerdFont-*.ttf "$font_dir"/
+  echo "Installed MesloLGS Nerd Font faces into ${font_dir}."
 fi
 
 # ── iTerm2 Dynamic Profile (loads live; NOT overwritten on quit) ─────────────

--- a/src/gsl/scripts/install_nerd_font_windows.ps1
+++ b/src/gsl/scripts/install_nerd_font_windows.ps1
@@ -44,9 +44,7 @@ $faces = @(
 )
 
 # Drop stale Ubuntu Mono registry entries whose files no longer exist (migration).
-$ErrorActionPreference = 'SilentlyContinue'
-$existing = Get-ItemProperty $regKey
-$ErrorActionPreference = 'Stop'
+$existing = Get-ItemProperty $regKey -ErrorAction SilentlyContinue
 if ($existing) {
     foreach ($p in $existing.PSObject.Properties) {
         if ($p.Name -match 'Ubuntu Mono' -and $p.Value -and -not (Test-Path $p.Value)) {
@@ -89,7 +87,11 @@ public static extern int AddFontResourceW(string lpFileName);
 [DllImport("user32.dll", CharSet=CharSet.Auto)]
 public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam, uint fuFlags, uint uTimeout, out IntPtr lpdwResult);
 '@
-$api = Add-Type -MemberDefinition $sig -Name FontApi -Namespace Win32 -PassThru
+if (-not ([System.Management.Automation.PSTypeName]'Win32.FontApi').Type) {
+    $api = Add-Type -MemberDefinition $sig -Name FontApi -Namespace Win32 -PassThru
+} else {
+    $api = [Win32.FontApi]
+}
 foreach ($p in $installed) { [void]$api::AddFontResourceW($p) }
 $res = [IntPtr]::Zero
 [void]$api::SendMessageTimeout([IntPtr]0xffff, 0x001D, [IntPtr]::Zero, [IntPtr]::Zero, 2, 2000, [ref]$res)

--- a/src/gsl/scripts/install_nerd_font_windows.ps1
+++ b/src/gsl/scripts/install_nerd_font_windows.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    gsl-packaged Windows Nerd Font installer. Installs the pinned MesloLGS NF
+    faces from the ryanoasis/nerd-fonts release and activates them for the
+    running session via GDI. Idempotent.
+.OUTPUTS
+    Returns the installed font family name ('MesloLGS NF') so callers (e.g.
+    setup-apps.ps1) can use it for terminal profiles.
+#>
+[CmdletBinding()]
+param()
+
+# Suppress interactive prompts and download progress bars so this script is
+# safe to invoke unattended (e.g. from a WSL bash script via powershell.exe).
+$ProgressPreference   = 'SilentlyContinue'
+$ConfirmPreference    = 'None'
+$ErrorActionPreference = 'Stop'
+
+$NerdFontsVersion = 'v3.4.0'
+$NerdFontsAsset   = 'Meslo.zip'
+$NerdFontsUrl     = "https://github.com/ryanoasis/nerd-fonts/releases/download/$NerdFontsVersion/$NerdFontsAsset"
+$FontFamily       = 'MesloLGS NF'
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+$fontDir = "$env:LOCALAPPDATA\Microsoft\Windows\Fonts"
+$regKey  = 'HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts'
+try { New-Item -ItemType Directory -Force -Path $fontDir -ErrorAction Stop | Out-Null }
+catch {
+    Write-Host "ERROR: cannot write to user font dir '$fontDir'; run from a normal (non-elevated) PowerShell." -ForegroundColor Red
+    return $null
+}
+if (-not (Get-Command Invoke-WebRequest -ErrorAction SilentlyContinue)) {
+    Write-Host "ERROR: Invoke-WebRequest unavailable; PowerShell 5.1+ required." -ForegroundColor Red
+    return $null
+}
+
+Write-Host "`n=== gsl Nerd Font ($FontFamily, nerd-fonts $NerdFontsVersion) ===" -ForegroundColor Cyan
+
+$faces = @(
+    @{ File = 'MesloLGS NF Regular.ttf';     Reg = 'MesloLGS NF (TrueType)' }
+    @{ File = 'MesloLGS NF Bold.ttf';        Reg = 'MesloLGS NF Bold (TrueType)' }
+    @{ File = 'MesloLGS NF Italic.ttf';      Reg = 'MesloLGS NF Italic (TrueType)' }
+    @{ File = 'MesloLGS NF Bold Italic.ttf'; Reg = 'MesloLGS NF Bold Italic (TrueType)' }
+)
+
+# Drop stale Ubuntu Mono registry entries whose files no longer exist (migration).
+$ErrorActionPreference = 'SilentlyContinue'
+$existing = Get-ItemProperty $regKey
+$ErrorActionPreference = 'Stop'
+if ($existing) {
+    foreach ($p in $existing.PSObject.Properties) {
+        if ($p.Name -match 'Ubuntu Mono' -and $p.Value -and -not (Test-Path $p.Value)) {
+            Remove-ItemProperty -Path $regKey -Name $p.Name -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# Download + extract once if any face is missing.
+$needDownload = $faces | Where-Object { -not (Test-Path (Join-Path $fontDir $_.File)) }
+if ($needDownload) {
+    $tmp = Join-Path $env:TEMP ("meslo-" + [Guid]::NewGuid())
+    New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+    $zip = Join-Path $tmp $NerdFontsAsset
+    Write-Host "Downloading $NerdFontsAsset..." -ForegroundColor Cyan
+    Invoke-WebRequest -Uri $NerdFontsUrl -OutFile $zip -UseBasicParsing
+    # Remove Zone.Identifier ADS so Expand-Archive does not trigger SmartScreen.
+    Unblock-File -Path $zip -ErrorAction SilentlyContinue
+    Expand-Archive -Path $zip -DestinationPath $tmp -Force
+    foreach ($f in $faces) {
+        $src = Get-ChildItem -Path $tmp -Filter $f.File -Recurse | Select-Object -First 1
+        if ($src) { Copy-Item $src.FullName (Join-Path $fontDir $f.File) -Force }
+    }
+    Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$installed = @()
+foreach ($f in $faces) {
+    $dest = Join-Path $fontDir $f.File
+    if (Test-Path $dest) {
+        New-ItemProperty -Path $regKey -Name $f.Reg -Value $dest -PropertyType String -Force | Out-Null
+        $installed += $dest
+    }
+}
+
+# Activate for the running session via GDI + broadcast WM_FONTCHANGE.
+$sig = @'
+[DllImport("gdi32.dll", CharSet=CharSet.Unicode)]
+public static extern int AddFontResourceW(string lpFileName);
+[DllImport("user32.dll", CharSet=CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam, uint fuFlags, uint uTimeout, out IntPtr lpdwResult);
+'@
+$api = Add-Type -MemberDefinition $sig -Name FontApi -Namespace Win32 -PassThru
+foreach ($p in $installed) { [void]$api::AddFontResourceW($p) }
+$res = [IntPtr]::Zero
+[void]$api::SendMessageTimeout([IntPtr]0xffff, 0x001D, [IntPtr]::Zero, [IntPtr]::Zero, 2, 2000, [ref]$res)
+Write-Host "Activated $FontFamily for this session (restart Terminal to pick it up)." -ForegroundColor Green
+return $FontFamily

--- a/src/gsl/scripts/install_nerd_font_windows.ps1
+++ b/src/gsl/scripts/install_nerd_font_windows.ps1
@@ -1,10 +1,10 @@
 <#
 .SYNOPSIS
-    gsl-packaged Windows Nerd Font installer. Installs the pinned MesloLGS NF
+    gsl-packaged Windows Nerd Font installer. Installs the pinned MesloLGS Nerd Font
     faces from the ryanoasis/nerd-fonts release and activates them for the
     running session via GDI. Idempotent.
 .OUTPUTS
-    Returns the installed font family name ('MesloLGS NF') so callers (e.g.
+    Returns the installed font family name ('MesloLGS Nerd Font') so callers (e.g.
     setup-apps.ps1) can use it for terminal profiles.
 #>
 [CmdletBinding()]
@@ -19,7 +19,7 @@ $ErrorActionPreference = 'Stop'
 $NerdFontsVersion = 'v3.4.0'
 $NerdFontsAsset   = 'Meslo.zip'
 $NerdFontsUrl     = "https://github.com/ryanoasis/nerd-fonts/releases/download/$NerdFontsVersion/$NerdFontsAsset"
-$FontFamily       = 'MesloLGS NF'
+$FontFamily       = 'MesloLGS Nerd Font'
 
 # ── Preflight ────────────────────────────────────────────────────────────────
 $fontDir = "$env:LOCALAPPDATA\Microsoft\Windows\Fonts"
@@ -37,10 +37,10 @@ if (-not (Get-Command Invoke-WebRequest -ErrorAction SilentlyContinue)) {
 Write-Host "`n=== gsl Nerd Font ($FontFamily, nerd-fonts $NerdFontsVersion) ===" -ForegroundColor Cyan
 
 $faces = @(
-    @{ File = 'MesloLGS NF Regular.ttf';     Reg = 'MesloLGS NF (TrueType)' }
-    @{ File = 'MesloLGS NF Bold.ttf';        Reg = 'MesloLGS NF Bold (TrueType)' }
-    @{ File = 'MesloLGS NF Italic.ttf';      Reg = 'MesloLGS NF Italic (TrueType)' }
-    @{ File = 'MesloLGS NF Bold Italic.ttf'; Reg = 'MesloLGS NF Bold Italic (TrueType)' }
+    @{ File = 'MesloLGSNerdFont-Regular.ttf';    Reg = 'MesloLGS Nerd Font (TrueType)' }
+    @{ File = 'MesloLGSNerdFont-Bold.ttf';       Reg = 'MesloLGS Nerd Font Bold (TrueType)' }
+    @{ File = 'MesloLGSNerdFont-Italic.ttf';     Reg = 'MesloLGS Nerd Font Italic (TrueType)' }
+    @{ File = 'MesloLGSNerdFont-BoldItalic.ttf'; Reg = 'MesloLGS Nerd Font Bold Italic (TrueType)' }
 )
 
 # Drop stale Ubuntu Mono registry entries whose files no longer exist (migration).

--- a/src/gsl/skill/SKILL.md
+++ b/src/gsl/skill/SKILL.md
@@ -92,6 +92,26 @@ The skill directory is linked by `opt/scripts/system/sync-skills.sh` into
 
 Run `sync-skills --build` to rebuild the binary and refresh all skill links.
 
+**Font setup (Nerd Font for powerline style)**
+
+`install.sh` runs the gsl-packaged font installers AFTER the gsl build so the
+`powerline` style renders glyphs correctly. Pinned release: `NERD_FONTS_VERSION=v3.4.0`
+(ryanoasis/nerd-fonts, `Meslo.zip` — family: `MesloLGS Nerd Font`).
+
+| OS | Installer | Notes |
+|----|-----------|-------|
+| macOS | `src/gsl/scripts/install_nerd_font_macos.sh` | Writes an iTerm2 Dynamic Profile (`gsl-nerd-font`) |
+| Linux/WSL | `src/gsl/scripts/install_nerd_font_linux.sh` | Also invokes Windows installer from WSL for Windows Terminal |
+| Windows | `src/gsl/scripts/install_nerd_font_windows.ps1` | Called by `setup-apps.ps1 → Install-NerdFont`; touchless (`-NonInteractive -ExecutionPolicy Bypass`) |
+
+After install, `src/gsl/scripts/check-font-glyphs.sh` proves the installed font
+covers all 17 PUA codepoints gsl emits. Run it manually to verify:
+
+```bash
+bash src/gsl/scripts/check-font-glyphs.sh
+# expect: OK: all 17 gsl codepoints present in .../MesloLGSNerdFont-Regular.ttf
+```
+
 ## Gemini command
 
 `/gsl-status` — defined in `ai/gemini/commands/gsl-status.toml`. Renders the


### PR DESCRIPTION
Implement Nerd Font auto-install scripts (macOS/Linux/WSL/Windows) with touchless PowerShell execution

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **gsl-nerdfont**.

- **#49 — edward-raigosa/impl (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
