### PR TITLE
ci(sdk): sdk-only discovery + legacy-path anti-regression guard (#114)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -68,7 +68,6 @@ jobs:
           # setup-go@v5 enables module caching by default (cache: true);
           # cache-dependency-path scopes the cache key to our four Go modules.
           cache-dependency-path: |
-            src/**/*.sum
             sdk/**/*.sum
 
       - name: Install golangci-lint
@@ -121,7 +120,6 @@ jobs:
         with:
           go-version: '1.26'
           cache-dependency-path: |
-            src/**/*.sum
             sdk/**/*.sum
       - name: Run Go Unit Tests
         run: make unit-test

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ help: ## Display this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: bin
-bin: ## Rebuild all binaries in ./src and ./sdk
-	@for d in src/* sdk/*; do \
+bin: ## Rebuild all binaries in ./sdk
+	@for d in sdk/*; do \
 		if [ -f "$$d/build.sh" ]; then \
 			echo "Building $$d..."; \
 			bash "$$d/build.sh"; \
@@ -65,18 +65,33 @@ claude-hook-test: ## Run safety_guard hook test suite only
 # -----------------------------------------------------------------------------
 
 .PHONY: lint
-lint: lint-go lint-shell lint-markdown ## Run all linters (go, shell, markdown)
+lint: check-legacy-paths lint-go lint-shell lint-markdown ## Run all linters (go, shell, markdown)
 
+
+.PHONY: check-legacy-paths
+check-legacy-paths: ## Fail if a legacy Go module path or src/<tool> reappears (Go lives in sdk/)
+	@echo "==> checking for legacy Go module paths (must be 0)..."
+	@if grep -rInE 'github\.com/(wenlock|eraigosa)/dotfiles' \
+		--include='*.go' --include='go.mod' --include='build.sh' --exclude-dir=.git . ; then \
+		echo "ERROR: legacy module path in Go source — use github.com/sfc-gh-eraigosa/dotfiles/sdk/<tool>"; \
+		exit 1; \
+	fi
+	@for t in gss gsl wol tmux-mgr; do \
+		if [ -e "src/$$t/go.mod" ]; then \
+			echo "ERROR: Go module src/$$t exists — Go modules live in sdk/"; exit 1; \
+		fi; \
+	done
+	@echo "OK: no legacy Go module paths; no Go modules under src/"
 .PHONY: lint-go
 lint-go: ## Lint Go modules (gofmt + golangci-lint, per-module)
-	@echo "==> gofmt check across src/ and sdk/..."
-	@unformatted=$$(gofmt -l ./src ./sdk 2>/dev/null); \
+	@echo "==> gofmt check across sdk/..."
+	@unformatted=$$(gofmt -l ./sdk 2>/dev/null); \
 		if [ -n "$$unformatted" ]; then \
 			echo "gofmt found unformatted files:"; \
 			echo "$$unformatted"; \
 			exit 1; \
 		fi
-	@for d in src/* sdk/*; do \
+	@for d in sdk/*; do \
 		if [ -f "$$d/go.mod" ]; then \
 			echo "==> golangci-lint run ($$d)"; \
 			(cd "$$d" && golangci-lint run ./...) || exit 1; \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -74,7 +74,7 @@ function run_unit_tests() {
     modules=()
     while IFS= read -r line; do
         modules+=("$line")
-    done < <(find "$REPO_ROOT/src" "$REPO_ROOT/sdk" -name "go.mod" -exec dirname {} + 2>/dev/null | xargs -n1 basename | sort)
+    done < <(find "$REPO_ROOT/sdk" -name "go.mod" -exec dirname {} + 2>/dev/null | xargs -n1 basename | sort)
 
     if [ ${#modules[@]} -eq 0 ]; then
         log "No Go modules found in src/"
@@ -88,7 +88,7 @@ function run_unit_tests() {
     for mod in "${modules[@]}"; do
         log "Testing module: $mod"
         # Find the full path to the module (search both src/ and sdk/)
-        mod_path=$(find "$REPO_ROOT/src" "$REPO_ROOT/sdk" -path "*/$mod/go.mod" -exec dirname {} \; 2>/dev/null | head -n 1)
+        mod_path=$(find "$REPO_ROOT/sdk" -path "*/$mod/go.mod" -exec dirname {} \; 2>/dev/null | head -n 1)
         (cd "$mod_path" && go test -coverprofile="$REPO_ROOT/coverage/$mod.out" ./...)
         (cd "$mod_path" && go tool cover -func="$REPO_ROOT/coverage/$mod.out" | tail -n 1)
 


### PR DESCRIPTION
## What
Finalizes the `src/` → `sdk/` cutover now that all four Go modules are merged under `sdk/`. Collapses the transitional dual-scan (from foundation #119) to **`sdk/`-only**, and adds an anti-regression guard.

## Changes
- **`scripts/test.sh`** — module discovery scans `sdk/` only.
- **`Makefile`** — `bin` + `lint-go` loops and the gofmt check scan `sdk/` only; help text updated.
- **`docker-image.yml`** — `cache-dependency-path` drops the transitional `src/**/*.sum` glob (keeps `sdk/**/*.sum`).
- **New `make check-legacy-paths`** (wired into `make lint`, so CI enforces it): fails the build if a legacy module path reappears in Go source / `go.mod` / `build.sh`, or if a Go module dir returns under `src/`.

## Verified
- Negative test: the guard **fails** on a planted legacy import; **passes** on the clean tree.
- `bash scripts/test.sh unit` discovers all four modules under `sdk/` and passes (coverage warn-only per D5).

## Notes
- Reversible CI cleanup — **left open for your review** (not auto-merged).
- This is the D9 sdk-only end state + the Phase-6 anti-regression guard. Tag automation (`sdk/<tool>/vX.Y.Z`) is a separate follow-up PR.

Part of #114.