### PR TITLE
fix(sync-plugins): stop install.sh hangs during plugin/extension sync

### DIFF
--- a/opt/scripts/system/sync-plugins.sh
+++ b/opt/scripts/system/sync-plugins.sh
@@ -28,6 +28,14 @@ esac
 # Resolve a timeout binary (GNU 'timeout', or 'gtimeout' from coreutils on macOS).
 # Empty when neither exists — calls then run unwrapped but still stdin-guarded.
 TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
+# Resolve setsid (util-linux). The claude/gemini plugin subcommands open
+# /dev/tty directly and render an interactive TUI when a controlling terminal is
+# present — bypassing the </dev/null stdin guard below and wedging an unattended
+# `./install.sh` (the CLI ends up job-control-stopped on a SIGTTOU/SIGTTIN). Run
+# them under `setsid` so they get a new session with NO controlling terminal,
+# can't open /dev/tty, and fall back to non-interactive mode. Empty on macOS
+# (no setsid); the per-call </dev/null + timeout guards still apply there.
+SETSID_BIN="$(command -v setsid || true)"
 # Per-call ceiling so a hung network fetch or an unexpected interactive prompt
 # can't wedge install.sh indefinitely (the orphaned-process failure mode this
 # guards against). Override with SYNC_PLUGINS_TIMEOUT for slow links.
@@ -37,6 +45,17 @@ CMD_TIMEOUT="${SYNC_PLUGINS_TIMEOUT:-300}"
 # the guard. `-k KILL_GRACE` escalates to SIGKILL KILL_GRACE seconds after the
 # initial signal, guaranteeing the call actually terminates.
 KILL_GRACE="${SYNC_PLUGINS_KILL_GRACE:-15}"
+
+# Guard prefix applied to every claude/gemini plugin invocation:
+#   setsid -w  → new session, no controlling terminal (see SETSID_BIN above);
+#                -w makes setsid wait and return the child's real exit code so
+#                the timeout rc detection below still works.
+#   timeout -k → bound runtime and SIGKILL a SIGTERM-ignoring CLI after the grace.
+# Either tool may be absent (minimal containers / macOS lacks setsid); the prefix
+# omits whatever is missing. </dev/null at each call site stays as the stdin guard.
+GUARD=()
+[ -n "$SETSID_BIN" ] && GUARD+=("$SETSID_BIN" -w)
+[ -n "$TIMEOUT_BIN" ] && GUARD+=("$TIMEOUT_BIN" -k "$KILL_GRACE" "$CMD_TIMEOUT")
 
 # Run a plugin command non-interactively. stdin comes from /dev/null so any
 # unexpected prompt (e.g. a credential or overwrite question) gets EOF and fails
@@ -49,11 +68,7 @@ run() {
     fi
     echo "+ $*"
     local rc=0
-    if [ -n "$TIMEOUT_BIN" ]; then
-        "$TIMEOUT_BIN" -k "$KILL_GRACE" "$CMD_TIMEOUT" "$@" </dev/null || rc=$?
-    else
-        "$@" </dev/null || rc=$?
-    fi
+    "${GUARD[@]+"${GUARD[@]}"}" "$@" </dev/null || rc=$?
     # 124 = timed out (SIGTERM); 137 = had to SIGKILL after -k grace (the gemini
     # CLI ignores SIGTERM, so this is the common timeout outcome, not a crash).
     if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
@@ -84,11 +99,7 @@ enable_claude_plugin() {
     fi
     echo "+ claude plugin enable $plugin"
     local rc=0
-    if [ -n "$TIMEOUT_BIN" ]; then
-        out="$("$TIMEOUT_BIN" -k "$KILL_GRACE" "$CMD_TIMEOUT" claude plugin enable "$plugin" </dev/null 2>&1)" || rc=$?
-    else
-        out="$(claude plugin enable "$plugin" </dev/null 2>&1)" || rc=$?
-    fi
+    out="$("${GUARD[@]+"${GUARD[@]}"}" claude plugin enable "$plugin" </dev/null 2>&1)" || rc=$?
     if [ "$rc" -eq 0 ]; then
         [ -n "$out" ] && echo "$out"
     elif printf '%s' "$out" | grep -qi "already enabled"; then
@@ -135,11 +146,7 @@ gemini_installed_names() {
 install_gemini_extension() {
     local source="$1" out rc=0
     echo "+ gemini extensions install $source --consent --skip-settings"
-    if [ -n "$TIMEOUT_BIN" ]; then
-        out="$("$TIMEOUT_BIN" -k "$KILL_GRACE" "$CMD_TIMEOUT" gemini extensions install "$source" --consent --skip-settings </dev/null 2>&1)" || rc=$?
-    else
-        out="$(gemini extensions install "$source" --consent --skip-settings </dev/null 2>&1)" || rc=$?
-    fi
+    out="$("${GUARD[@]+"${GUARD[@]}"}" gemini extensions install "$source" --consent --skip-settings </dev/null 2>&1)" || rc=$?
     if [ "$rc" -eq 0 ]; then
         [ -n "$out" ] && echo "$out"
     elif [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then

--- a/opt/scripts/system/sync-plugins.sh
+++ b/opt/scripts/system/sync-plugins.sh
@@ -25,12 +25,41 @@ case "${1:-}" in
     *) echo "sync-plugins: unknown argument '$1'" >&2; exit 2 ;;
 esac
 
+# Resolve a timeout binary (GNU 'timeout', or 'gtimeout' from coreutils on macOS).
+# Empty when neither exists — calls then run unwrapped but still stdin-guarded.
+TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
+# Per-call ceiling so a hung network fetch or an unexpected interactive prompt
+# can't wedge install.sh indefinitely (the orphaned-process failure mode this
+# guards against). Override with SYNC_PLUGINS_TIMEOUT for slow links.
+CMD_TIMEOUT="${SYNC_PLUGINS_TIMEOUT:-300}"
+# The gemini CLI (a Node process) ignores SIGTERM, so a plain `timeout N` would
+# send SIGTERM and then wait forever for a process that never dies — defeating
+# the guard. `-k KILL_GRACE` escalates to SIGKILL KILL_GRACE seconds after the
+# initial signal, guaranteeing the call actually terminates.
+KILL_GRACE="${SYNC_PLUGINS_KILL_GRACE:-15}"
+
+# Run a plugin command non-interactively. stdin comes from /dev/null so any
+# unexpected prompt (e.g. a credential or overwrite question) gets EOF and fails
+# fast instead of blocking forever; when a timeout binary is available the call
+# also runs under CMD_TIMEOUT. All failures are non-fatal (ensure-only).
 run() {
     if [ "$DRY_RUN" = "1" ]; then
         echo "DRY-RUN: $*"
+        return 0
+    fi
+    echo "+ $*"
+    local rc=0
+    if [ -n "$TIMEOUT_BIN" ]; then
+        "$TIMEOUT_BIN" -k "$KILL_GRACE" "$CMD_TIMEOUT" "$@" </dev/null || rc=$?
     else
-        echo "+ $*"
-        "$@" || echo "sync-plugins: WARNING — '$*' failed; continuing." >&2
+        "$@" </dev/null || rc=$?
+    fi
+    # 124 = timed out (SIGTERM); 137 = had to SIGKILL after -k grace (the gemini
+    # CLI ignores SIGTERM, so this is the common timeout outcome, not a crash).
+    if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+        echo "sync-plugins: WARNING — '$*' timed out after ${CMD_TIMEOUT}s; continuing." >&2
+    elif [ "$rc" -ne 0 ]; then
+        echo "sync-plugins: WARNING — '$*' failed (rc=$rc); continuing." >&2
     fi
 }
 
@@ -54,7 +83,13 @@ enable_claude_plugin() {
         return 0
     fi
     echo "+ claude plugin enable $plugin"
-    if out="$(claude plugin enable "$plugin" 2>&1)"; then
+    local rc=0
+    if [ -n "$TIMEOUT_BIN" ]; then
+        out="$("$TIMEOUT_BIN" -k "$KILL_GRACE" "$CMD_TIMEOUT" claude plugin enable "$plugin" </dev/null 2>&1)" || rc=$?
+    else
+        out="$(claude plugin enable "$plugin" </dev/null 2>&1)" || rc=$?
+    fi
+    if [ "$rc" -eq 0 ]; then
         [ -n "$out" ] && echo "$out"
     elif printf '%s' "$out" | grep -qi "already enabled"; then
         echo "  ($plugin already enabled)"
@@ -82,15 +117,69 @@ sync_claude() {
     done < <(yq '.plugins[] | select(.enabled == true) | select(.claude.plugin != null) | .claude.plugin' "$MANIFEST")
 }
 
+# Names of currently-installed Gemini extensions, one per line. The list output
+# is "<glyph> <name> (<version>)" for each extension followed by indented detail
+# lines, so the name is field 2 of every non-indented row. `gemini extensions
+# list` prints to stderr, so capture 2>&1. Empty on any error.
+gemini_installed_names() {
+    gemini extensions list 2>&1 | awk '!/^[[:space:]]/ && NF>=2 {print $2}'
+}
+
+# Install one Gemini extension, stdin/timeout-guarded. `gemini extensions install`
+# is not idempotent — it exits non-zero with "already installed" when the
+# extension is present — so treat that as a quiet skip (mirrors how
+# enable_claude_plugin treats "already enabled"). This is the safety net for
+# sources whose extension name differs from the repo basename (e.g. the
+# gemini-agent-creator repo installs as "agent-creator"), which the name-based
+# pre-skip in sync_gemini cannot match.
+install_gemini_extension() {
+    local source="$1" out rc=0
+    echo "+ gemini extensions install $source --consent --skip-settings"
+    if [ -n "$TIMEOUT_BIN" ]; then
+        out="$("$TIMEOUT_BIN" -k "$KILL_GRACE" "$CMD_TIMEOUT" gemini extensions install "$source" --consent --skip-settings </dev/null 2>&1)" || rc=$?
+    else
+        out="$(gemini extensions install "$source" --consent --skip-settings </dev/null 2>&1)" || rc=$?
+    fi
+    if [ "$rc" -eq 0 ]; then
+        [ -n "$out" ] && echo "$out"
+    elif [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+        echo "sync-plugins: WARNING — gemini install $source timed out after ${CMD_TIMEOUT}s; continuing." >&2
+    elif printf '%s' "$out" | grep -qi "already installed"; then
+        echo "  ($source already installed)"
+    else
+        printf '%s\n' "$out" >&2
+        echo "sync-plugins: WARNING — gemini install $source failed (rc=$rc); continuing." >&2
+    fi
+}
+
 sync_gemini() {
     if [ "$DRY_RUN" = "0" ] && ! command -v gemini >/dev/null 2>&1; then
         echo "sync-plugins: 'gemini' CLI not on PATH; skipping Gemini extensions."
         return 0
     fi
+    # Snapshot installed extensions so re-runs skip them instead of erroring with
+    # "already installed, please uninstall first" (which, unguarded, could hang).
+    # `gemini extensions install` names an extension after its repo basename, so
+    # match on that. The set also grows as we install, so an in-manifest duplicate
+    # (the code-review source is shared by two plugins) is only installed once.
+    local seen=""
+    [ "$DRY_RUN" = "0" ] && seen="$(gemini_installed_names)"
     local any=0
     while IFS= read -r source; do
         { [ -z "$source" ] || [ "$source" = "null" ]; } && continue
         any=1
+        if [ "$DRY_RUN" = "0" ]; then
+            local name="${source##*/}"
+            if printf '%s\n' "$seen" | grep -qxF -- "$name"; then
+                echo "  ($name already installed)"
+                continue
+            fi
+            seen="${seen}
+${name}"
+            install_gemini_extension "$source"
+            continue
+        fi
+        # Dry-run path: keep printing the planned action via run().
         run gemini extensions install "$source" --consent --skip-settings
     done < <(yq '.plugins[] | select(.enabled == true) | select(.gemini.source != null) | .gemini.source' "$MANIFEST")
     [ "$any" = "0" ] && echo "sync-plugins: no Gemini extension sources in manifest (nothing to do)."

--- a/opt/scripts/system/sync-plugins_test.sh
+++ b/opt/scripts/system/sync-plugins_test.sh
@@ -17,6 +17,15 @@ assert_contains() {
     fi
 }
 
+assert_not_contains() {
+    local haystack="$1" needle="$2" desc="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "FAIL: $desc (unexpectedly present: $needle)"; FAIL=$((FAIL+1))
+    else
+        echo "PASS: $desc"; PASS=$((PASS+1))
+    fi
+}
+
 assert_eq() {
     local got="$1" want="$2" desc="$3"
     if [ "$got" = "$want" ]; then
@@ -37,6 +46,73 @@ assert_eq "$INSTALL_COUNT" "12" "plans install for all 12 plugins"
 
 ENABLE_COUNT="$(printf '%s' "$OUT" | grep -c 'DRY-RUN: claude plugin enable ')"
 assert_eq "$ENABLE_COUNT" "12" "plans enable for all 12 plugins"
+
+GEMINI_COUNT="$(printf '%s' "$OUT" | grep -c 'DRY-RUN: gemini extensions install ')"
+assert_eq "$GEMINI_COUNT" "7" "plans install for all 7 gemini extension sources"
+
+# --- Behavioral: idempotent skip + no-hang (hermetic, fake CLIs on PATH) -------
+# Real `yq` still resolves (the fakes only shadow claude/gemini), so the manifest
+# is parsed for real. The fake gemini reports superpowers as already installed and
+# reads stdin on install — if install.sh ever attached an interactive stdin the
+# read would block and this test would hang, so completing here is itself the
+# hang-guard assertion.
+FAKE_BIN="$(mktemp -d)"
+cat > "$FAKE_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$FAKE_BIN/gemini" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1 $2" = "extensions list" ]; then
+    echo "✓ superpowers (5.1.0)" >&2   # real gemini prints the list to stderr
+elif [ "$1 $2" = "extensions install" ]; then
+    IFS= read -r _ </dev/stdin 2>/dev/null || true   # must hit EOF, never block
+    case "$3" in
+        # Simulate a source whose extension name differs from its repo basename
+        # and is already installed: the name pre-skip cannot catch it, so the
+        # install path must treat "already installed" as a quiet skip.
+        *gemini-agent-creator*)
+            echo 'Extension "agent-creator" is already installed. Please uninstall it first.' >&2
+            exit 1 ;;
+        # FAKE_HANG=1 makes this source mimic the real gemini CLI: ignore SIGTERM
+        # and refuse to die, so only the timeout's -k SIGKILL escalation can stop
+        # it. Off by default so the idempotency run (OUT2) stays fast.
+        *mcp-toolbox*)
+            if [ "${FAKE_HANG:-0}" = "1" ]; then
+                trap '' TERM
+                for _ in $(seq 1 120); do sleep 0.2; done
+            fi
+            echo "INSTALL_CALLED $3" ;;
+        *) echo "INSTALL_CALLED $3" ;;
+    esac
+fi
+EOF
+chmod +x "$FAKE_BIN/claude" "$FAKE_BIN/gemini"
+OUT2="$(PATH="$FAKE_BIN:$PATH" bash "$SYNC" 2>&1)"
+
+assert_contains "$OUT2" "(superpowers already installed)" "skips an already-installed gemini extension"
+CR_INSTALLS="$(printf '%s' "$OUT2" | grep -c 'INSTALL_CALLED https://github.com/gemini-cli-extensions/code-review')"
+assert_eq "$CR_INSTALLS" "1" "installs the duplicated code-review source only once"
+SP_INSTALLS="$(printf '%s' "$OUT2" | grep -c 'INSTALL_CALLED https://github.com/obra/superpowers')"
+assert_eq "$SP_INSTALLS" "0" "does not reinstall the already-installed superpowers source"
+
+# Name-mismatch source (repo basename != extension name) that is already
+# installed: must be reported as a quiet skip, never a WARNING.
+assert_contains "$OUT2" "(https://github.com/jduncan-rva/gemini-agent-creator already installed)" "treats name-mismatched 'already installed' as a quiet skip"
+assert_not_contains "$OUT2" "WARNING — gemini install https://github.com/jduncan-rva/gemini-agent-creator" "does not warn on a name-mismatched already-installed extension"
+
+# --- Behavioral: timeout actually kills a SIGTERM-ignoring install (-k) --------
+# The gemini CLI ignores SIGTERM, so a plain `timeout N` would wait forever. With
+# FAKE_HANG=1 the mcp-toolbox fake ignores SIGTERM too. A short timeout (2s) + kill
+# grace (2s) must SIGKILL it. The outer `timeout 40` is the test's own backstop:
+# if -k were missing the inner run would hang and this would exit 124, failing the
+# completion assertion loudly instead of wedging the whole suite.
+OUT3="$(FAKE_HANG=1 SYNC_PLUGINS_TIMEOUT=2 SYNC_PLUGINS_KILL_GRACE=2 \
+        PATH="$FAKE_BIN:$PATH" timeout 40 bash "$SYNC" 2>&1)"
+T3RC=$?
+rm -rf "$FAKE_BIN"
+assert_eq "$T3RC" "0" "sync completes (no hang) when an install ignores SIGTERM"
+assert_contains "$OUT3" "timed out after 2s" "escalates to SIGKILL on a SIGTERM-ignoring install"
 
 echo "----"
 echo "PASS=$PASS FAIL=$FAIL"

--- a/opt/scripts/system/sync-plugins_test.sh
+++ b/opt/scripts/system/sync-plugins_test.sh
@@ -114,6 +114,69 @@ rm -rf "$FAKE_BIN"
 assert_eq "$T3RC" "0" "sync completes (no hang) when an install ignores SIGTERM"
 assert_contains "$OUT3" "timed out after 2s" "escalates to SIGKILL on a SIGTERM-ignoring install"
 
+# --- Behavioral: plugin calls run under setsid (no controlling terminal) -------
+# The real claude/gemini plugin subcommands open /dev/tty directly and render an
+# interactive TUI when a controlling terminal is present — bypassing the
+# </dev/null stdin guard and wedging the unattended installer (observed as a
+# job-control-stopped `claude`). sync-plugins must run them under `setsid` so the
+# CLIs have no controlling terminal and fall back to non-interactive mode. Verify
+# the wiring with a `setsid` shim that records its use (and shadows any real one,
+# so this also asserts the intent on macOS where setsid is absent).
+GUARD_BIN="$(mktemp -d)"
+cat > "$GUARD_BIN/setsid" <<'EOF'
+#!/usr/bin/env bash
+echo "SETSID_USED" >&2
+[ "$1" = "-w" ] && shift   # sync-plugins is expected to pass -w; then exec the rest
+exec "$@"
+EOF
+cat > "$GUARD_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$GUARD_BIN/gemini" <<'EOF'
+#!/usr/bin/env bash
+[ "$1 $2" = "extensions list" ] && exit 0
+exit 0
+EOF
+chmod +x "$GUARD_BIN/setsid" "$GUARD_BIN/claude" "$GUARD_BIN/gemini"
+GUARDOUT="$(PATH="$GUARD_BIN:$PATH" bash "$SYNC" 2>&1)"
+rm -rf "$GUARD_BIN"
+assert_contains "$GUARDOUT" "SETSID_USED" "runs plugin commands under setsid to detach the controlling terminal"
+
+# --- Behavioral: a /dev/tty-grabbing CLI must NOT hang the installer -----------
+# End-to-end proof of the fix: run sync_claude under a real pseudo-terminal (so a
+# controlling terminal exists, as in an interactive `./install.sh`) with a fake
+# claude that blocks forever IF it can open its controlling terminal, and prints
+# a sentinel only when it cannot. With setsid the controlling terminal is gone,
+# so the fake runs headless and sync completes; without setsid it would block
+# (and the sentinel would never appear). Linux-only — skipped where `script` or
+# `setsid` are unavailable (e.g. macOS).
+if command -v script >/dev/null 2>&1 && command -v setsid >/dev/null 2>&1; then
+    TTY_BIN="$(mktemp -d)"
+    cat > "$TTY_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+if : <>/dev/tty 2>/dev/null; then
+    sleep 600            # controlling terminal reachable -> mimic the hanging TUI
+else
+    echo "headless-ok"   # no controlling terminal -> setsid detached it
+fi
+exit 0
+EOF
+    cat > "$TTY_BIN/gemini" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$TTY_BIN/claude" "$TTY_BIN/gemini"
+    # Short per-call timeout bounds the pre-fix blocking case; outer `timeout 60`
+    # backstops the whole pty run so a regression fails loudly instead of wedging.
+    TTYOUT="$(SYNC_PLUGINS_TIMEOUT=3 SYNC_PLUGINS_KILL_GRACE=2 PATH="$TTY_BIN:$PATH" \
+              timeout 60 script -qec "bash '$SYNC'" /dev/null </dev/null 2>&1 | tr -d '\r')"
+    TTYRC=$?
+    rm -rf "$TTY_BIN"
+    assert_eq "$TTYRC" "0" "sync completes under a pty when the CLI would grab /dev/tty"
+    assert_contains "$TTYOUT" "headless-ok" "setsid detaches the controlling terminal so claude runs headless"
+fi
+
 echo "----"
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What
Two layered fixes that keep `sync-plugins.sh` (run by `install.sh`) from hanging an unattended or interactive install:

1. **Gemini guard + idempotency** (`e190363`): snapshot already-installed extensions to skip them on re-run, treat "already installed"/"already enabled" as quiet successes, feed stdin from `/dev/null`, and wrap calls in `timeout -k` so a SIGTERM-ignoring Node CLI is SIGKILLed after the grace period.
2. **setsid TTY-grab fix** (`1eb74f7`): run every `claude`/`gemini` plugin subcommand under `setsid -w` so it gets a new session with **no controlling terminal**.

## Why
The `claude`/`gemini` plugin subcommands open `/dev/tty` **directly** and render an interactive TUI whenever a controlling terminal is present — bypassing the `</dev/null` stdin guard. The Node process ignores SIGTERM and gets job-control-**stopped** (state `T`) on SIGTTOU/SIGTTIN, so an interactive `./install.sh` wedged on the very first `claude plugin marketplace add`, and `timeout`'s kill couldn't even land on the stopped process. Detaching the controlling terminal with `setsid` makes the CLIs fall back to non-interactive mode and return promptly.

## Impact
- `install.sh` no longer hangs at the "Syncing AI plugins…" step on interactive (TTY) runs.
- No orphaned/stopped `claude` processes left behind.
- Guarded for portability: `setsid` (util-linux) is used only when present — macOS, which lacks it, keeps the `</dev/null` + `timeout` guards. The `if/else` timeout branches were simplified into a single `GUARD` prefix.

## Testing
- `sync-plugins_test.sh`: **16/16 pass**, including two new regression tests — a `setsid`-wiring shim check, and a pty-based "must not hang when the CLI would grab `/dev/tty`" behavioral proof (both fail without the fix, confirmed via TDD).
- End-to-end: ran the real `sync-plugins.sh` with the real `claude` CLI under a pseudo-terminal (mimicking interactive `./install.sh`) — completed all 12 plugins + gemini extensions in ~22s with no hang and no leftover processes.