### PR TITLE
feat: railway-go-deploy skill + reusable deploy workflow

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -1,0 +1,52 @@
+name: Deploy to Railway
+
+# Reusable Railway deploy workflow.
+# Triggered on push to main when files under the service subdirectory change.
+# Requires two repository secrets:
+#   RAILWAY_TOKEN      — Railway API token (Account Settings → Tokens)
+#   RAILWAY_SERVICE_ID — Service ID from Railway dashboard → Service → Settings
+
+# Pin-to-SHA convention (mirrors docker-image.yml):
+# Every third-party action is pinned to a full 40-char commit SHA with a
+# trailing `# vX.Y.Z` comment. Dependabot bumps both together on new releases.
+#
+# To refresh a pin by hand:
+#   tag=$(gh api repos/<owner>/<repo>/releases/latest --jq .tag_name)
+#   sha=$(gh api repos/<owner>/<repo>/git/ref/tags/$tag --jq .object.sha)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "playweb/**"
+      - ".github/workflows/deploy-railway.yml"
+  # Allow manual re-deploys from the Actions tab
+  workflow_dispatch:
+
+# Cancel any in-flight deploy for the same ref so only the latest commit lands.
+concurrency:
+  group: deploy-railway-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Railway deploy (playweb)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Railway CLI
+        # Install the official Railway CLI via npm.
+        # Pinned to a specific version for reproducibility.
+        run: npm install -g @railway/cli@3.17.2
+
+      - name: Deploy to Railway
+        working-directory: playweb
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up \
+            --service "${{ secrets.RAILWAY_SERVICE_ID }}" \
+            --detach

--- a/ai/skills/railway-go-deploy/SKILL.md
+++ b/ai/skills/railway-go-deploy/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: railway-go-deploy
+description: Scaffold, containerize, and deploy a Go web service to Railway.app using a multi-stage Docker build and a GitHub Actions CI/CD workflow.
+teams: [go, ai-ci]
+---
+
+# Railway Go Deploy
+
+This skill scaffolds a production-ready Go web service under a `<app>/` subdirectory, adds a multi-stage `Dockerfile`, and wires a GitHub Actions workflow that auto-deploys to [Railway.app](https://railway.app) on every push to `main`.
+
+## When to use
+
+- Creating a new Go HTTP service that needs a public URL fast.
+- Adding Railway deployment to an existing Go service in a monorepo.
+- Automating Railway deploys from GitHub (no manual clicks after first setup).
+
+## Teams involved
+
+| Team slug | Why |
+|-----------|-----|
+| `go` → `go-godev` | Scaffolds idiomatic Go service code (`main.go`, `go.mod`). |
+| `go` → `go-goqa` | Adds `/health` endpoint and basic smoke-test advice. |
+| `ai-ci` → `the_ci_engineer` | Authors the GitHub Actions deploy workflow and pins all action SHAs. |
+
+## Prerequisites
+
+| What | Where to get it |
+|------|----------------|
+| Railway account | [railway.app](https://railway.app) — free trial, no card needed |
+| `RAILWAY_TOKEN` secret | Railway dashboard → Account Settings → Tokens → New Token; store as a GitHub repo secret |
+| `RAILWAY_SERVICE_ID` secret | Railway dashboard → your project → service → Settings → Service ID |
+
+## Usage
+
+### 1. Scaffold a new Go service
+
+Ask `go-godev` to scaffold the service:
+
+```
+@go-godev scaffold a new Go HTTP service under playweb/ in this monorepo.
+Expose PORT from env (default 8080). Add routes / and /health.
+```
+
+Expected output:
+```
+<app>/
+  main.go      # HTTP server reading $PORT, routes / and /health
+  go.mod       # module github.com/<owner>/<repo>/<app>
+  Dockerfile   # multi-stage: golang:1.22-alpine builder + alpine:3.19 runtime
+```
+
+### 2. Add the Dockerfile
+
+`go-godev` will produce the multi-stage Dockerfile. Key properties:
+- Builder stage: `golang:1.22-alpine` — compiles static binary (`CGO_ENABLED=0`)
+- Runtime stage: `alpine:3.19` — minimal image, no Go toolchain
+- Reads `$PORT` at runtime (Railway injects this automatically)
+- `EXPOSE 8080` as default
+
+### 3. Wire the GitHub Actions deploy workflow
+
+Ask `the_ci_engineer` to add the workflow:
+
+```
+@the_ci_engineer add a Railway deploy workflow for the playweb/ service.
+Trigger on push to main, paths: playweb/**. Use RAILWAY_TOKEN and
+RAILWAY_SERVICE_ID secrets. Pin all action SHAs per repo convention.
+```
+
+The workflow (`deploy-railway.yml`) will:
+1. Checkout the repo.
+2. Install the Railway CLI.
+3. Run `railway up --service $RAILWAY_SERVICE_ID --detach` from the service subdirectory.
+
+### 4. Configure Railway (one-time, in the dashboard)
+
+1. **New Project → Deploy from GitHub** → select your repo.
+2. **Service → Settings → Build → Root Directory**: set to `<app>/` (e.g. `playweb`).
+3. **Service → Variables**: add `PORT=8080` (Railway also injects its own `PORT` — this is a safe default).
+4. **Service → Settings → Networking → Generate Domain** → pick port `8080`.
+
+After this first manual setup, every `git push` to `main` triggers an automatic deploy.
+
+## Secrets reference
+
+```
+RAILWAY_TOKEN       # Railway API token (repo or org secret)
+RAILWAY_SERVICE_ID  # Railway service ID for this specific service
+```
+
+## File reference
+
+| File | Purpose |
+|------|---------|
+| `<app>/main.go` | Go HTTP server |
+| `<app>/go.mod` | Go module definition |
+| `<app>/Dockerfile` | Multi-stage Docker build |
+| `.github/workflows/deploy-railway.yml` | CI/CD deploy workflow |
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `go.sum not found` | Dockerfile references `go.sum` but no external deps | Remove `go.sum` from `COPY` line in Dockerfile |
+| `PORT bind failed` | App hardcodes port instead of reading `$PORT` | Use `os.Getenv("PORT")` with fallback |
+| `railway: command not found` | CLI not installed in workflow | Add `npm install -g @railway/cli` step |
+| `Unauthorized` in deploy step | `RAILWAY_TOKEN` missing or expired | Re-generate token in Railway dashboard |


### PR DESCRIPTION
## Summary

Adds a new skill and reusable GitHub Actions workflow for deploying Go services to [Railway.app](https://railway.app) from a monorepo.

## Changes

### `ai/skills/railway-go-deploy/SKILL.md`
New skill that documents the full Railway + Go deployment pattern:
- **Go team** (`go-godev`, `go-goqa`) — scaffolds idiomatic Go HTTP service with `/` and `/health` routes, multi-stage Dockerfile
- **CI team** (`the_ci_engineer`) — authors the GitHub Actions deploy workflow, pins all action SHAs per repo convention
- Troubleshooting table covering common Railway build errors (missing `go.sum`, hardcoded port, missing CLI, expired token)

### `.github/workflows/deploy-railway.yml`
Reusable Railway deploy workflow template:
- Triggers on `push` to `main` (path-filtered to service subdir) and `workflow_dispatch`
- Cancels in-flight deploys for the same ref (`concurrency` group)
- All action SHAs pinned per repo convention (Dependabot-maintainable)
- Requires `RAILWAY_TOKEN` and `RAILWAY_SERVICE_ID` as repo secrets

## Secrets needed (one-time setup per repo)
```
RAILWAY_TOKEN       # Railway dashboard → Account Settings → Tokens
RAILWAY_SERVICE_ID  # Railway dashboard → Service → Settings → Service ID
```

## Related
- Companion deploy workflow added directly to `sfc-gh-eraigosa/playground` for the `playweb/` Go service.

## Checklist
- [ ] `RAILWAY_TOKEN` secret added to target repos
- [ ] `RAILWAY_SERVICE_ID` secret added to target repos
- [ ] Railway service root directory set to `playweb` in dashboard
- [ ] First deploy triggered manually or via `workflow_dispatch`
