### PR TITLE
feat(claude): claude-config tool + opt-in remote-control launch flag

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -155,9 +155,11 @@ jobs:
     # gate the Go suite and vice-versa.
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Install jq
-        # safety_guard_test.sh builds its tool_input payloads with jq.
-        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Install jq + zsh
+        # safety_guard_test.sh builds its tool_input payloads with jq; zsh is
+        # needed so aliases_test.sh's cross-shell doctor regression case runs
+        # for real here (it skips gracefully where zsh is absent).
+        run: sudo apt-get update && sudo apt-get install -y jq zsh
       - name: Run make shell-test
         run: make shell-test
 

--- a/ai/claude/aliases.sh
+++ b/ai/claude/aliases.sh
@@ -1,31 +1,95 @@
 #!/bin/sh
 # Shell helpers for the Claude Code CLI.
-# Sourced from opt/profiles/.zshrc and opt/profiles/.bashrc.
+# Sourced from opt/profiles/.zshrc and opt/profiles/.bashrc (so the runtime
+# shell is always bash or zsh — both support arrays/`local`, which the flag
+# injection below relies on; this file is never executed by a bare POSIX sh).
 #
 # Commands:
 #
-#   claude          Honors the YOLO toggle and auto-anchors in tmux when possible.
+#   claude          Honors the on-disk config and auto-anchors in tmux when possible.
 #                     - If running inside a tmux pane: anchors the pane as "claude"
 #                       so AI-driven 'tmux-mgr window split' targets it correctly.
 #                     - If not in tmux but a server is running: prints a nudge.
-#                     claude "fix bug"               -> claude [--dangerously-skip-permissions] "fix bug"
-#                     claude --model haiku "..."     -> claude [--dangerously-skip-permissions] --model haiku "..."
-#                     claude --continue              -> claude [--dangerously-skip-permissions] --continue
+#                     - Injects flags based on the config sentinels below (both
+#                       OFF by default — opt in with `claude-config`):
+#                     claude "fix bug"           -> claude [--remote-control <dir>] [--dangerously-skip-permissions] "fix bug"
+#                     claude --model haiku "..." -> claude [--remote-control <dir>] [--dangerously-skip-permissions] --model haiku "..."
+#                     claude -p "..."            -> claude [--dangerously-skip-permissions] -p "..."   (never --remote-control)
 #
-#   claude-toggle   flip YOLO on/off and report the new state.
+#   claude-config   Show or change the launch config:
+#                     claude-config                 # show current state
+#                     claude-config yolo   on|off   # --dangerously-skip-permissions
+#                     claude-config remote on|off   # --remote-control on interactive sessions
 #
-# State is a single sentinel file. Present => YOLO ON, absent => OFF.
-# Path: $XDG_CONFIG_HOME/claude/yolo.enabled (defaults to ~/.config/claude/).
-# Kept under ~/.config/claude/ so it doesn't pollute ~/.claude/ (owned by Claude Code).
+# Config is expressed as sentinel files under $XDG_CONFIG_HOME/claude
+# (defaults to ~/.config/claude/), kept out of ~/.claude/ (owned by Claude Code).
+# Both sentinels share the same polarity — present => ON, absent => OFF — so the
+# safe, no-config default for both is OFF (you opt in explicitly):
+#
+#   yolo.enabled     present => YOLO ON   (default OFF — opt in).
+#   remote.enabled   present => remote ON (default OFF — opt in).
+#
+# --remote-control is added ONLY for interactive sessions: it is skipped when
+# stdin is not a TTY or when print mode (-p / --print) is requested, so
+# scripted/headless `claude -p "..."` and piped runs are left untouched.
+#
+# Security note (remote-control): --remote-control opens a remote-control
+# surface for the interactive session. It is OPT-IN (default OFF) and gated to
+# interactive TTYs, and access is still mediated by your normal authenticated
+# SSH + tmux. Because this aliases.sh is symlinked onto every machine `install`
+# runs on, the opt-in default keeps fresh/shared/remote hosts quiet until you
+# run `claude-config remote on` there. Turn it off again with
+# `claude-config remote off`. See docs/machine-local-overrides.md.
 
-CLAUDE_YOLO_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/claude"
-CLAUDE_YOLO_FILE="$CLAUDE_YOLO_DIR/yolo.enabled"
+CLAUDE_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/claude"
+# CROSS-REPO CONTRACT — DO NOT RENAME OR INLINE.
+# The shell variable CLAUDE_YOLO_FILE (name + value semantics: absolute path to
+# the YOLO sentinel) is read by the playground project's nano-carried
+# `claude-local` helper (~/.config/nano/ollama-client.sh), which sources into the
+# same interactive shell, reads ${CLAUDE_YOLO_FILE:-}, and re-applies the YOLO
+# policy itself before calling `command claude`. Renaming this var, changing its
+# meaning, or moving the sentinel path silently breaks `claude-local`. The
+# yolo.enabled FILENAME and the claude-config tool name are NOT part of the
+# contract — only this variable. Coordinate cross-repo before changing it.
+CLAUDE_YOLO_FILE="$CLAUDE_CONFIG_DIR/yolo.enabled"
+CLAUDE_REMOTE_ENABLED_FILE="$CLAUDE_CONFIG_DIR/remote.enabled"
 
-# Note: the YOLO check is inlined (instead of a helper function) because
-# Claude Code's shell-snapshot mechanism strips functions whose names start
-# with '_'. A separate `_claude_yolo_enabled` helper would survive in the
-# live shell but vanish from the snapshot, causing "command not found"
-# errors whenever the snapshot is sourced.
+# Note: the config logic lives in top-level functions (NOT underscore-prefixed)
+# because Claude Code's shell-snapshot mechanism strips functions whose names
+# start with '_'. A `_claude_*` helper would survive in the live shell but
+# vanish from the snapshot, causing "command not found" errors whenever the
+# snapshot is sourced.
+
+# Decide which launch flags to inject. Populates the global array
+# CLAUDE_LAUNCH_FLAGS. TTY state is PASSED IN (not probed) so the test driver
+# can exercise this deterministically. Top-level (no leading '_') so the
+# shell-snapshot keeps it.
+#   $1     : "tty" if stdin is an interactive terminal, anything else otherwise
+#   $2..   : the user's claude args
+claude_launch_flags() {
+    CLAUDE_LAUNCH_FLAGS=()
+    claude_tty="$1"
+    shift
+
+    # YOLO (opt-in): present sentinel => skip permission prompts.
+    [ -f "$CLAUDE_YOLO_FILE" ] && CLAUDE_LAUNCH_FLAGS+=(--dangerously-skip-permissions)
+
+    # Remote control (opt-in): only for interactive sessions, never print mode.
+    if [ -f "$CLAUDE_REMOTE_ENABLED_FILE" ] && [ "$claude_tty" = "tty" ]; then
+        claude_remote_ok=1
+        # Scan args positionally (not a substring match on the joined string) so
+        # a prompt that merely contains the token "-p" doesn't suppress remote.
+        for claude_arg in "$@"; do
+            case "$claude_arg" in
+                -p|--print) claude_remote_ok=0; break ;;
+            esac
+        done
+        # --remote-control takes an OPTIONAL [name]; pass an explicit name (the
+        # current dir basename) so it can never consume the user's positional
+        # prompt as the session name. The array carries a name-with-spaces safely.
+        [ "$claude_remote_ok" = 1 ] && CLAUDE_LAUNCH_FLAGS+=(--remote-control "$(basename "$PWD")")
+    fi
+}
 
 claude() {
     # Auto-anchor in tmux so AI-driven pane splits target this pane.
@@ -35,22 +99,48 @@ claude() {
         echo "Tip: run inside a tmux pane for AI pane-split support." \
              "Use 'tmux-start' or 'tmux new-session -A -s main' first." >&2
     fi
-    if [ -f "$CLAUDE_YOLO_FILE" ]; then
-        command claude --dangerously-skip-permissions "$@"
-    else
-        command claude "$@"
-    fi
+
+    claude_tty="other"
+    [ -t 0 ] && claude_tty="tty"
+    claude_launch_flags "$claude_tty" "$@"
+    command claude "${CLAUDE_LAUNCH_FLAGS[@]}" "$@"
 }
 
-claude-toggle() {
-    mkdir -p "$CLAUDE_YOLO_DIR"
-    if [ -f "$CLAUDE_YOLO_FILE" ]; then
-        rm -f "$CLAUDE_YOLO_FILE"
-        echo "Claude YOLO mode: OFF — claude will prompt for permissions."
-    else
-        : > "$CLAUDE_YOLO_FILE"
-        echo "Claude YOLO mode: ON  — claude will run with --dangerously-skip-permissions."
-    fi
+claude-config() {
+    mkdir -p "$CLAUDE_CONFIG_DIR"
+    case "$1" in
+        yolo)
+            case "$2" in
+                on)  : > "$CLAUDE_YOLO_FILE"
+                     echo "Claude YOLO: ON  — claude runs with --dangerously-skip-permissions." ;;
+                off) rm -f "$CLAUDE_YOLO_FILE"
+                     echo "Claude YOLO: OFF — claude prompts for permissions." ;;
+                *)   echo "usage: claude-config yolo on|off" >&2; return 2 ;;
+            esac
+            ;;
+        remote)
+            case "$2" in
+                on)  : > "$CLAUDE_REMOTE_ENABLED_FILE"
+                     echo "Claude Remote Control: ON  — interactive sessions start with --remote-control." ;;
+                off) rm -f "$CLAUDE_REMOTE_ENABLED_FILE"
+                     echo "Claude Remote Control: OFF — interactive sessions start normally." ;;
+                *)   echo "usage: claude-config remote on|off" >&2; return 2 ;;
+            esac
+            ;;
+        ""|status)
+            [ -f "$CLAUDE_YOLO_FILE" ] && yolo_state="ON" || yolo_state="OFF"
+            [ -f "$CLAUDE_REMOTE_ENABLED_FILE" ] && remote_state="ON" || remote_state="OFF"
+            echo "Claude launch config:"
+            echo "  yolo    $yolo_state   (claude-config yolo on|off)"
+            echo "  remote  $remote_state   (claude-config remote on|off)"
+            ;;
+        *)
+            echo "usage: claude-config [status]" >&2
+            echo "       claude-config yolo on|off" >&2
+            echo "       claude-config remote on|off" >&2
+            return 2
+            ;;
+    esac
 }
 
 alias sync-skills="bash $HOME/opt/scripts/system/sync-skills.sh"

--- a/ai/claude/aliases.sh
+++ b/ai/claude/aliases.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# shellcheck shell=bash
+# shellcheck disable=SC2139  # the sync-* aliases expand $HOME at definition time on purpose ($HOME is stable for the shell's lifetime)
 # Shell helpers for the Claude Code CLI.
 # Sourced from opt/profiles/.zshrc and opt/profiles/.bashrc (so the runtime
 # shell is always bash or zsh — both support arrays/`local`, which the flag
@@ -137,9 +139,11 @@ claude-config() {
             # install.sh): npm on Linux/WSL, brew cask on macOS. Extra copies
             # (e.g. the native `curl claude.ai/install.sh` install under
             # ~/.local) are consolidated away by re-running install.sh.
+            # Split PATH via tr, not `for d in $PATH`: zsh does not word-split
+            # unquoted variables, so the for-loop form sees PATH as ONE word
+            # and doctor reports <not found> in the user's login shell.
             claude_all="$(
-                IFS=:
-                for claude_d in $PATH; do
+                printf '%s\n' "$PATH" | tr ':' '\n' | while IFS= read -r claude_d; do
                     [ -x "$claude_d/claude" ] && printf '%s\n' "$claude_d/claude"
                 done | awk '!seen[$0]++'
             )"

--- a/ai/claude/aliases.sh
+++ b/ai/claude/aliases.sh
@@ -20,6 +20,8 @@
 #                     claude-config                 # show current state
 #                     claude-config yolo   on|off   # --dangerously-skip-permissions
 #                     claude-config remote on|off   # --remote-control on interactive sessions
+#                     claude-config doctor          # report the installed claude binary,
+#                                                   # warn if more than one is on PATH
 #
 # Config is expressed as sentinel files under $XDG_CONFIG_HOME/claude
 # (defaults to ~/.config/claude/), kept out of ~/.claude/ (owned by Claude Code).
@@ -127,17 +129,47 @@ claude-config() {
                 *)   echo "usage: claude-config remote on|off" >&2; return 2 ;;
             esac
             ;;
+        doctor)
+            # Report which claude binary the wrapper actually runs (via PATH —
+            # `command claude` bypasses this function but still does a PATH
+            # lookup) and warn if more than one is installed. The canonical
+            # binary is the one installed by claude_install.sh (run by
+            # install.sh): npm on Linux/WSL, brew cask on macOS. Extra copies
+            # (e.g. the native `curl claude.ai/install.sh` install under
+            # ~/.local) are consolidated away by re-running install.sh.
+            claude_all="$(
+                IFS=:
+                for claude_d in $PATH; do
+                    [ -x "$claude_d/claude" ] && printf '%s\n' "$claude_d/claude"
+                done | awk '!seen[$0]++'
+            )"
+            claude_resolved="$(printf '%s\n' "$claude_all" | sed '/^$/d' | head -1)"
+            claude_n="$(printf '%s\n' "$claude_all" | grep -c .)"
+            echo "Claude binary diagnostics:"
+            echo "  command claude -> ${claude_resolved:-<not found>}"
+            echo "  on PATH ($claude_n):"
+            printf '%s\n' "$claude_all" | sed '/^$/d; s/^/    /'
+            if [ "$claude_n" -gt 1 ]; then
+                echo "  WARNING: more than one claude binary is installed. The dotfiles"
+                echo "  installer (claude_install.sh, run by install.sh) keeps ONE canonical"
+                echo "  binary (npm on Linux/WSL, brew cask on macOS) and removes the"
+                echo "  non-orchestrated native install. Re-run install.sh to consolidate."
+                return 1
+            fi
+            ;;
         ""|status)
             [ -f "$CLAUDE_YOLO_FILE" ] && yolo_state="ON" || yolo_state="OFF"
             [ -f "$CLAUDE_REMOTE_ENABLED_FILE" ] && remote_state="ON" || remote_state="OFF"
             echo "Claude launch config:"
             echo "  yolo    $yolo_state   (claude-config yolo on|off)"
             echo "  remote  $remote_state   (claude-config remote on|off)"
+            echo "  (run 'claude-config doctor' to check the installed binary)"
             ;;
         *)
             echo "usage: claude-config [status]" >&2
             echo "       claude-config yolo on|off" >&2
             echo "       claude-config remote on|off" >&2
+            echo "       claude-config doctor" >&2
             return 2
             ;;
     esac

--- a/ai/claude/aliases_test.sh
+++ b/ai/claude/aliases_test.sh
@@ -101,6 +101,11 @@ assert_in_subshell "doctor: multiple binaries => WARNING + nonzero" \
 # De-dups a binary that appears under repeated PATH entries (one logical claude).
 assert_in_subshell "doctor: dedups repeated PATH entries (no false warning)" \
     "H=\$(mktemp -d); mkdir -p \"\$H/b1\"; : > \"\$H/b1/claude\"; chmod +x \"\$H/b1/claude\"; export PATH=\"\$H/b1:\$H/b1:/usr/bin:/bin\"; . '$ALIASES'; claude-config doctor >/dev/null 2>&1; [ \$? -eq 0 ]"
+# Cross-shell regression: zsh does not word-split unquoted variables, so a
+# 'for d in \$PATH' scan sees PATH as ONE word and doctor reports <not found>
+# in the user's login shell. Skips (passes) when zsh is not installed.
+assert_in_subshell "doctor: resolves the binary under zsh (PATH-split regression)" \
+    "command -v zsh >/dev/null 2>&1 || exit 0; H=\$(mktemp -d); mkdir -p \"\$H/b1\"; : > \"\$H/b1/claude\"; chmod +x \"\$H/b1/claude\"; export H ALIASES='$ALIASES'; zsh -c 'export PATH=\"\$H/b1:/usr/bin:/bin\"; . \"\$ALIASES\"; claude-config doctor 2>&1 | grep -q \"\$H/b1/claude\"'"
 
 # === Flag-injection behavior (the headline feature — exercised directly) ===
 # Default (nothing opted in), interactive, with a prompt: NO flags injected.

--- a/ai/claude/aliases_test.sh
+++ b/ai/claude/aliases_test.sh
@@ -1,13 +1,20 @@
 #!/bin/bash
 # Test driver for ai/claude/aliases.sh
 #
-# Why: the `claude` / `claude-toggle` functions historically depended on a
-# private helper `_claude_yolo_enabled`. Claude Code's shell-snapshot
-# mechanism strips functions whose names start with `_`, so the snapshot kept
-# `claude()` but dropped `_claude_yolo_enabled` — producing
+# Why: the `claude` / `claude-config` functions must stay free of private
+# helpers. Claude Code's shell-snapshot mechanism strips functions whose names
+# start with `_`, so a `_claude_yolo_enabled` helper would survive in the live
+# shell but vanish from the snapshot, producing
 #   "claude:8: command not found: _claude_yolo_enabled"
-# on every Claude Code launch. The inline-check fix removes that dependency;
-# this test driver guards against any reintroduction of an underscore helper.
+# on every Claude Code launch. The top-level-function design avoids that; this
+# driver guards against any reintroduction of an underscore helper, and covers
+# the claude-config tool plus the actual flag-injection behavior of
+# claude_launch_flags (TTY/print guards, the opt-in sentinels, and the
+# regression guard for the --remote-control prompt-swallow bug).
+#
+# claude_launch_flags(tty_state, args...) populates the global array
+# CLAUDE_LAUNCH_FLAGS, so we can exercise the real decision logic deterministically
+# without shelling out to the claude binary (TTY state is passed in, not probed).
 #
 # Run: bash ai/claude/aliases_test.sh
 set -u
@@ -24,27 +31,99 @@ ALIASES="${SELF_DIR}/aliases.sh"
 assert_grep_negative "no underscore-prefixed helper functions" \
     '^_[a-zA-Z_]+\(\)[[:space:]]*\{' "$ALIASES"
 
-# `claude` and `claude-toggle` must be defined at the top level.
+# `claude` must NOT be accidentally removed.
 assert_grep_negative "claude() not removed by accident" \
     '^# REMOVED claude\(\)' "$ALIASES"
+
+# CROSS-REPO CONTRACT GUARD: the literal `CLAUDE_YOLO_FILE=` assignment must
+# survive. Playground's claude-local reads this exact variable; a rename here
+# silently breaks it, so trip a red test if it ever disappears.
+assert_grep "CLAUDE_YOLO_FILE cross-repo contract var preserved" \
+    '^CLAUDE_YOLO_FILE=' "$ALIASES"
+
+# The remote-control injection MUST pass an explicit name so the optional
+# --remote-control [name] arg cannot swallow the user's positional prompt.
+assert_grep "remote-control passes an explicit session name (anti prompt-swallow)" \
+    '\-\-remote-control "\$\(basename' "$ALIASES"
 
 # === Runtime checks (source the file in a subshell) ===
 assert_in_subshell "claude function defined after sourcing" \
     ". '$ALIASES' && type claude >/dev/null 2>&1"
-assert_in_subshell "claude-toggle function defined after sourcing" \
-    ". '$ALIASES' && type claude-toggle >/dev/null 2>&1"
-# `claude` must NOT reference any undefined command at parse time. We can't
-# easily invoke claude() (it would shell out to the real binary), but we can
-# inspect its body for forbidden references.
+assert_in_subshell "claude-config function defined after sourcing" \
+    ". '$ALIASES' && type claude-config >/dev/null 2>&1"
+assert_in_subshell "claude_launch_flags function defined after sourcing" \
+    ". '$ALIASES' && type claude_launch_flags >/dev/null 2>&1"
+# `claude` must NOT reference any undefined command at parse time.
 assert_in_subshell "claude body does not call _claude_yolo_enabled" \
     ". '$ALIASES' && ! declare -f claude | grep -q '_claude_yolo_enabled'"
-assert_in_subshell "claude-toggle body does not call _claude_yolo_enabled" \
-    ". '$ALIASES' && ! declare -f claude-toggle | grep -q '_claude_yolo_enabled'"
+assert_in_subshell "claude-config body does not call _claude_yolo_enabled" \
+    ". '$ALIASES' && ! declare -f claude-config | grep -q '_claude_yolo_enabled'"
 
 # === Variable setup ===
-assert_in_subshell "CLAUDE_YOLO_DIR exported" \
-    ". '$ALIASES' && [ -n \"\$CLAUDE_YOLO_DIR\" ]"
-assert_in_subshell "CLAUDE_YOLO_FILE exported" \
+assert_in_subshell "CLAUDE_CONFIG_DIR set" \
+    ". '$ALIASES' && [ -n \"\$CLAUDE_CONFIG_DIR\" ]"
+assert_in_subshell "CLAUDE_YOLO_FILE set" \
     ". '$ALIASES' && [ -n \"\$CLAUDE_YOLO_FILE\" ]"
+assert_in_subshell "CLAUDE_REMOTE_ENABLED_FILE set" \
+    ". '$ALIASES' && [ -n \"\$CLAUDE_REMOTE_ENABLED_FILE\" ]"
+
+# === claude-config behavior (isolated XDG dir per case) ===
+# Both settings default OFF (opt-in): no sentinels present after a fresh source.
+assert_in_subshell "remote defaults OFF (no enabled sentinel)" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES' && [ ! -f \"\$CLAUDE_REMOTE_ENABLED_FILE\" ]"
+assert_in_subshell "yolo defaults OFF (no enabled sentinel)" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES' && [ ! -f \"\$CLAUDE_YOLO_FILE\" ]"
+assert_in_subshell "claude-config remote on creates enabled sentinel" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES' && claude-config remote on >/dev/null && [ -f \"\$CLAUDE_REMOTE_ENABLED_FILE\" ]"
+assert_in_subshell "claude-config remote off removes enabled sentinel" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES' && claude-config remote on >/dev/null && claude-config remote off >/dev/null && [ ! -f \"\$CLAUDE_REMOTE_ENABLED_FILE\" ]"
+assert_in_subshell "claude-config yolo on creates yolo sentinel" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES' && claude-config yolo on >/dev/null && [ -f \"\$CLAUDE_YOLO_FILE\" ]"
+assert_in_subshell "claude-config yolo off removes yolo sentinel" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES' && claude-config yolo on >/dev/null && claude-config yolo off >/dev/null && [ ! -f \"\$CLAUDE_YOLO_FILE\" ]"
+assert_in_subshell "claude-config status reports remote OFF by default" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES' && claude-config | grep -q 'remote  OFF'"
+assert_in_subshell "claude-config status reports yolo OFF by default" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES' && claude-config | grep -q 'yolo    OFF'"
+assert_in_subshell "claude-config rejects unknown setting (exit 2)" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config bogus >/dev/null 2>&1; [ \$? -eq 2 ]"
+
+# === Flag-injection behavior (the headline feature — exercised directly) ===
+# Default (nothing opted in), interactive, with a prompt: NO flags injected.
+assert_in_subshell "default opt-out: no flags injected for interactive prompt" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude_launch_flags tty 'fix bug'; [ \${#CLAUDE_LAUNCH_FLAGS[@]} -eq 0 ]"
+
+# Remote ON + interactive + prompt: injects exactly --remote-control + a name
+# (2 elements), and the user's prompt is NOT in the flags array (the blocker
+# regression guard — proves --remote-control cannot swallow the prompt).
+assert_in_subshell "remote on: injects --remote-control with explicit name" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config remote on >/dev/null; claude_launch_flags tty 'fix bug'; [ \"\${CLAUDE_LAUNCH_FLAGS[0]}\" = '--remote-control' ] && [ \${#CLAUDE_LAUNCH_FLAGS[@]} -eq 2 ]"
+assert_in_subshell "remote on: user prompt is NOT captured into the flags (anti prompt-swallow)" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config remote on >/dev/null; claude_launch_flags tty 'fix bug'; ! printf '%s\n' \"\${CLAUDE_LAUNCH_FLAGS[@]}\" | grep -qx 'fix bug'"
+
+# Remote ON but NON-interactive (no TTY): suppressed.
+assert_in_subshell "remote on but non-tty: no --remote-control" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config remote on >/dev/null; claude_launch_flags other 'fix bug'; ! printf '%s\n' \"\${CLAUDE_LAUNCH_FLAGS[@]:-}\" | grep -q -- '--remote-control'"
+
+# Remote ON + interactive + print mode (-p / --print): suppressed.
+assert_in_subshell "remote on but -p print mode: no --remote-control" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config remote on >/dev/null; claude_launch_flags tty -p 'do x'; ! printf '%s\n' \"\${CLAUDE_LAUNCH_FLAGS[@]:-}\" | grep -q -- '--remote-control'"
+assert_in_subshell "remote on but --print mode: no --remote-control" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config remote on >/dev/null; claude_launch_flags tty --print 'do x'; ! printf '%s\n' \"\${CLAUDE_LAUNCH_FLAGS[@]:-}\" | grep -q -- '--remote-control'"
+
+# False-positive guard: a prompt that merely CONTAINS the token '-p' must NOT
+# be treated as print mode (positional scan, not substring match).
+assert_in_subshell "prompt containing '-p' is not mistaken for print mode" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config remote on >/dev/null; claude_launch_flags tty 'tell me about the -p flag'; printf '%s\n' \"\${CLAUDE_LAUNCH_FLAGS[@]}\" | grep -q -- '--remote-control'"
+
+# YOLO ON: injects --dangerously-skip-permissions regardless of TTY.
+assert_in_subshell "yolo on: injects --dangerously-skip-permissions" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config yolo on >/dev/null; claude_launch_flags other 'x'; printf '%s\n' \"\${CLAUDE_LAUNCH_FLAGS[@]}\" | grep -q -- '--dangerously-skip-permissions'"
+assert_in_subshell "yolo off: no --dangerously-skip-permissions" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude_launch_flags tty 'x'; ! printf '%s\n' \"\${CLAUDE_LAUNCH_FLAGS[@]:-}\" | grep -q -- '--dangerously-skip-permissions'"
+
+# Both ON + interactive: both flags present, prompt still not swallowed.
+assert_in_subshell "yolo+remote on: both flags injected, prompt preserved" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config yolo on >/dev/null; claude-config remote on >/dev/null; claude_launch_flags tty 'fix bug'; printf '%s\n' \"\${CLAUDE_LAUNCH_FLAGS[@]}\" | grep -q -- '--remote-control' && printf '%s\n' \"\${CLAUDE_LAUNCH_FLAGS[@]}\" | grep -q -- '--dangerously-skip-permissions' && ! printf '%s\n' \"\${CLAUDE_LAUNCH_FLAGS[@]}\" | grep -qx 'fix bug'"
 
 _test_report

--- a/ai/claude/aliases_test.sh
+++ b/ai/claude/aliases_test.sh
@@ -88,6 +88,20 @@ assert_in_subshell "claude-config status reports yolo OFF by default" \
 assert_in_subshell "claude-config rejects unknown setting (exit 2)" \
     "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config bogus >/dev/null 2>&1; [ \$? -eq 2 ]"
 
+# === claude-config doctor (single-binary diagnostic) ===
+# Header line always printed.
+assert_in_subshell "doctor prints the resolved binary line" \
+    "export XDG_CONFIG_HOME=\$(mktemp -d); . '$ALIASES'; claude-config doctor 2>&1 | grep -q 'command claude ->'"
+# Exactly one claude on a controlled PATH: no warning, exit 0, resolves to it.
+assert_in_subshell "doctor: single binary => no warning, exit 0" \
+    "H=\$(mktemp -d); mkdir -p \"\$H/b1\"; : > \"\$H/b1/claude\"; chmod +x \"\$H/b1/claude\"; export PATH=\"\$H/b1:/usr/bin:/bin\"; . '$ALIASES'; out=\$(claude-config doctor 2>&1); rc=\$?; [ \$rc -eq 0 ] && printf '%s' \"\$out\" | grep -q \"\$H/b1/claude\" && ! printf '%s' \"\$out\" | grep -q WARNING"
+# Two claude binaries on PATH: warns and returns non-zero.
+assert_in_subshell "doctor: multiple binaries => WARNING + nonzero" \
+    "H=\$(mktemp -d); mkdir -p \"\$H/b1\" \"\$H/b2\"; : > \"\$H/b1/claude\"; : > \"\$H/b2/claude\"; chmod +x \"\$H/b1/claude\" \"\$H/b2/claude\"; export PATH=\"\$H/b1:\$H/b2:/usr/bin:/bin\"; . '$ALIASES'; claude-config doctor >/dev/null 2>&1; [ \$? -ne 0 ]"
+# De-dups a binary that appears under repeated PATH entries (one logical claude).
+assert_in_subshell "doctor: dedups repeated PATH entries (no false warning)" \
+    "H=\$(mktemp -d); mkdir -p \"\$H/b1\"; : > \"\$H/b1/claude\"; chmod +x \"\$H/b1/claude\"; export PATH=\"\$H/b1:\$H/b1:/usr/bin:/bin\"; . '$ALIASES'; claude-config doctor >/dev/null 2>&1; [ \$? -eq 0 ]"
+
 # === Flag-injection behavior (the headline feature — exercised directly) ===
 # Default (nothing opted in), interactive, with a prompt: NO flags injected.
 assert_in_subshell "default opt-out: no flags injected for interactive prompt" \

--- a/docs/machine-local-overrides.md
+++ b/docs/machine-local-overrides.md
@@ -42,13 +42,22 @@ locally without changing the repo:
 ```zsh
 # ~/.zshrc.local
 claude() {
-    if _claude_yolo_enabled; then
+    if [ -f "$CLAUDE_YOLO_FILE" ]; then
         sf ai claude -- --dangerously-skip-permissions "$@"
     else
         sf ai claude -- "$@"
     fi
 }
 ```
+
+> The launch config is two opt-in sentinel files under `~/.config/claude/`
+> (`yolo.enabled`, `remote.enabled`), both **OFF by default**. Toggle them with
+> `claude-config yolo on|off` / `claude-config remote on|off`. `remote` adds
+> `--remote-control` to interactive sessions only; turn it on per machine where
+> you want it, and `claude-config remote off` to disable. (The old
+> `_claude_yolo_enabled` helper was removed — Claude Code's shell-snapshot
+> strips `_`-prefixed functions; check the `$CLAUDE_YOLO_FILE` sentinel inline
+> instead, as above.)
 
 ### Add a host-specific PATH entry
 
@@ -87,7 +96,7 @@ export EDITOR="code --wait"
 ```
 ~/.zshrc  (symlink → dotfiles/opt/profiles/.zshrc)
   └─ sources opt/profiles/.zshrc content
-       └─ sources ~/.config/claude/aliases.sh  (claude, claude-toggle)
+       └─ sources ~/.config/claude/aliases.sh  (claude, claude-config)
        └─ ... other tools ...
        └─ sources ~/.zshrc.local  ← your overrides land here, last
 ```

--- a/docs/mbo/index.md
+++ b/docs/mbo/index.md
@@ -26,6 +26,7 @@ done` (also `parked`, `superseded`).
 | `memory-provisioning` | [design](./designs/memory-provisioning.md) | [spec](./specs/memory-provisioning.md) | [plan](./plans/memory-provisioning.md) | [#134](https://github.com/sfc-gh-eraigosa/dotfiles/issues/134) | #135 | in-review |
 | `shell-portability` | — | [spec](./specs/shell-portability.md) | — | — | (this PR) | building |
 | `gsl-visual-improvements` | [design](./designs/gsl-visual-improvements.md) | [spec](./specs/gsl-visual-improvements.md) | [plan](./plans/gsl-visual-improvements.md) | [#54](https://github.com/sfc-gh-eraigosa/dotfiles/issues/54) | #55 | in-review |
+| `claude-config` | — | [spec](./specs/claude-config.md) | [plan](./plans/claude-config.md) | — | #126 | in-review |
 
 ## Merged / historical (pre-MBO — tracking columns best-effort)
 

--- a/docs/mbo/plans/claude-config.md
+++ b/docs/mbo/plans/claude-config.md
@@ -26,12 +26,21 @@ in PR #126) and folds in the architecture-team review verdict.
 - **Contract drift risk**: `CLAUDE_YOLO_FILE` marked as a frozen cross-repo
   contract (comment + guard test).
 
+**Follow-up scope (binary consolidation):** a machine could accumulate two
+`claude` binaries — the orchestrated npm/brew one and the official native
+installer's `~/.local` copy — differing in version with a PATH-order foot-gun.
+`claude_install.sh` is made the single source of truth: after installing the
+canonical copy it removes the native install (guarded/idempotent), and
+`claude-config doctor` reports the resolved binary and flags duplicates.
+
 ## 2. File inventory
 
 | Path | Purpose | Implements |
 | :-- | :-- | :-- |
-| `ai/claude/aliases.sh` | `claude` wrapper, `claude_launch_flags`, `claude-config` tool, config vars, contract comment, security note | spec §3, §4, §7 |
-| `ai/claude/aliases_test.sh` | 31-case driver: source-level + behavioral | spec §5, §6 |
+| `ai/claude/aliases.sh` | `claude` wrapper, `claude_launch_flags`, `claude-config` tool (+`doctor`), config vars, contract comment, security note | spec §3, §4, §7 |
+| `ai/claude/aliases_test.sh` | 35-case driver: source-level + behavioral + doctor | spec §5, §6 |
+| `opt/scripts/system/claude_install.sh` | sourceable refactor; `resolve_canonical_claude` + `cleanup_conflicting_installs` (single canonical binary) | spec §4.7, §7 |
+| `opt/scripts/system/claude_install_test.sh` | 10-case driver for the cleanup decision (sandboxed `$HOME`) | spec §5.7 |
 | `docs/machine-local-overrides.md` | refreshed override example (drop removed `_claude_yolo_enabled`); opt-in note | spec §2, §8 |
 | `opt/profiles/.zshrc` | comment refresh (`claude-config`) | — |
 | `opt/profiles/.bashrc` | comment refresh (`claude-config`) | — |
@@ -39,8 +48,9 @@ in PR #126) and folds in the architecture-team review verdict.
 | `docs/mbo/plans/claude-config.md` | this plan | — |
 | `docs/mbo/index.md` | Active-table registration | — |
 
-No changes to `install.sh`/`scripts/test.sh`/`sync-skills` — `install_claude_skills.sh`
-already symlinks `aliases.sh`; the test driver runs under the existing shell-test path.
+`install.sh` already calls `claude_install.sh` (no edit). Both `*_test.sh` are
+auto-discovered by `make shell-test` (no wiring). `install_claude_skills.sh`
+already symlinks `aliases.sh`.
 
 ## 3. Interface contracts
 
@@ -87,6 +97,10 @@ Frozen: `CLAUDE_YOLO_FILE` = abs path to YOLO sentinel (read by playground
 | 5d prompt-swallow | `user prompt is NOT captured into the flags`, `yolo+remote on: … prompt preserved` |
 | 5e print false-positive | `prompt containing '-p' is not mistaken for print mode` |
 | 6 no `_` helpers | `no underscore-prefixed helper functions` |
+| 7a native cleanup | `removes native install when canonical is confirmed`, `keeps native install when no canonical is confirmed`, `skips when canonical also resolves under ~/.local` |
+| 7b cleanup safety | `keeps a convenience symlink that points at the canonical binary`, `no-op when there is no native install`, `cleanup never touches ~/.claude (documented)` |
+| 8a doctor report | `doctor prints the resolved binary line` |
+| 8b doctor duplicates | `doctor: single binary => no warning, exit 0`, `doctor: multiple binaries => WARNING + nonzero`, `doctor: dedups repeated PATH entries` |
 | §7 contract | `CLAUDE_YOLO_FILE cross-repo contract var preserved`, `remote-control passes an explicit session name` |
 
 ## 6. Integration & rollout

--- a/docs/mbo/plans/claude-config.md
+++ b/docs/mbo/plans/claude-config.md
@@ -1,0 +1,106 @@
+# claude-config — implementation plan
+
+- **Slug:** claude-config
+- **Date:** 2026-06-07
+- **Status:** In-progress
+- **Relates to:** spec `../specs/claude-config.md` · PR #126 · consumer: playground PR #73
+
+## 1. Summary & verdict
+
+Rename `claude-toggle` → `claude-config` and add an opt-in `--remote-control`
+launch flag alongside the existing opt-in YOLO flag, both via sentinel files
+under `$XDG_CONFIG_HOME/claude`. This plan is **retroactive** (the code shipped
+in PR #126) and folds in the architecture-team review verdict.
+
+**Review verdict:** *needs-changes → addressed.* Must-fixes resolved:
+- **Prompt-swallow blocker** (`--remote-control [name]` greedily eats the prompt):
+  fixed by injecting an explicit name `--remote-control "$(basename "$PWD")"` via
+  a bash/zsh **array** (`command claude "${CLAUDE_LAUNCH_FLAGS[@]}" "$@"`).
+- **Security default-posture** (remote default-ON across synced machines): fixed
+  by flipping to **opt-in/default-OFF** (`remote.enabled`, symmetric with YOLO) —
+  supersedes the original inverted `remote.disabled` sentinel.
+- **No real test coverage** (only a blind `grep 'print'`): fixed by extracting
+  `claude_launch_flags()` and adding 13 behavioral cases incl. the prompt-swallow
+  regression guard.
+- **MBO non-compliance**: this spec + plan + `index.md` row + PR-body links.
+- **Contract drift risk**: `CLAUDE_YOLO_FILE` marked as a frozen cross-repo
+  contract (comment + guard test).
+
+## 2. File inventory
+
+| Path | Purpose | Implements |
+| :-- | :-- | :-- |
+| `ai/claude/aliases.sh` | `claude` wrapper, `claude_launch_flags`, `claude-config` tool, config vars, contract comment, security note | spec §3, §4, §7 |
+| `ai/claude/aliases_test.sh` | 31-case driver: source-level + behavioral | spec §5, §6 |
+| `docs/machine-local-overrides.md` | refreshed override example (drop removed `_claude_yolo_enabled`); opt-in note | spec §2, §8 |
+| `opt/profiles/.zshrc` | comment refresh (`claude-config`) | — |
+| `opt/profiles/.bashrc` | comment refresh (`claude-config`) | — |
+| `docs/mbo/specs/claude-config.md` | the spec | — |
+| `docs/mbo/plans/claude-config.md` | this plan | — |
+| `docs/mbo/index.md` | Active-table registration | — |
+
+No changes to `install.sh`/`scripts/test.sh`/`sync-skills` — `install_claude_skills.sh`
+already symlinks `aliases.sh`; the test driver runs under the existing shell-test path.
+
+## 3. Interface contracts
+
+```sh
+# Populates global array CLAUDE_LAUNCH_FLAGS. TTY passed in for testability.
+claude_launch_flags <tty_state> <args...>     # tty_state = "tty" | anything else
+#   yolo.enabled            -> += --dangerously-skip-permissions   (any mode)
+#   remote.enabled & tty &  -> += --remote-control "$(basename "$PWD")"
+#     not (-p|--print in args)
+claude()                                       # tmux-anchor; command claude "${CLAUDE_LAUNCH_FLAGS[@]}" "$@"
+claude-config [status] | yolo on|off | remote on|off
+```
+
+Frozen: `CLAUDE_YOLO_FILE` = abs path to YOLO sentinel (read by playground
+`claude-local`; see spec §7).
+
+## 4. TDD build order
+
+1. **Source-level guards** — write greps (no `_` helpers; `CLAUDE_YOLO_FILE=`
+   present; explicit-name injection present). *done-when:* greps pass against the
+   rewritten file.
+2. **`claude_launch_flags` extraction** — refactor decision logic into the pure,
+   array-populating function. *done-when:* defaults inject nothing; yolo/remote
+   gates behave per spec §5.
+3. **Prompt-swallow regression** — assert the user prompt is never an element of
+   `CLAUDE_LAUNCH_FLAGS` and `--remote-control` is followed by a name. *done-when:*
+   case green.
+4. **TTY / print / false-positive gates** — non-TTY, `-p`, `--print`, and
+   `"about -p"` cases. *done-when:* all green.
+5. **opt-in flip** — `remote.enabled` create/remove + status default OFF.
+   *done-when:* config cases green.
+
+## 5. Verification mapping
+
+| Spec rule | Test case (aliases_test.sh) |
+| :-- | :-- |
+| 1 yolo toggle | `claude-config yolo on/off creates/removes yolo sentinel` |
+| 2 remote toggle | `claude-config remote on/off creates/removes enabled sentinel` |
+| 3 defaults | `remote/yolo defaults OFF`, `status reports … OFF by default` |
+| 4 yolo flag | `yolo on/off: …dangerously-skip-permissions` |
+| 5a remote flag | `remote on: injects --remote-control with explicit name` |
+| 5b TTY gate | `remote on but non-tty: no --remote-control` |
+| 5c print gate | `remote on but -p/--print print mode: no --remote-control` |
+| 5d prompt-swallow | `user prompt is NOT captured into the flags`, `yolo+remote on: … prompt preserved` |
+| 5e print false-positive | `prompt containing '-p' is not mistaken for print mode` |
+| 6 no `_` helpers | `no underscore-prefixed helper functions` |
+| §7 contract | `CLAUDE_YOLO_FILE cross-repo contract var preserved`, `remote-control passes an explicit session name` |
+
+## 6. Integration & rollout
+
+`aliases.sh` is symlinked into `~/.config/claude/` by `install_claude_skills.sh`
+and sourced by the profiles — no new wiring. Manual acceptance: on a machine,
+`claude-config remote on`, then in a TTY run `claude "hello"` and confirm the
+session starts with remote-control and the prompt is delivered; `claude-config
+remote off` to revert. Verify a sibling `claude-local` shell still applies YOLO
+from `CLAUDE_YOLO_FILE` and never receives `--remote-control`.
+
+### 6.1 Build leaves / DAG
+
+Not broken out — single PR (#126), no parallel leaves.
+
+> Retroactive plan capturing the shipped PR #126 + the architecture-team review
+> must-fixes. Update `../index.md` state as it moves.

--- a/docs/mbo/specs/claude-config.md
+++ b/docs/mbo/specs/claude-config.md
@@ -35,6 +35,17 @@ opts in per machine. Renames the former `claude-toggle` (YOLO-only) to
   `${CLAUDE_YOLO_FILE:-}` and calls `command claude` directly · *acceptance:* it
   still applies YOLO from the same sentinel and is never given `--remote-control`
   (see §7 contract).
+- **Single canonical binary** — *actor:* user running `install.sh` · *trigger:*
+  `claude_install.sh` (invoked by `install.sh`) · *flow:* installs/updates the
+  orchestrated binary (npm on Linux/WSL, brew cask on macOS), then removes the
+  non-orchestrated native install (`~/.local/bin/claude` →
+  `~/.local/share/claude/…`, `~/.local/state/claude`) when a canonical binary is
+  confirmed · *acceptance:* exactly one `claude` on PATH afterwards; `~/.claude/`
+  untouched; idempotent on re-run.
+- **Diagnose which binary is in use** — *actor:* user · *trigger:*
+  `claude-config doctor` · *flow:* scans `$PATH`, prints the resolved binary,
+  warns + exits non-zero if more than one is found · *acceptance:* one binary ⇒
+  exit 0, no warning; two ⇒ warning + non-zero.
 
 ## 3. Architecture
 
@@ -60,6 +71,11 @@ shell is always bash or zsh). Components, each independently testable:
 5. Remote sentinel present **and** interactive TTY **and** not print mode ⇒ inject
    `--remote-control "$(basename "$PWD")"` (explicit name).
 6. No `_`-prefixed helper functions anywhere in the file.
+7. `claude_install.sh` is the single source of the binary: installs the
+   orchestrated copy then removes the native-installer copy (guarded:
+   only a `~/.local/bin/claude` symlink that points into `~/.local/share/claude/`,
+   only when a canonical claude outside `~/.local` is confirmed; never `~/.claude/`).
+8. `claude-config doctor` reports the resolved binary and flags duplicates.
 
 ## 5. Evaluation criteria (per feature)
 
@@ -75,20 +91,37 @@ shell is always bash or zsh). Components, each independently testable:
 | 5d | **prompt-swallow guard** | remote on ⇒ `--remote-control` carries an explicit name | the user's prompt is **never** an element of `CLAUDE_LAUNCH_FLAGS` | prompt with spaces | prompt preserved as `"$@"` |
 | 5e | print false-positive | prompt containing token `-p` is **not** print mode | — | `claude "about -p"` | `--remote-control` still injected |
 | 6 | no `_` helpers | — | no `^_name()` in file | — | grep-negative passes |
+| 7a | native cleanup | canonical confirmed ⇒ native link+data+state removed | no canonical ⇒ native kept | canonical under `~/.local` ⇒ skip | one binary remains |
+| 7b | cleanup safety | — | convenience symlink to canonical ⇒ kept; `~/.claude/` never touched | no native link ⇒ no-op | idempotent |
+| 8a | doctor report | always prints `command claude -> …` | — | binary not found ⇒ `<not found>` | header present |
+| 8b | doctor duplicates | ≥2 on PATH ⇒ WARNING + non-zero | 1 on PATH ⇒ exit 0, no warning | repeated PATH entries de-duped | correct verdict |
 
 ## 6. Verification harness
 
-`ai/claude/aliases_test.sh` (run: `bash ai/claude/aliases_test.sh`). Layers:
-source-level greps (no `_` helpers; `CLAUDE_YOLO_FILE=` contract var present;
-explicit-name injection present) + runtime behavioral cases that call
-`claude_launch_flags` directly and inspect `CLAUDE_LAUNCH_FLAGS` (deterministic,
-no binary shell-out). **31 cases, all green.** `bash -n` syntax-clean. The
-prompt-swallow regression (rule 5d) is empirically grounded: the real binary
+- `ai/claude/aliases_test.sh` (run: `bash ai/claude/aliases_test.sh`) — source-level
+  greps (no `_` helpers; `CLAUDE_YOLO_FILE=` contract var present; explicit-name
+  injection present) + behavioral cases that call `claude_launch_flags` and
+  inspect `CLAUDE_LAUNCH_FLAGS` (deterministic, no binary shell-out) + `doctor`
+  cases against a controlled `$PATH`. **35 cases.**
+- `opt/scripts/system/claude_install_test.sh` — sources the (now sourceable)
+  installer and exercises `cleanup_conflicting_installs` against a sandboxed
+  `$HOME` with `$CLAUDE_CANONICAL_BIN` overridden. **10 cases.**
+- Both auto-discovered by `make shell-test`. `bash -n` + shellcheck clean.
+
+The prompt-swallow regression (rule 5d) is empirically grounded: the real binary
 binds the optional `--remote-control [name]` arg greedily, so a bare flag would
 consume the prompt — the explicit name prevents it.
 
 ## 7. Prerequisites / dependencies
 
+- **Install flow:** `install.sh` → `opt/scripts/system/claude_install.sh` is the
+  single orchestrated installer (npm-global `@anthropic-ai/claude-code` on
+  Linux/WSL; brew cask `claude-code` on macOS). The official native installer
+  (`curl claude.ai/install.sh`, layout `~/.local/bin/claude` →
+  `~/.local/share/claude/versions/<v>`) is a *second*, self-updating copy that
+  dotfiles does not orchestrate; the installer consolidates it away. The wrapper
+  resolves the binary purely via `$PATH` (no hard-coded path → stays portable
+  across nvm node versions and macOS).
 - **CROSS-REPO CONTRACT (frozen):** the shell variable **`CLAUDE_YOLO_FILE`** —
   name and value semantics (absolute path to the YOLO sentinel) — is read by
   playground PR #73's nano-carried `claude-local` (`~/.config/nano/ollama-client.sh`),

--- a/docs/mbo/specs/claude-config.md
+++ b/docs/mbo/specs/claude-config.md
@@ -1,0 +1,118 @@
+# claude-config — spec
+
+- **Slug:** claude-config
+- **Date:** 2026-06-07
+- **Status:** Approved
+- **Relates to:** PR #126 · consumer: playground PR #73 (`claude-local`)
+
+## 1. Goal
+
+Give the `claude` shell wrapper a small, discoverable launch-config tool —
+`claude-config` — that controls two opt-in launch flags via sentinel files under
+`$XDG_CONFIG_HOME/claude`: YOLO (`--dangerously-skip-permissions`) and Remote
+Control (`--remote-control` on interactive sessions). Both default **OFF**, so a
+fresh or shared machine behaves like plain `claude` until the user explicitly
+opts in per machine. Renames the former `claude-toggle` (YOLO-only) to
+`claude-config`.
+
+## 2. Use cases
+
+- **Enable remote-control on a machine** — *actor:* user · *trigger:*
+  `claude-config remote on` · *flow:* creates `~/.config/claude/remote.enabled`;
+  subsequent interactive `claude` invocations inject `--remote-control <dir>` ·
+  *acceptance:* sentinel exists; an interactive `claude "fix bug"` runs as
+  `command claude --remote-control <dir> "fix bug"` with the prompt intact.
+- **Run headless / piped unchanged** — *actor:* user/SDK · *trigger:*
+  `claude -p "..."` or a piped/redirected stdin · *flow:* the wrapper detects
+  print mode or a non-TTY and skips `--remote-control` · *acceptance:* no
+  `--remote-control` injected; `--dangerously-skip-permissions` still honored if
+  YOLO is on.
+- **Inspect state** — *actor:* user · *trigger:* `claude-config` /
+  `claude-config status` · *flow:* prints `yolo` and `remote` as `ON`/`OFF` ·
+  *acceptance:* both default to `OFF` with no sentinels present.
+- **Local-model sibling keeps working** — *actor:* playground `claude-local` ·
+  *trigger:* user runs `claude-local` in the same shell · *flow:* it reads
+  `${CLAUDE_YOLO_FILE:-}` and calls `command claude` directly · *acceptance:* it
+  still applies YOLO from the same sentinel and is never given `--remote-control`
+  (see §7 contract).
+
+## 3. Architecture
+
+Single sourced file `ai/claude/aliases.sh` (loaded by `.zshrc`/`.bashrc`; runtime
+shell is always bash or zsh). Components, each independently testable:
+
+- **Config vars** — `CLAUDE_CONFIG_DIR`, `CLAUDE_YOLO_FILE` (frozen cross-repo
+  contract, see §7), `CLAUDE_REMOTE_ENABLED_FILE`.
+- **`claude_launch_flags(tty_state, args…)`** — pure decision logic; populates the
+  global array `CLAUDE_LAUNCH_FLAGS`. TTY state is **passed in** (not probed) for
+  deterministic testing. Top-level name (no leading `_`) so Claude Code's
+  shell-snapshot does not strip it.
+- **`claude()` wrapper** — tmux-anchor (unchanged) → computes TTY state → calls
+  `claude_launch_flags` → `command claude "${CLAUDE_LAUNCH_FLAGS[@]}" "$@"`.
+- **`claude-config()` tool** — `yolo|remote on|off`, `status`.
+
+## 4. Behavior / features
+
+1. `claude-config yolo on|off` toggles `yolo.enabled`.
+2. `claude-config remote on|off` toggles `remote.enabled`.
+3. `claude-config` / `status` prints both states (default `OFF`).
+4. YOLO sentinel present ⇒ inject `--dangerously-skip-permissions` (any mode).
+5. Remote sentinel present **and** interactive TTY **and** not print mode ⇒ inject
+   `--remote-control "$(basename "$PWD")"` (explicit name).
+6. No `_`-prefixed helper functions anywhere in the file.
+
+## 5. Evaluation criteria (per feature)
+
+| # | Rule | Fires | Must-not-fire | Edge | Pass |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| 1 | yolo toggle | `yolo on` creates sentinel | `yolo off` leaves it | unknown subarg ⇒ exit 2 | sentinel state matches |
+| 2 | remote toggle | `remote on` creates sentinel | `remote off` leaves it | unknown subarg ⇒ exit 2 | sentinel state matches |
+| 3 | defaults | — | fresh source has neither sentinel | status shows both `OFF` | both `OFF` |
+| 4 | yolo flag | yolo on ⇒ `--dangerously-skip-permissions` | yolo off ⇒ absent | present even when non-TTY | flag present/absent |
+| 5a | remote flag | remote on + TTY + no print ⇒ `--remote-control` | remote off ⇒ absent | both yolo+remote ⇒ both flags | flag present |
+| 5b | TTY gate | — | remote on + non-TTY ⇒ no `--remote-control` | piped stdin | absent |
+| 5c | print gate | — | remote on + `-p`/`--print` ⇒ no `--remote-control` | flag anywhere in args | absent |
+| 5d | **prompt-swallow guard** | remote on ⇒ `--remote-control` carries an explicit name | the user's prompt is **never** an element of `CLAUDE_LAUNCH_FLAGS` | prompt with spaces | prompt preserved as `"$@"` |
+| 5e | print false-positive | prompt containing token `-p` is **not** print mode | — | `claude "about -p"` | `--remote-control` still injected |
+| 6 | no `_` helpers | — | no `^_name()` in file | — | grep-negative passes |
+
+## 6. Verification harness
+
+`ai/claude/aliases_test.sh` (run: `bash ai/claude/aliases_test.sh`). Layers:
+source-level greps (no `_` helpers; `CLAUDE_YOLO_FILE=` contract var present;
+explicit-name injection present) + runtime behavioral cases that call
+`claude_launch_flags` directly and inspect `CLAUDE_LAUNCH_FLAGS` (deterministic,
+no binary shell-out). **31 cases, all green.** `bash -n` syntax-clean. The
+prompt-swallow regression (rule 5d) is empirically grounded: the real binary
+binds the optional `--remote-control [name]` arg greedily, so a bare flag would
+consume the prompt — the explicit name prevents it.
+
+## 7. Prerequisites / dependencies
+
+- **CROSS-REPO CONTRACT (frozen):** the shell variable **`CLAUDE_YOLO_FILE`** —
+  name and value semantics (absolute path to the YOLO sentinel) — is read by
+  playground PR #73's nano-carried `claude-local` (`~/.config/nano/ollama-client.sh`),
+  which sources into the same interactive shell, reads `${CLAUDE_YOLO_FILE:-}`,
+  and calls `command claude` directly (never the `claude()` wrapper). Therefore:
+  (a) `CLAUDE_YOLO_FILE` must not be renamed/inlined or have its path semantics
+  changed; (b) the `--remote-control` injection cannot leak into `claude-local`
+  (it bypasses the wrapper) — verified; (c) the `claude-toggle`→`claude-config`
+  rename and the `yolo.enabled` filename are **not** part of the contract. An
+  inline comment in `aliases.sh` and a guard test mark this coupling.
+
+## 8. Out of scope (and why)
+
+- Inverted/default-ON remote-control — rejected: default-OFF/opt-in is the
+  agreed posture (symmetric with YOLO; quiet on fresh/shared/remote hosts).
+- Committed/synced kill-switch or central policy — the sentinels are per-machine
+  local by design (same model as the existing YOLO sentinel).
+- Cross-host `claude-local` wiring (tunnel endpoints) — owned by the nano project.
+
+## 9. Rollback
+
+Revert PR #126. The sentinel files under `~/.config/claude/` are inert without
+the wrapper; no global state is written (nothing touches `~/.claude/`).
+
+> Aligned with the architecture-team review of PR #126 (sysarch/secarch/principal
+> + adversary). The matching plan is `../plans/claude-config.md`. Registered in
+> `../index.md`.

--- a/opt/profiles/.bashrc
+++ b/opt/profiles/.bashrc
@@ -270,5 +270,5 @@ source <(openclaw completion --shell bash)
 # Gemini CLI helpers: gemini() wrapper with tmux auto-anchor
 [ -f "${HOME}/.config/gemini/aliases.sh" ] && . "${HOME}/.config/gemini/aliases.sh"
 
-# Claude Code CLI helpers: claude (wrapper) and claude-toggle (YOLO on/off)
+# Claude Code CLI helpers: claude (wrapper) and claude-config (yolo/remote on/off)
 [ -f "${HOME}/.config/claude/aliases.sh" ] && . "${HOME}/.config/claude/aliases.sh"

--- a/opt/profiles/.zshrc
+++ b/opt/profiles/.zshrc
@@ -192,7 +192,7 @@ source $ZSH/oh-my-zsh.sh
 # critical for any AI assistant (Claude, Gemini) that calls `gss push`.
 unalias gss 2>/dev/null
 
-# Claude Code CLI helpers: claude (wrapper) and claude-toggle (YOLO on/off)
+# Claude Code CLI helpers: claude (wrapper) and claude-config (yolo/remote on/off)
 [ -f "${HOME}/.config/claude/aliases.sh" ] && . "${HOME}/.config/claude/aliases.sh"
 
 # You may need to manually set your language environment

--- a/opt/profiles/.zshrc
+++ b/opt/profiles/.zshrc
@@ -399,8 +399,12 @@ else
   _comp_mtime=$(stat -c %Y "$_comp_dumpfile" 2>/dev/null || echo 0)
 fi
 
+# -i: ignore (don't prompt about) insecure $fpath dirs. Without it, an
+# insecure completion dir makes compinit try to prompt, which on a
+# non-interactive/headless shell aborts with "not interactive and can't open
+# terminal" — breaking startup and the rc_test.sh clean-source check.
 if (( $(date +%s) - _comp_mtime > 86400 )); then
-  compinit
+  compinit -i
 else
   compinit -C
 fi

--- a/opt/scripts/system/claude_install.sh
+++ b/opt/scripts/system/claude_install.sh
@@ -8,27 +8,37 @@
 #   - Linux:       Debian/Ubuntu, Raspberry Pi (arm64/armv7l), and NVIDIA Jetson — installed via npm.
 #   - Windows WSL: Treated as Linux — installed via npm.
 #
+# SINGLE CANONICAL BINARY: this installer is the one source of truth for the
+# `claude` binary. After (re)installing the canonical copy, it removes the
+# official *native* installer's copy (the `curl claude.ai/install.sh` layout at
+# ~/.local/bin/claude -> ~/.local/share/claude/...) when present, so a machine
+# never ends up with two `claude` binaries + two self-update mechanisms and a
+# PATH-order foot-gun. Auth/config under ~/.claude/ is never touched. The
+# `claude` shell wrapper (ai/claude/aliases.sh) resolves the binary via PATH;
+# `claude-config doctor` reports which binary wins and flags any duplicates.
+#
 # Re-running this script is safe and idempotent: it updates an existing install
-# rather than re-installing from scratch.
-
-set -e
+# rather than re-installing from scratch, and the cleanup is a no-op once there
+# is only one binary.
 
 NPM_PKG="@anthropic-ai/claude-code"
 
-# Detect platform
-OS_KIND="unknown"
-case "$(uname -s)" in
-    Darwin*) OS_KIND="macos" ;;
-    Linux*)
-        if grep -qi microsoft /proc/version 2>/dev/null; then
-            OS_KIND="wsl"
-        else
-            OS_KIND="linux"
-        fi
-        ;;
-esac
+# Detect platform -> echoes one of: macos | wsl | linux | unknown
+detect_platform() {
+    case "$(uname -s)" in
+        Darwin*) echo "macos" ;;
+        Linux*)
+            if grep -qi microsoft /proc/version 2>/dev/null; then
+                echo "wsl"
+            else
+                echo "linux"
+            fi
+            ;;
+        *) echo "unknown" ;;
+    esac
+}
 
-echo "Detected platform: $OS_KIND"
+OS_KIND="$(detect_platform)"
 
 install_via_brew() {
     if ! command -v brew &> /dev/null; then
@@ -76,21 +86,109 @@ install_via_npm() {
     fi
 }
 
-case "$OS_KIND" in
-    macos) install_via_brew ;;
-    linux|wsl) install_via_npm ;;
-    *)
-        echo "ERROR: Unsupported platform: $(uname -s)"
-        exit 1
-        ;;
-esac
+# Resolve the path to the dotfiles-orchestrated ("canonical") claude binary —
+# the npm-global (Linux/WSL) or brew (macOS) one — explicitly NOT a copy under
+# ~/.local. Echoes the path, or nothing if none can be confirmed. Tests/hosts
+# may override the result via $CLAUDE_CANONICAL_BIN.
+resolve_canonical_claude() {
+    if [ -n "${CLAUDE_CANONICAL_BIN:-}" ]; then
+        echo "$CLAUDE_CANONICAL_BIN"
+        return 0
+    fi
+    # macOS: the brew cask binary.
+    if [ "$OS_KIND" = "macos" ] && command -v brew &> /dev/null; then
+        local bp; bp="$(brew --prefix 2>/dev/null)/bin/claude"
+        [ -x "$bp" ] && { echo "$bp"; return 0; }
+    fi
+    # Linux/WSL (and macOS npm fallback): the npm global bin.
+    local prefix; prefix="$(npm config get prefix 2>/dev/null || true)"
+    if [ -n "$prefix" ] && [ -x "$prefix/bin/claude" ]; then
+        echo "$prefix/bin/claude"
+        return 0
+    fi
+    # Last resort: the first claude on PATH that is not under ~/.local.
+    local c
+    for c in $(type -ap claude 2>/dev/null); do
+        case "$c" in
+            "$HOME/.local/"*) continue ;;
+            *) [ -x "$c" ] && { echo "$c"; return 0; } ;;
+        esac
+    done
+    return 0
+}
 
-# Verify
-if command -v claude &> /dev/null; then
-    echo "Claude Code installed successfully!"
-    claude --version || true
-    echo "Run 'claude' to authenticate and get started."
-else
-    echo "WARNING: 'claude' is not on PATH after install. You may need to open a new shell."
-    echo "         npm global bin: $(npm config get prefix 2>/dev/null)/bin"
+# Remove the official native-installer copy of claude so only the canonical
+# (npm/brew) binary remains. Guarded + idempotent + non-destructive to config:
+#   - acts only on a ~/.local/bin/claude that is a SYMLINK INTO
+#     ~/.local/share/claude/ (the native-installer layout); a convenience
+#     symlink to the canonical binary is left alone;
+#   - removes nothing unless a canonical claude OUTSIDE ~/.local is confirmed
+#     (so a failed install never leaves the user with no claude);
+#   - never touches ~/.claude/ (auth + settings live there).
+cleanup_conflicting_installs() {
+    local native_link="$HOME/.local/bin/claude"
+    local native_data="$HOME/.local/share/claude"
+    local native_state="$HOME/.local/state/claude"
+
+    # No native symlink => nothing to consolidate.
+    [ -L "$native_link" ] || return 0
+
+    local target; target="$(readlink "$native_link" 2>/dev/null || true)"
+    case "$target" in
+        */.local/share/claude/*) ;;          # native installer — candidate
+        *) return 0 ;;                        # points elsewhere (e.g. canonical) — keep
+    esac
+
+    local canonical; canonical="$(resolve_canonical_claude)"
+    if [ -z "$canonical" ] || [ ! -x "$canonical" ]; then
+        echo "  Skipping native-install cleanup: no canonical claude confirmed (leaving ~/.local install intact)."
+        return 0
+    fi
+    case "$canonical" in
+        "$HOME/.local/"*)
+            echo "  Skipping native-install cleanup: canonical also resolves under ~/.local."
+            return 0 ;;
+    esac
+
+    echo "Consolidating to a single Claude binary (canonical: $canonical)."
+    echo "Removing the non-orchestrated native install:"
+    echo "  - $native_link -> $target"
+    rm -f "$native_link"
+    if [ -d "$native_data" ]; then echo "  - $native_data/"; rm -rf "$native_data"; fi
+    if [ -d "$native_state" ]; then echo "  - $native_state/"; rm -rf "$native_state"; fi
+    echo "Done. ~/.claude/ (auth + settings) was not touched."
+}
+
+main() {
+    set -e
+    echo "Detected platform: $OS_KIND"
+
+    case "$OS_KIND" in
+        macos) install_via_brew ;;
+        linux|wsl) install_via_npm ;;
+        *)
+            echo "ERROR: Unsupported platform: $(uname -s)"
+            exit 1
+            ;;
+    esac
+
+    # Enforce a single canonical binary (remove any native-installer copy).
+    cleanup_conflicting_installs
+
+    # Verify
+    if command -v claude &> /dev/null; then
+        echo "Claude Code installed successfully!"
+        claude --version || true
+        echo "Run 'claude' to authenticate and get started."
+        echo "Tip: 'claude-config doctor' reports which binary is in use."
+    else
+        echo "WARNING: 'claude' is not on PATH after install. You may need to open a new shell."
+        echo "         npm global bin: $(npm config get prefix 2>/dev/null)/bin"
+    fi
+}
+
+# Run only when executed directly; sourcing (e.g. the test driver) loads the
+# functions without performing an install.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main "$@"
 fi

--- a/opt/scripts/system/claude_install_test.sh
+++ b/opt/scripts/system/claude_install_test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Test driver for opt/scripts/system/claude_install.sh
+#
+# Focuses on cleanup_conflicting_installs() — the guarded removal of the
+# official native-installer copy of claude so only the canonical (npm/brew)
+# binary remains. The script is sourceable (main() runs only when executed
+# directly), so we load the functions and exercise the decision logic against a
+# sandboxed $HOME. Canonical resolution is overridden via $CLAUDE_CANONICAL_BIN.
+#
+# Run: bash opt/scripts/system/claude_install_test.sh
+set -u
+
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../../ai/_test_helpers.sh
+. "${SELF_DIR}/../../../ai/_test_helpers.sh"
+
+SCRIPT="${SELF_DIR}/claude_install.sh"
+
+# === Source-level checks ===
+assert_grep "script is sourceable (BASH_SOURCE guard)" \
+    'BASH_SOURCE\[0\]' "$SCRIPT"
+assert_grep "defines cleanup_conflicting_installs" \
+    '^cleanup_conflicting_installs\(\)' "$SCRIPT"
+assert_grep "cleanup never touches ~/.claude (documented)" \
+    'never touches \~?/?\.claude' "$SCRIPT"
+
+# Sourcing must NOT trigger an install (main guarded behind BASH_SOURCE==$0).
+assert_in_subshell "sourcing loads functions without running install" \
+    ". '$SCRIPT' && type cleanup_conflicting_installs >/dev/null 2>&1 && type resolve_canonical_claude >/dev/null 2>&1"
+
+# === cleanup_conflicting_installs behavior (sandboxed HOME) ===
+# Helper: a sandbox with a native-installer layout. NATIVE link -> ~/.local/share/claude/...
+mk_native='H=$(mktemp -d); export HOME="$H";
+  mkdir -p "$H/.local/bin" "$H/.local/share/claude/versions" "$H/.local/state/claude" "$H/realbin";
+  : > "$H/.local/share/claude/versions/9.9.9";
+  ln -s "$H/.local/share/claude/versions/9.9.9" "$H/.local/bin/claude";
+  : > "$H/realbin/claude"; chmod +x "$H/realbin/claude";'
+
+# 1) Native install present + canonical confirmed => native link/data/state removed.
+assert_in_subshell "removes native install when canonical is confirmed" \
+    "$mk_native export CLAUDE_CANONICAL_BIN=\"\$H/realbin/claude\"; . '$SCRIPT'; cleanup_conflicting_installs >/dev/null 2>&1; [ ! -e \"\$H/.local/bin/claude\" ] && [ ! -d \"\$H/.local/share/claude\" ] && [ ! -d \"\$H/.local/state/claude\" ]"
+
+# 2) Native install present but canonical NOT confirmed (path not executable) => kept.
+assert_in_subshell "keeps native install when no canonical is confirmed" \
+    "$mk_native export CLAUDE_CANONICAL_BIN=\"\$H/nope/claude\"; . '$SCRIPT'; cleanup_conflicting_installs >/dev/null 2>&1; [ -L \"\$H/.local/bin/claude\" ] && [ -d \"\$H/.local/share/claude\" ]"
+
+# 3) Canonical resolves UNDER ~/.local => skip (don't delete the thing we'd keep).
+assert_in_subshell "skips when canonical also resolves under ~/.local" \
+    "$mk_native mkdir -p \"\$H/.local/altbin\"; : > \"\$H/.local/altbin/claude\"; chmod +x \"\$H/.local/altbin/claude\"; export CLAUDE_CANONICAL_BIN=\"\$H/.local/altbin/claude\"; . '$SCRIPT'; cleanup_conflicting_installs >/dev/null 2>&1; [ -L \"\$H/.local/bin/claude\" ]"
+
+# 4) Convenience symlink to the canonical binary (NOT into ~/.local/share/claude) => kept.
+assert_in_subshell "keeps a convenience symlink that points at the canonical binary" \
+    "H=\$(mktemp -d); export HOME=\"\$H\"; mkdir -p \"\$H/.local/bin\" \"\$H/realbin\"; : > \"\$H/realbin/claude\"; chmod +x \"\$H/realbin/claude\"; ln -s \"\$H/realbin/claude\" \"\$H/.local/bin/claude\"; export CLAUDE_CANONICAL_BIN=\"\$H/realbin/claude\"; . '$SCRIPT'; cleanup_conflicting_installs >/dev/null 2>&1; [ -L \"\$H/.local/bin/claude\" ]"
+
+# 5) Idempotent: no native link present => no-op, exit 0.
+assert_in_subshell "no-op when there is no native install" \
+    "H=\$(mktemp -d); export HOME=\"\$H\"; mkdir -p \"\$H/.local/bin\"; export CLAUDE_CANONICAL_BIN=\"\$H/realbin/claude\"; . '$SCRIPT'; cleanup_conflicting_installs >/dev/null 2>&1"
+
+# 6) resolve_canonical_claude honors the override.
+assert_in_subshell "resolve_canonical_claude honors CLAUDE_CANONICAL_BIN" \
+    "export CLAUDE_CANONICAL_BIN=/opt/x/claude; . '$SCRIPT'; [ \"\$(resolve_canonical_claude)\" = /opt/x/claude ]"
+
+_test_report


### PR DESCRIPTION
## Summary

Renames the `claude-toggle` YOLO switch into **`claude-config`**, a small launch-config tool for the `claude` shell wrapper; adds an **opt-in `--remote-control`** flag for interactive sessions; and makes the installer enforce a **single canonical `claude` binary**.

Two launch settings, each a sentinel file under `$XDG_CONFIG_HOME/claude` (kept out of `~/.claude/`, owned by Claude Code). Both default **OFF** — opt in per machine:

| Command | Effect | Default |
|---|---|---|
| `claude-config yolo on\|off` | `--dangerously-skip-permissions` | **OFF** (`yolo.enabled`) |
| `claude-config remote on\|off` | `--remote-control` on interactive sessions | **OFF** (`remote.enabled`) |
| `claude-config doctor` | report the installed binary; warn if >1 on PATH | — |
| `claude-config` / `status` | show current state | — |

### Launch behavior
- `--remote-control` is injected **only for interactive sessions**: skipped when stdin is not a TTY or in print mode (`-p`/`--print`), so headless `claude -p "..."` and piped runs are untouched.
- Both flags are **opt-in / default-OFF** (symmetric) — a fresh/shared/remote host stays quiet until you opt in.
- Config logic lives in top-level functions (no `_`-prefix) to survive Claude Code's shell-snapshot stripping.

### Single canonical binary (consolidation)
A machine can accumulate two `claude` binaries: the dotfiles-orchestrated one (npm-global on Linux/WSL, brew cask on macOS — installed by `claude_install.sh` via `install.sh`) and the official **native installer** copy (`curl claude.ai/install.sh` → `~/.local/bin/claude` → `~/.local/share/claude/…`). They drift in version and create a PATH-order foot-gun.
- `claude_install.sh` is now the **single source of truth**: after installing the canonical copy it removes the native install. **Guarded + idempotent + safe** — acts only on a `~/.local/bin/claude` symlink pointing into `~/.local/share/claude/`, only when a canonical claude **outside `~/.local`** is confirmed, and **never touches `~/.claude/`** (auth + settings). A convenience symlink to the canonical binary is left alone.
- `claude-config doctor` reports which binary `command claude` resolves to and warns if more than one is installed. The wrapper resolves via PATH (no hard-coded path → portable across nvm versions / macOS).

### Architecture-team review (folded in)
Reviewed by the architecture team (sysarch / secarch / principal + adversary). Must-fixes addressed:
- **Security posture** — `--remote-control` is **opt-in / default-OFF** (was inverted default-ON).
- **Prompt-swallow bug (blocker)** — `--remote-control [name]` takes an *optional* arg that greedily consumes the next token (verified on the real binary: a bare flag turned `claude "fix bug"` into `claude --remote-control fix bug`). Fixed by injecting `--remote-control "$(basename "$PWD")"` via a bash/zsh **array** so the prompt can never be captured.
- **Real test coverage** — decision logic extracted to a testable `claude_launch_flags()`; the installer is now sourceable for unit tests.

### Backward-compatibility with `claude-local` (playground #73)
`claude-local` reads the shell var **`CLAUDE_YOLO_FILE`** and calls `command claude` directly (never the `claude()` wrapper). This PR **freezes `CLAUDE_YOLO_FILE`** (name + path semantics) as a documented cross-repo contract (inline comment + guard test): `--remote-control` can never leak into `claude-local`, the rename is invisible to it, and a future rename trips a red test.

### Changes
- `ai/claude/aliases.sh` — wrapper, `claude_launch_flags`, `claude-config` (+`doctor`), contract comment, security note
- `ai/claude/aliases_test.sh` — **35 cases**
- `opt/scripts/system/claude_install.sh` — sourceable refactor; `resolve_canonical_claude` + `cleanup_conflicting_installs`
- `opt/scripts/system/claude_install_test.sh` — **10 cases** (sandboxed `$HOME`)
- `docs/machine-local-overrides.md` — refresh stale `_claude_yolo_enabled` example + opt-in note
- `opt/profiles/.zshrc`, `opt/profiles/.bashrc` — comment refresh

### MBO artifacts
- spec: [`docs/mbo/specs/claude-config.md`](docs/mbo/specs/claude-config.md)
- plan: [`docs/mbo/plans/claude-config.md`](docs/mbo/plans/claude-config.md)
- registered in [`docs/mbo/index.md`](docs/mbo/index.md) (state: in-review)

### Testing
`make shell-test` → **19 drivers, 0 failures** (incl. `aliases_test.sh` 35/35 and `claude_install_test.sh` 10/10); `bash -n` + shellcheck clean.

---
_Reviewed by the architecture team via Claude Code workflow orchestration._