### PR TITLE
ci(sdk): VERSION-driven tag automation for sdk/<tool> modules (#114)

### DIFF
--- a/.github/workflows/tag-sdk-modules.yml
+++ b/.github/workflows/tag-sdk-modules.yml
@@ -1,0 +1,71 @@
+name: Tag SDK modules
+
+# Automates the path-prefixed release tags Go requires for sub-directory modules:
+# each sdk/<tool> is tagged `sdk/<tool>/v<VERSION>` so external consumers can pin
+# `go install github.com/sfc-gh-eraigosa/dotfiles/sdk/<tool>@sdk/<tool>/v<VERSION>`.
+#
+# Versioning is VERSION-file driven (explicit + controlled): a tag is cut only
+# when sdk/<tool>/VERSION changes on main and the corresponding tag does not yet
+# exist. Idempotent — re-runs never move or duplicate an existing tag.
+#
+# Trigger:
+#   - push to main touching any sdk/*/VERSION (the normal path: bump VERSION in a PR)
+#   - workflow_dispatch (manual bootstrap of the first tags)
+#
+# NOTE: tags are created ANNOTATED but UNSIGNED — CI signing needs a GPG/SSH
+# signing key provisioned in repo secrets (a Phase-0 security follow-up), and a
+# tag-protection ruleset on `sdk/<tool>/v*` should be added so released tags
+# cannot be force-moved. See docs/plans/2026-06-04-sdk-migration-plan.md (D4).
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'sdk/*/VERSION'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: tag-sdk-modules
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Create per-module version tags
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          set -euo pipefail
+          created=0
+          for vf in sdk/*/VERSION; do
+            [ -f "$vf" ] || continue
+            dir="$(dirname "$vf")"
+            tool="$(basename "$dir")"
+            # Only tag actual Go modules.
+            [ -f "$dir/go.mod" ] || { echo "skip $tool: no go.mod"; continue; }
+            ver="$(tr -d ' \t\r\n' < "$vf")"
+            [ -n "$ver" ] || { echo "skip $tool: empty VERSION"; continue; }
+            ver="${ver#v}"                      # normalize: VERSION may or may not carry a leading v
+            tag="sdk/${tool}/v${ver}"
+            if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+              echo "exists: ${tag}"
+            else
+              echo "creating: ${tag}"
+              git tag -a "${tag}" -m "Release ${tool} v${ver}"
+              git push origin "refs/tags/${tag}"
+              created=$((created+1))
+            fi
+          done
+          echo "tags created this run: ${created}"


### PR DESCRIPTION
## What
Adds `.github/workflows/tag-sdk-modules.yml` — automates the path-prefixed release tags Go needs for sub-directory modules (`sdk/<tool>/vX.Y.Z`), so external consumers can pin `go install github.com/sfc-gh-eraigosa/dotfiles/sdk/<tool>@sdk/<tool>/v<VERSION>`.

## How (D4)
- **Trigger:** push to `main` touching any `sdk/*/VERSION` (the normal path — bump VERSION in a PR), plus `workflow_dispatch` for the manual first-tag bootstrap.
- **Versioning is VERSION-file driven** (explicit, controlled): for each Go module, it cuts `sdk/<tool>/v<VERSION>` only if that tag doesn't already exist. **Idempotent** — never moves or duplicates a tag.
- Dry-run of the loop confirms it would create `sdk/{gss,gsl,wol,tmux-mgr}/v0.1.0` (current VERSION files).

## Deliberately deferred (call-outs for review)
- **Signing:** tags are annotated but **unsigned** — CI signing needs a GPG/SSH key in repo secrets (a Phase-0 security task). The plan (D4) calls for signed tags.
- **Tag protection:** add a `sdk/<tool>/v*` tag-protection ruleset so released tags can't be force-moved.
- These two are the remaining hardening steps before relying on the public tags.

## Notes
- New workflow only; **does not cut any tags until merged** (and then only on a VERSION bump or manual dispatch). **Left open for your review.**
- Interacts with the merge queue (still needs the UI toggle) but doesn't depend on it.

Part of #114.