### PR TITLE
hotcorner-multimon: fix

### DIFF
--- a/opt/Desktop/Apps/scripts/hotcorners.test.ahk
+++ b/opt/Desktop/Apps/scripts/hotcorners.test.ahk
@@ -1,0 +1,86 @@
+#Requires AutoHotkey v2.0
+#SingleInstance Off
+#NoTrayIcon
+#Include lib\hotcorners.ahk
+; Headless test for the hot-corner geometry layer (issue #93). Results ->
+; %TEMP%\hotcorners_test_out.txt. First line "RESULT GREEN" (no fails) or
+; "RESULT RED", then "TOTAL n  FAILS m", then one line per case.
+; Exit code: 0 = all pass, 1 = a failure, 2 = an uncaught error.
+;
+; All asserted coordinates are REACHABLE on-screen points: the OS clamps the
+; cursor, so a point off every monitor is meaningless and is never asserted.
+
+OUT := A_Temp "\hotcorners_test_out.txt"
+
+; Surface any uncaught error as a distinct RED result so the runner never hangs.
+OnError(_OnTestError)
+_OnTestError(err, mode) {
+    global OUT
+    FileAppend "RESULT ERROR " err.Message "`n", OUT
+    ExitApp(2)
+}
+
+lines := ""           ; accumulated PASS/FAIL lines
+total := 0
+fails := 0
+
+Assert(cond, name) {
+    global lines, total, fails
+    total += 1
+    if (cond) {
+        lines .= "PASS " name "`n"
+    } else {
+        lines .= "FAIL " name "`n"
+        fails += 1
+    }
+}
+
+T := 3
+
+; --- A) Dual: primary left + secondary right ----------------------------------
+dualA := [{left: 0, top: 0, right: 1920, bottom: 1080}, {left: 1920, top: 0, right: 4480, bottom: 1440}]
+tA := _HotCornerTarget(dualA)
+Assert(tA.right = 4480, "A: target right=4480")
+Assert(tA.top = 0, "A: target top=0")
+Assert(!!_InHotCorner(4479, 1, tA, T), "A: true outer corner fires")
+Assert(!_InHotCorner(3000, 1, tA, T), "A: top-center of right monitor does NOT fire (#93 bug)")
+Assert(!_InHotCorner(1919, 1, tA, T), "A: seam (top-right of left monitor) does NOT fire")
+
+; --- B) Single monitor --------------------------------------------------------
+single := [{left: 0, top: 0, right: 1920, bottom: 1080}]
+tB := _HotCornerTarget(single)
+Assert(tB.right = 1920, "B: target right=1920")
+Assert(tB.top = 0, "B: target top=0")
+Assert(!!_InHotCorner(1919, 1, tB, T), "B: outer corner fires")
+Assert(!_InHotCorner(960, 1, tB, T), "B: top-center does NOT fire")
+
+; --- C) Monitor extended to the LEFT (negative coords) ------------------------
+leftExt := [{left: -2560, top: 0, right: 0, bottom: 1440}, {left: 0, top: 0, right: 1920, bottom: 1080}]
+tC := _HotCornerTarget(leftExt)
+Assert(tC.right = 1920, "C: target right=1920 (rightmost wins over negative-coord mon)")
+Assert(tC.top = 0, "C: target top=0")
+Assert(!!_InHotCorner(1919, 1, tC, T), "C: outer corner fires")
+Assert(!_InHotCorner(-100, 1, tC, T), "C: point on left monitor does NOT fire")
+
+; --- D) Vertically-offset right monitor (corner at real top, not y=0) ---------
+offset := [{left: 0, top: 0, right: 1920, bottom: 1080}, {left: 1920, top: 300, right: 4480, bottom: 1740}]
+tD := _HotCornerTarget(offset)
+Assert(tD.right = 4480, "D: target right=4480")
+Assert(tD.top = 300, "D: target top=300 (real monitor top)")
+Assert(!!_InHotCorner(4479, 301, tD, T), "D: corner at monitor's real top fires")
+Assert(!_InHotCorner(4479, 1, tD, T), "D: y=1 (above real top) does NOT fire")
+
+; --- E) Hotplug: corner relocates on geometry change --------------------------
+targetA := _HotCornerTarget(dualA)
+targetB := _HotCornerTarget([{left: 0, top: 0, right: 1920, bottom: 1080}])
+Assert(targetA.right = 4480, "E: dual target right=4480")
+Assert(targetB.right = 1920, "E: single target right=1920 (corner RELOCATES)")
+Assert(!!_InHotCorner(1919, 1, targetB, T), "E: under single target, outer corner fires")
+Assert(!_InHotCorner(960, 1, targetB, T), "E: under single target, top-center does NOT fire")
+
+; --- Emit the report ----------------------------------------------------------
+try FileDelete OUT
+header := (fails = 0 ? "RESULT GREEN" : "RESULT RED") "`n"
+header .= "TOTAL " total "  FAILS " fails "`n"
+FileAppend header . lines, OUT
+ExitApp(fails = 0 ? 0 : 1)

--- a/opt/Desktop/Apps/scripts/lib/hotcorners.ahk
+++ b/opt/Desktop/Apps/scripts/lib/hotcorners.ahk
@@ -1,0 +1,43 @@
+#Requires AutoHotkey v2.0
+; hotcorners.ahk — outer-corner-only hot-corner GEOMETRY layer (issue #93).
+; Pure functions (monitors in, target/boolean out): no GUI, no hotkeys, no
+; SetTimer, no auto-execute side effects, so they can be exercised headlessly by
+; hotcorners.test.ahk. #Include'd by macos.ahk.
+;
+; Why this layer exists: the old HotCorners() used A_ScreenWidth (the PRIMARY
+; monitor width) for the X test. With CoordMode Screen, a monitor to the right of
+; primary has mx >= primaryWidth, so the X test was always true across the ENTIRE
+; right monitor and the whole top edge fired Task View. We instead derive the true
+; top-right corner from the rightmost monitor's REAL bounds.
+
+; Enumerate every monitor's FULL bounds (NOT the work area) via live WinAPI queries.
+; Recomputed every poll by the caller, so disconnect/reconnect/resolution/arrangement
+; changes self-heal within one tick (MonitorGet* are live, never cached here).
+_EnumMonitors() {
+    mons := []
+    count := MonitorGetCount()
+    loop count {
+        MonitorGet A_Index, &left, &top, &right, &bottom
+        mons.Push({left: left, top: top, right: right, bottom: bottom})
+    }
+    return mons
+}
+
+; The single true outer corner: the {right, top} of the monitor with the greatest
+; .right edge (the rightmost monitor). Returns "" when there are no monitors.
+_HotCornerTarget(monitors) {
+    if (monitors.Length = 0)
+        return ""
+    best := monitors[1]
+    for mon in monitors {
+        if (mon.right > best.right)
+            best := mon
+    }
+    return {right: best.right, top: best.top}
+}
+
+; True only inside the T-sized box hugging the rightmost monitor's top-right corner.
+; The seam between monitors and the top-center of any monitor must NOT match.
+_InHotCorner(mx, my, target, T) {
+    return (mx >= target.right - T) && (my >= target.top) && (my <= target.top + T)
+}

--- a/opt/Desktop/Apps/scripts/macos.ahk
+++ b/opt/Desktop/Apps/scripts/macos.ahk
@@ -2,6 +2,7 @@
 #SingleInstance Force
 #Include flow-calib.ahk      ; overlay-offset calibration data layer (DEFAULT + ini load/save)
 #Include flow-triggers.ahk   ; extra-trigger-key data + policy layer (load/save/normalize/compose/validate/manifest)
+#Include lib\hotcorners.ahk  ; outer-corner-only hot-corner geometry layer (multi-monitor, hotplug-safe)
 
 ; ==============================================================================
 ;  macOS-style shortcuts for Windows  (AutoHotkey v2)
@@ -805,7 +806,12 @@ HotCorners()
     CoordMode "Mouse", "Screen"
     MouseGetPos &mx, &my
     T := 3
-    inTopRight := (my <= T) && (mx >= A_ScreenWidth - T)
+    ; Recompute the corner every tick from the rightmost monitor's REAL bounds so
+    ; the geometry self-heals on hotplug/resolution/arrangement changes. Only the
+    ; single true top-right corner of the rightmost monitor fires (NOT the seam,
+    ; NOT the whole top edge — that A_ScreenWidth bug was issue #93).
+    target := _HotCornerTarget(_EnumMonitors())
+    inTopRight := (target != "") && _InHotCorner(mx, my, target, T)
     if (inTopRight && armed)
     {
         armed := false


### PR DESCRIPTION
Outer-corner-only hot-corner detection via rightmost-monitor bounds (fixes #93)

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **hotcorner-multimon**.

- **(no PR yet) — edward-raigosa/fix (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
