### PR TITLE
worker-md-placement: move WORKER.md outside the worktree (#132)

### DIFF
--- a/docs/mbo/designs/worker-md-placement.md
+++ b/docs/mbo/designs/worker-md-placement.md
@@ -1,0 +1,130 @@
+# WORKER.md placement — design
+
+- **Slug:** worker-md-placement
+- **Date:** 2026-06-08
+- **Status:** Proposed
+- **Relates to:** issue #132
+- **Author(s):** architecture team (sysarch · principal · secarch · adversary) via Workflow
+
+## 1. Problem / context
+
+`gss feature worker add` seeds a `WORKER.md` scaffolding file into the **root of the worker's git worktree** (`sdk/gss/internal/feature/worker.go:128`, an unconditional `os.WriteFile(filepath.Join(res.Worktree, "WORKER.md"), …, 0o644)`). Because it lives inside the worktree, it shows up as `?? WORKER.md` in `git status` of the consumer repo and risks being swept into a commit (`git add -A`, or a misfired `git add .` from the wrong cwd). The auto-checkpoint path also appends to it (`auto.go:142-150`, `O_APPEND|O_CREATE`), so even a clean worktree can re-grow the file after the user deletes it.
+
+The current mitigation is a **manual chore**: the gss skill (`sdk/gss/skill/SKILL.md:136-139`) mandates deleting and committing the removal of `WORKER.md` before `gss feature pr --ready`. Issue #132 wants a **structural fix** so accidental commits become impossible, and explicitly **rejects** adding `WORKER.md` to the consumer repo's `.gitignore` (that pollutes every consumer repo with gss-internal scaffolding).
+
+Verified layout facts (read from source, not assumed):
+
+- `worker.go:100`: `wtPath = filepath.Join(s.WorktreeRoot, s.NWO, opts.Feature, user, leaf)`, where `leaf = purpose[-suffix]` (`worker.go:94-98`). Default `WorktreeRoot = ~/.config/gss/worktrees`, `NWO = "<owner>/<repo>"`.
+- `identity.AllocateRef` (`worker.go:90`) **deliberately allocates a distinct suffix** when a bare `(feature,user,purpose)` is taken, so multiple leaves (e.g. `design/`, `impl/`) **coexist under the same `<feature>/<user>/` parent by design**. This is the crux of the collision analysis below.
+- Precedent: `FEATURE.md` already lives **outside** any leaf worktree at `<feature>/FEATURE.md` (`start.go:98`, read back at `done.go:128`). gss already keeps one scaffolding markdown a directory level above the leaves.
+- `checkpoint.go:61`: `title := fmt.Sprintf("%s: %s", ref.Feature, ref.Purpose) // first H1 of WORKER.md` — the trailing comment is **stale**; the title is built from `ref`, and **no read of WORKER.md occurs anywhere**.
+
+The complete set of `WORKER.md` touchpoints (grep-verified): (1) WRITE `worker.go:128`; (2) APPEND `auto.go:142-150`; (3) the stale comment at `checkpoint.go:61` (no behavioral read).
+
+## 2. Goals & non-goals
+
+**Goals**
+- `WORKER.md` must never appear in the consumer worktree's `git status` — make accidental commits **structurally** impossible, not merely hidden.
+- Do **not** touch the consumer repo's tracked ignore rules (`.gitignore`) — and, as the adversary proved, do **not** touch the consumer repo's `.git/info/exclude` either (see §3, Option C).
+- Each worker owns its own `WORKER.md` inode: no cross-worker clobber, no interleaved auto-logs.
+- Lifecycle symmetry: every file the fix creates is torn down by `feature done`; no orphan accretion under `~/.config/gss/worktrees`.
+- Route all touchpoints through **one** path helper so WRITE and APPEND can never diverge.
+- Migrate worktrees created under the old in-worktree layout without dropping human/agent edits or the appended auto-log.
+- Retire the manual SKILL.md cleanup mandate for `WORKER.md`.
+
+**Non-goals**
+- Eliminating the `WORKER.md` file entirely / serving it from the registry (Option D) — larger refactor, changes the agent-facing contract; deferred as separate tech-debt.
+- Changing `FEATURE.md` handling (already outside the worktree, cleaned by `done.go`).
+- Changing file permissions (`0o644` is correct; `WORKER.md` is non-secret scaffolding).
+- Extracting a parallel `FeatureMetaPath` helper for `FEATURE.md` — noted as optional follow-up to keep the diff tight.
+
+## 3. Options considered
+
+**Recommendation: Option B** — `<feature>/<user>/.gss-meta/<leaf>/WORKER.md` (leaf-keyed, outside the worktree). All three lenses and the adversary converge here.
+
+| Option | Shape | Verdict | Why |
+|---|---|---|---|
+| **B (chosen)** | `<feature>/<user>/.gss-meta/<leaf>/WORKER.md` | **Adopt** | A's correct instinct (move out of the worktree; don't touch consumer ignore rules) made **collision-safe** by keying on `leaf`, and **lifecycle-symmetric** by namespacing under a single dir that `done.go` can `RemoveAll`. |
+| A (the issue's proposal) | `<feature>/<user>/WORKER.md` (parent of leaf) | **Reject** | Puts a **per-worker (1:N)** file at a **shared parent** dir. Real, source-confirmed data-loss when siblings coexist. False analogy to `FEATURE.md`. Orphaned forever by `done.go`. |
+| C | Keep file in worktree; add it to `info/exclude` | **Reject** | **Empirically disproven** by the adversary: a linked worktree does **not** consult a per-worktree `info/exclude`; `git rev-parse --git-path info/exclude` resolves to the **shared common** `.git/info/exclude`. So C either fails to hide the file *or* writes into the file shared with the consumer's own checkout — i.e. the exact consumer-repo pollution #132 rejected. Cannot deliver "per-clone + invisible + no consumer pollution" simultaneously. |
+| D | No file; render from registry on demand | **Defer** | Best blast-radius profile, but changes the agent contract (`WORKER.md` is a real artifact agents `cat`/edit and `auto.go` writes to) and relocates auto-log diagnostics into JSON. Out of scope for a path-contract fix; route to a separate objective. |
+
+**Shared-parent collision analysis (why A does not survive).** A worker_ref is `<feature>/<user>/<purpose>[-suffix]`. `AllocateRef` exists precisely to let `design/` and `impl/` (or two same-purpose workers) live under one `<feature>/<user>/`. Option A maps **both** to the single `<feature>/<user>/WORKER.md`:
+- **WRITE collision** — `worker.go:128` is an unconditional `os.WriteFile`; the second `worker add` **clobbers** the first worker's seeded file.
+- **APPEND collision** — `appendAutoLog` (`auto.go:142`, `O_APPEND|O_CREATE`) interleaves two distinct workers' auto-checkpoint diagnostics into one file, making the log ambiguous.
+- **Race** — the worktree materialization + `WriteFile` happen **after** the `Store.Update` lock is released (`worker.go:118-130`; lock only covers the registry row). Two concurrent `worker add` calls compound A's sequential clobber into a genuine write race. B is immune: distinct leaves, distinct paths.
+
+**Why the `FEATURE.md` precedent does not rescue A.** `FEATURE.md` is safe at `<feature>/` because that dir is **1:1** (exactly one feature, matching cleanup at `done.go:111`). A borrows the precedent's *path shape* (one level above the leaf) while breaking its *invariant* (single owner per dir). The faithful analogue keys by the leaf → Option B.
+
+**Cleanup gap (applies to A and B alike, must be fixed).** `done.go:69` `Backend.Remove(w.Worktree)` removes only the **leaf inode**. `FEATURE.md`/`featDir` are removed only when the feature fully empties (`done.go:110-112`, non-recursive best-effort `os.Remove`). **Nothing ever touches the `<feature>/<user>/` level.** So A's parent file accretes forever; B's `.gss-meta/<leaf>/` likewise requires an **explicit** `os.RemoveAll` in the worker-removal path. (A leftover under `featDir` would also make the existing `os.Remove(featDir)` silently fail on a non-empty dir.) Cleanup is therefore in-scope, not optional.
+
+**Latent benefit of B (surfaced by the adversary).** `done.go:55-57` refuses teardown when `git status --porcelain` is non-empty. Today an untracked `WORKER.md` makes the worktree perpetually "dirty," which already pushes users toward `--force` or the manual-delete chore. Moving the file out makes the dirty-check **honest** — only real work shows as dirty. This is a second motivation for the fix.
+
+## 4. Decision
+
+Adopt **Option B**. Do **not** layer Option C on top (its premise is disproven). Defer Option D.
+
+**Path contract.** Per worker, `WORKER.md` lives at:
+
+```
+~/.config/gss/worktrees/<owner>/<repo>/<feature>/<user>/.gss-meta/<leaf>/WORKER.md
+```
+
+i.e. a leaf-keyed sibling of the leaf worktree, namespaced under `.gss-meta/`. This is a new public-ish on-disk contract; document it in `sdk/gss/docs/` and `SKILL.md`. Future gss-internal scaffolding nests under the same `.gss-meta/` namespace rather than proliferating sibling dot-files.
+
+**Single path helper (one source of truth).** Add one **pure** helper in `internal/feature` (a small `paths.go`, or in `worker.go`):
+
+```go
+func workerMetaPath(worktree string) string {
+    return filepath.Join(filepath.Dir(worktree), ".gss-meta", filepath.Base(worktree), "WORKER.md")
+}
+```
+
+It derives **solely** from the leaf worktree path: `leaf == filepath.Base(worktree)` and `<feature>/<user>/` is `filepath.Dir(worktree)`. This is the decisive resolution of the one inter-lens disagreement: the Principal lens leaned toward persisting a `MetaDir` field on the registry row to feed `auto.go`; the adversary refuted the necessity — because `.gss-meta` is a **sibling of the leaf** (not above the `user` level), the pure helper resolves correctly from `w.Worktree` alone, with **no registry-schema change**. We take the **derive** path. (Persist a field *only if* a future layout change makes `leaf != filepath.Base(worktree)`; until then a schema change is unjustified coupling.)
+
+**Concrete change at each touchpoint:**
+
+1. **WRITE — `worker.go:128`.** Replace `filepath.Join(res.Worktree, "WORKER.md")` with `metaPath := workerMetaPath(res.Worktree)`; call `os.MkdirAll(filepath.Dir(metaPath), 0o755)` before the `os.WriteFile(metaPath, []byte(content), 0o644)` (mirrors the `MkdirAll` pattern start.go uses for `FEATURE.md`). The file is now physically **outside** `res.Worktree`, so it cannot appear in the consumer's `git status` — the point of #132.
+
+2. **APPEND — `auto.go:142-150`.** In `appendAutoLog`, replace `filepath.Join(worktree, "WORKER.md")` with `workerMetaPath(worktree)`. Keep `O_APPEND|O_CREATE|O_WRONLY, 0o644`. Add a defensive `os.MkdirAll(filepath.Dir(path), 0o755)` before the open, because `appendAutoLog` can be the **first** writer (`O_CREATE`) if an auto-checkpoint skip fires before any successful manual add — without the guard the open fails when `.gss-meta/<leaf>/` doesn't yet exist. `appendAutoLog` keeps its `(worktree, reason)` signature; the helper needs nothing more, so **no signature change** is required.
+
+3. **`checkpoint.go:61` — comment only.** No code change. Update the stale `// first H1 of WORKER.md` comment so it no longer implies a read (e.g. `// title from worker_ref (feature:purpose), not read from WORKER.md`).
+
+**Cleanup / lifecycle — `done.go`.** After `Backend.Remove(w.Worktree)` succeeds (`done.go:69`), add:
+```go
+_ = os.RemoveAll(filepath.Join(filepath.Dir(w.Worktree), ".gss-meta", filepath.Base(w.Worktree)))
+```
+to tear down the leaf's meta dir, plus a best-effort `os.Remove` of the now-possibly-empty `.gss-meta` parent. In the `deleteFeature` branch (`done.go:110-112`), also best-effort-remove the now-empty `<user>/.gss-meta` and `<user>` dirs (same pattern as the existing `os.Remove(featDir)`), so a fully-done feature leaves no orphan. This restores the write↔cleanup symmetry A lacks.
+
+**Backward-compat / migration of existing worktrees.** Worktrees created under the old layout have `WORKER.md` at the worktree root (untracked, possibly committed, possibly dirty). Migration must run on **both** writer paths (the adversary's edge: `auto.go` can be the first writer):
+- Factor a small `migrateLegacyWorkerMD(worktree string)` invoked at the top of the WRITE path (`worker.go`) **and** before the append in `appendAutoLog` (`auto.go`). It: detects `filepath.Join(worktree, "WORKER.md")`; if present, `os.MkdirAll` the meta dir and `os.Rename` the legacy file to `workerMetaPath(worktree)` (**preserving** human edits + the appended auto-log); if the legacy file was git-tracked, run `git -C <worktree> rm --cached --quiet WORKER.md` so it leaves `git status`.
+- A naive "just write the new path" is rejected: it would leave the old root-level file in `git status` — the exact symptom #132 fixes. Migration is a first-class, tested step.
+
+**SKILL.md cleanup — `sdk/gss/skill/SKILL.md:136-139`.** The "Cleanup (Mandatory)" bullet currently mandates deleting/committing `WORKER.md` before `gss feature pr --ready`. Once `WORKER.md` lives outside the worktree this step is **structurally unreachable** and leaving it is actively misleading (agents will hunt a file that can't be there → false "I forgot to delete it" churn). Remove the `WORKER.md` clause; **keep the `FEATURE.md` wording** (handled separately by `done.go`'s template-clean compare-and-remove). Add one line stating `WORKER.md` now lives at `<feature>/<user>/.gss-meta/<leaf>/WORKER.md` outside the worktree and is auto-removed on `feature done`. Document the new on-disk path in `sdk/gss/docs/` per repo convention.
+
+**Test contract (must land in the same commit).** Invert the existing assertions and add the collision guard:
+- `worker_test.go:46` (`Stat(Join(res.Worktree, "WORKER.md"))` succeeds) → assert WORKER.md is **NOT** under `res.Worktree` and **IS** at `workerMetaPath(res.Worktree)`; add a direct #132 regression assertion that the worktree root is free of `WORKER.md`.
+- `auto_test.go:98` and `:154` → repoint reads from `Join(wt, "WORKER.md")` to `workerMetaPath(wt)`.
+- **New** two-sibling test: two workers under the same `(feature,user)` (forcing a suffix) get **distinct** `WORKER.md` files — the regression guard that proves B over A.
+- Migration test: a pre-seeded legacy root-level `WORKER.md` is moved to the meta path with content preserved, and `git status --porcelain` in the worktree is clean afterward.
+
+## 5. Risks & blast radius
+
+- **WRITE/APPEND divergence (medium).** If only one site moves, the other re-creates `WORKER.md` inside the worktree and reintroduces the pollution. Mitigated: both route through the single `workerMetaPath` helper — that helper *is* the deliverable.
+- **Cleanup omission (medium).** Forgetting the `done.go` `RemoveAll` trades a git-status nuisance for disk-litter under `~/.config/gss/worktrees` and can wedge the existing `os.Remove(featDir)`. Mitigated: explicit cleanup is in-scope (§4) with the test asserting a done feature leaves no orphan.
+- **Migration drops edits or leaves the legacy file (medium).** A naive write strands the old file in `git status`. Mitigated: `os.Rename` (not write-new) + conditional `git rm --cached`, invoked on **both** writer paths, with a test asserting content preservation + clean porcelain.
+- **`auto.go` first-writer ordering (low/medium).** Auto-checkpoint skip before any manual add. Mitigated by the defensive `MkdirAll` in `appendAutoLog` and running migration on the auto path.
+- **Path-traversal via user names (low / non-issue, recorded so it isn't re-litigated).** `identity.ValidateSegment` (`identity/validate.go:18`, `^[a-z][a-z0-9-]{0,30}[a-z0-9]$`) forbids `/`, `.`, `..`, control chars; `ValidatePurpose` runs (`worker.go:49`) before any `filepath.Join`; suffix is wordlist-drawn. No segment can escape the gss-private tree. Any future loosening of the segment grammar, or sourcing the leaf from raw input, would reopen this.
+- **Permissions / at-rest (none).** `0o644` unchanged; non-secret scaffolding; destination is the same `~/.config`, same-uid, gss-private tree where `FEATURE.md` already lives. No trust boundary crossed.
+- **New dot-dir per worker (low).** One extra dir + one small md per worker. Negligible inode/storage cost; documented as a public on-disk contract.
+
+Blast radius is contained to `internal/feature` (`worker.go`, `auto.go`, `done.go`, `checkpoint.go` comment), its tests, and `skill/SKILL.md` + `sdk/gss/docs/`. No registry schema change, no CLI surface change, no consumer-repo file touched.
+
+## 6. Rollback
+
+Pure-additive path move with no schema migration, so rollback is low-cost:
+- **Code:** revert the `internal/feature` commit. New worktrees revert to seeding `WORKER.md` in the worktree root (old behavior); the manual SKILL.md cleanup mandate is restored in the same revert.
+- **On-disk state:** worktrees created while the fix was live have `WORKER.md` under `.gss-meta/<leaf>/`. After rollback, the reverted code looks for it at the worktree root and won't find it; the auto-log path simply recreates a root-level file on next append (no data corruption, only the relocated history is stranded). A one-line operator cleanup (`find ~/.config/gss/worktrees -type d -name .gss-meta -prune -exec rm -rf {} +`) removes the stranded meta dirs if desired — they are gss-private and safe to delete.
+- **No consumer-repo footprint** was ever created (no `.gitignore`/`info/exclude` writes), so there is nothing to unwind in any consumer checkout — a key reason Option C was rejected.
+
+> Produced via an architecture-team `Workflow` (sysarch · principal · secarch · adversary). Register in `../index.md`. Spec → `../specs/worker-md-placement.md`.

--- a/docs/mbo/designs/worker-md-placement.md
+++ b/docs/mbo/designs/worker-md-placement.md
@@ -127,4 +127,15 @@ Pure-additive path move with no schema migration, so rollback is low-cost:
 - **On-disk state:** worktrees created while the fix was live have `WORKER.md` under `.gss-meta/<leaf>/`. After rollback, the reverted code looks for it at the worktree root and won't find it; the auto-log path simply recreates a root-level file on next append (no data corruption, only the relocated history is stranded). A one-line operator cleanup (`find ~/.config/gss/worktrees -type d -name .gss-meta -prune -exec rm -rf {} +`) removes the stranded meta dirs if desired — they are gss-private and safe to delete.
 - **No consumer-repo footprint** was ever created (no `.gitignore`/`info/exclude` writes), so there is nothing to unwind in any consumer checkout — a key reason Option C was rejected.
 
+## 7. Implementation note (reconciled post-build)
+
+One refinement surfaced during implementation and is reflected in the spec/plan and code:
+**migration runs once at `AutoCheckpoint` entry**, not on "both writer paths." `worker add`
+*always* materializes a **fresh** worktree (`worker.go` calls `Backend.Create` on a new path),
+so a legacy root-level `WORKER.md` can only be encountered by `auto-checkpoint` over a
+pre-existing (old-layout) worktree. Placing the single `migrateLegacyWorkerMD` call at the top of
+`AutoCheckpoint` (which has `ctx` for the `git rm --cached` on a tracked legacy file) covers that
+sole case without dead code on the seed path. The `WorkerMetaPath` helper is **exported** (used by
+the write, append, cleanup sites and tests); `migrateLegacyWorkerMD` stays unexported.
+
 > Produced via an architecture-team `Workflow` (sysarch · principal · secarch · adversary). Register in `../index.md`. Spec → `../specs/worker-md-placement.md`.

--- a/docs/mbo/index.md
+++ b/docs/mbo/index.md
@@ -22,7 +22,7 @@ done` (also `parked`, `superseded`).
 | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
 | `prping` | — | [spec](./specs/2026-06-05-prping-design.md) | [plan](./plans/2026-06-05-prping-implementation-plan.md) | — | #127 | in-review |
 | `mbo` | this folder + the `mbo-plan` skill (`ai/skills/mbo-plan/`) | — | — | — | #127 | in-review |
-| `worker-md-placement` | [design](./designs/worker-md-placement.md) | — | — | [#132](https://github.com/sfc-gh-eraigosa/dotfiles/issues/132) | #133 | in-review |
+| `worker-md-placement` | [design](./designs/worker-md-placement.md) | [spec](./specs/worker-md-placement.md) | [plan](./plans/worker-md-placement.md) | [#132](https://github.com/sfc-gh-eraigosa/dotfiles/issues/132) | #133 | planning |
 
 ## Merged / historical (pre-MBO — tracking columns best-effort)
 

--- a/docs/mbo/index.md
+++ b/docs/mbo/index.md
@@ -22,7 +22,7 @@ done` (also `parked`, `superseded`).
 | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
 | `prping` | — | [spec](./specs/2026-06-05-prping-design.md) | [plan](./plans/2026-06-05-prping-implementation-plan.md) | — | #127 | in-review |
 | `mbo` | this folder + the `mbo-plan` skill (`ai/skills/mbo-plan/`) | — | — | — | #127 | in-review |
-| `worker-md-placement` | [design](./designs/worker-md-placement.md) | — | — | [#132](https://github.com/sfc-gh-eraigosa/dotfiles/issues/132) | — | designing |
+| `worker-md-placement` | [design](./designs/worker-md-placement.md) | — | — | [#132](https://github.com/sfc-gh-eraigosa/dotfiles/issues/132) | #133 | in-review |
 
 ## Merged / historical (pre-MBO — tracking columns best-effort)
 

--- a/docs/mbo/index.md
+++ b/docs/mbo/index.md
@@ -22,7 +22,7 @@ done` (also `parked`, `superseded`).
 | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
 | `prping` | — | [spec](./specs/2026-06-05-prping-design.md) | [plan](./plans/2026-06-05-prping-implementation-plan.md) | — | #127 | in-review |
 | `mbo` | this folder + the `mbo-plan` skill (`ai/skills/mbo-plan/`) | — | — | — | #127 | in-review |
-| `worker-md-placement` | [design](./designs/worker-md-placement.md) | [spec](./specs/worker-md-placement.md) | [plan](./plans/worker-md-placement.md) | [#132](https://github.com/sfc-gh-eraigosa/dotfiles/issues/132) | #133 | planning |
+| `worker-md-placement` | [design](./designs/worker-md-placement.md) | [spec](./specs/worker-md-placement.md) | [plan](./plans/worker-md-placement.md) | [#132](https://github.com/sfc-gh-eraigosa/dotfiles/issues/132) | #133 | in-review |
 
 ## Merged / historical (pre-MBO — tracking columns best-effort)
 

--- a/docs/mbo/index.md
+++ b/docs/mbo/index.md
@@ -22,6 +22,7 @@ done` (also `parked`, `superseded`).
 | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
 | `prping` | — | [spec](./specs/2026-06-05-prping-design.md) | [plan](./plans/2026-06-05-prping-implementation-plan.md) | — | #127 | in-review |
 | `mbo` | this folder + the `mbo-plan` skill (`ai/skills/mbo-plan/`) | — | — | — | #127 | in-review |
+| `worker-md-placement` | [design](./designs/worker-md-placement.md) | — | — | [#132](https://github.com/sfc-gh-eraigosa/dotfiles/issues/132) | — | designing |
 
 ## Merged / historical (pre-MBO — tracking columns best-effort)
 

--- a/docs/mbo/plans/worker-md-placement.md
+++ b/docs/mbo/plans/worker-md-placement.md
@@ -2,7 +2,7 @@
 
 - **Slug:** worker-md-placement
 - **Date:** 2026-06-08
-- **Status:** Draft
+- **Status:** In-progress
 - **Relates to:** spec `../specs/worker-md-placement.md` · issue #132 · PR #133
 
 ## 1. Summary & verdict
@@ -26,8 +26,8 @@ breakout (see §6.1).
 | `sdk/gss/internal/feature/paths_test.go` *(new)* | helper table test + migration unit test | F1, F5 |
 | `sdk/gss/internal/feature/worker.go` | WRITE → meta path; `MkdirAll`; call migration | F2, F5 |
 | `sdk/gss/internal/feature/worker_test.go` | **invert**: assert WORKER.md outside worktree, at meta path; #132 regression; two-sibling guard | F2, UC-2 |
-| `sdk/gss/internal/feature/auto.go` | APPEND → meta path; `MkdirAll`; call migration | F3, F5 |
-| `sdk/gss/internal/feature/auto_test.go` | **repoint** reads (`:98`,`:154`) to meta path; first-writer case | F3 |
+| `sdk/gss/internal/feature/auto.go` | APPEND → meta path + `MkdirAll`; call `migrateLegacyWorkerMD` once at `AutoCheckpoint` entry | F3, F5 |
+| `sdk/gss/internal/feature/auto_test.go` | **repoint** reads (`:98`,`:154`) to meta path — these run over an empty worktree, doubling as the first-writer coverage | F3 |
 | `sdk/gss/internal/feature/done.go` | `os.RemoveAll` leaf meta dir after `Backend.Remove`; best-effort empty-parent cleanup on feature delete | F4 |
 | `sdk/gss/internal/feature/done_test.go` *(new or extend)* | post-`done` meta dir gone; sibling survives | F4 |
 | `sdk/gss/internal/feature/checkpoint.go` | fix stale `:61` comment (no behavior change) | F6 |
@@ -82,9 +82,10 @@ in `done.go` after `Backend.Remove` (and in the `deleteFeature` branch). *Verify
 
 **Phase 5 — legacy migration (F5).** *Write first:* `paths_test.go` migration cases — (a)
 untracked root `WORKER.md` → moved to meta path, content byte-identical; (b) tracked root file →
-moved **and** `git status --porcelain` clean of `WORKER.md`; (c) no legacy file → no-op. *Then:*
-implement `migrateLegacyWorkerMD` and call it at the top of the WRITE path and before the append
-in `appendAutoLog`. *Verify:* `go test ./internal/feature -run 'TestMigrat'`. **Done-when:** all
+`git rm --cached -- WORKER.md` issued; (c) no legacy file → no-op (no git call). *Then:*
+implement `migrateLegacyWorkerMD` and call it **once at `AutoCheckpoint` entry** (the only path
+that meets a pre-existing worktree — `worker add` always creates a fresh one, so the seed path has
+nothing to migrate). *Verify:* `go test ./internal/feature -run 'TestMigrat'`. **Done-when:** all
 three migration cases green.
 
 **Phase 6 — docs/skill + comment (F6).** Remove the `WORKER.md` delete clause from

--- a/docs/mbo/plans/worker-md-placement.md
+++ b/docs/mbo/plans/worker-md-placement.md
@@ -1,0 +1,134 @@
+# WORKER.md placement — implementation plan
+
+- **Slug:** worker-md-placement
+- **Date:** 2026-06-08
+- **Status:** Draft
+- **Relates to:** spec `../specs/worker-md-placement.md` · issue #132 · PR #133
+
+## 1. Summary & verdict
+
+Move the gss worker `WORKER.md` from the worktree root to a leaf-keyed
+`<feature>/<user>/.gss-meta/<leaf>/WORKER.md` outside the worktree, routed through one pure
+helper, with `done.go` cleanup, legacy migration on both writer paths, and skill/docs updates.
+
+**Architecture-team verdict (design):** Option B, adversary-confirmed (4 confirmed refutations).
+Must-fixes folded in below: (a) single helper feeds WRITE **and** APPEND; (b) migration runs on
+**both** writer paths because `appendAutoLog` can create the file first; (c) explicit `done.go`
+cleanup because nothing today touches the `<feature>/<user>/` level; (d) Option C (`info/exclude`)
+**not** adopted — empirically disproven. This is a **single-PR, sequential** build — no CAP-B
+breakout (see §6.1).
+
+## 2. File inventory
+
+| Path | Purpose | Implements |
+| :-- | :-- | :-- |
+| `sdk/gss/internal/feature/paths.go` *(new)* | `workerMetaPath` + `migrateLegacyWorkerMD` helpers | F1, F5 |
+| `sdk/gss/internal/feature/paths_test.go` *(new)* | helper table test + migration unit test | F1, F5 |
+| `sdk/gss/internal/feature/worker.go` | WRITE → meta path; `MkdirAll`; call migration | F2, F5 |
+| `sdk/gss/internal/feature/worker_test.go` | **invert**: assert WORKER.md outside worktree, at meta path; #132 regression; two-sibling guard | F2, UC-2 |
+| `sdk/gss/internal/feature/auto.go` | APPEND → meta path; `MkdirAll`; call migration | F3, F5 |
+| `sdk/gss/internal/feature/auto_test.go` | **repoint** reads (`:98`,`:154`) to meta path; first-writer case | F3 |
+| `sdk/gss/internal/feature/done.go` | `os.RemoveAll` leaf meta dir after `Backend.Remove`; best-effort empty-parent cleanup on feature delete | F4 |
+| `sdk/gss/internal/feature/done_test.go` *(new or extend)* | post-`done` meta dir gone; sibling survives | F4 |
+| `sdk/gss/internal/feature/checkpoint.go` | fix stale `:61` comment (no behavior change) | F6 |
+| `sdk/gss/skill/SKILL.md` | remove `WORKER.md` clause from "Cleanup (Mandatory)"; keep `FEATURE.md`; add new-path note | F6 |
+| `sdk/gss/docs/` (the worktree/feature doc) | document the `.gss-meta/<leaf>/WORKER.md` on-disk contract | F6 |
+| **Rebuild:** `sdk/gss/build.sh` (run, not edit) | reinstall binary so tmux-mgr's runtime shell-out isn't stale | harness |
+
+No edits to `install.sh`, `scripts/test.sh`, or the registry schema — discovery is by-directory
+and the change is package-internal.
+
+## 3. Interface contracts
+
+```go
+// paths.go — the single source of truth for the on-disk WORKER.md location.
+// Derives solely from the leaf worktree path: leaf == filepath.Base(worktree),
+// <feature>/<user>/ == filepath.Dir(worktree). No registry field needed.
+func workerMetaPath(worktree string) string {
+    return filepath.Join(filepath.Dir(worktree), ".gss-meta", filepath.Base(worktree), "WORKER.md")
+}
+
+// migrateLegacyWorkerMD moves a pre-existing root-level WORKER.md to the meta
+// path (preserving content) and un-tracks it if it was committed. Idempotent:
+// a no-op when no legacy file exists. Invoked from BOTH writer paths.
+func (s *Service) migrateLegacyWorkerMD(ctx context.Context, worktree string)
+```
+
+Write/append sites both become: `p := workerMetaPath(wt); os.MkdirAll(filepath.Dir(p), 0o755); …`.
+
+## 4. TDD build order
+
+**Phase 1 — helper (F1).** *Write first:* `paths_test.go` table test mapping representative
+worktree paths (incl. a suffix'd leaf `design-foo`) → exact expected meta path. *Verify:*
+`go test ./internal/feature -run TestWorkerMetaPath`. **Done-when:** helper exists, table green.
+
+**Phase 2 — WRITE moves out (F2, UC-2).** *Write first:* invert `worker_test.go:46` to assert
+`Stat(workerMetaPath(res.Worktree))==nil` **and** `Stat(Join(res.Worktree,"WORKER.md"))!=nil`;
+add the two-sibling guard (two workers under one feature/user → distinct meta paths + independent
+content). *Then:* change `worker.go:128` to write the meta path with a preceding `os.MkdirAll`.
+*Verify:* `go test ./internal/feature -run 'TestWorker'`. **Done-when:** new+inverted tests green;
+no test still expects a root file.
+
+**Phase 3 — APPEND moves out (F3).** *Write first:* repoint `auto_test.go:98`/`:154` reads to the
+meta path; add a first-writer case (`appendAutoLog` with no prior seed lands at the meta path).
+*Then:* update `appendAutoLog` to use `workerMetaPath` + defensive `MkdirAll`. *Verify:*
+`go test ./internal/feature -run 'TestAuto'`. **Done-when:** auto-log tests green incl. first-writer.
+
+**Phase 4 — cleanup on done (F4).** *Write first:* `done_test.go` — after `feature done`, the
+leaf `.gss-meta/<leaf>/` is gone and an unrelated sibling's meta dir survives; full-feature delete
+leaves no `.gss-meta` orphan. *Then:* add `os.RemoveAll` (+ best-effort empty-parent `os.Remove`)
+in `done.go` after `Backend.Remove` (and in the `deleteFeature` branch). *Verify:*
+`go test ./internal/feature -run 'TestDone'`. **Done-when:** cleanup tests green.
+
+**Phase 5 — legacy migration (F5).** *Write first:* `paths_test.go` migration cases — (a)
+untracked root `WORKER.md` → moved to meta path, content byte-identical; (b) tracked root file →
+moved **and** `git status --porcelain` clean of `WORKER.md`; (c) no legacy file → no-op. *Then:*
+implement `migrateLegacyWorkerMD` and call it at the top of the WRITE path and before the append
+in `appendAutoLog`. *Verify:* `go test ./internal/feature -run 'TestMigrat'`. **Done-when:** all
+three migration cases green.
+
+**Phase 6 — docs/skill + comment (F6).** Remove the `WORKER.md` delete clause from
+`SKILL.md` "Cleanup (Mandatory)" (keep `FEATURE.md`); add the new-path note; fix `checkpoint.go:61`
+comment; document the path in `sdk/gss/docs/`. *Verify:* `grep -n "WORKER.md" sdk/gss/skill/SKILL.md`
+shows only the new descriptive line, not a delete mandate. **Done-when:** grep + review pass.
+
+**Phase 7 — gate + rebuild.** Run `go test ./...` in `sdk/gss` with coverage ≥60% for
+`internal/feature`; `bash sdk/gss/build.sh`; run `scripts/e2e-gss-integration.sh`; do the
+human-evidenced scratch-repo check (`worker add` → `git status` clean, file at meta path).
+**Done-when:** all gates green + evidence captured.
+
+## 5. Verification mapping
+
+| Spec rule | Test case |
+| :-- | :-- |
+| F1 helper exact path (incl. suffix) | `TestWorkerMetaPath` (table) |
+| F2 file outside worktree / at meta path | `worker_test.go` inverted Stat asserts + `TestWorkerAdd_NoRootWorkerMD` |
+| UC-2 two-sibling distinct files | `TestWorkerAdd_SiblingLeavesDistinct` |
+| F3 auto-log at meta path | `auto_test.go` repointed reads |
+| F3 first-writer tolerance | `TestAppendAutoLog_FirstWriter` |
+| F4 leaf cleanup + sibling survives | `TestDone_RemovesMetaDir` |
+| F5 untracked move / tracked move-clean / no-op | `TestMigrateLegacyWorkerMD_*` |
+| F6 skill no longer mandates delete | `grep` assertion / review |
+| Coverage ≥60% | `scripts/test.sh` / CI gate |
+| Integration intact | `scripts/e2e-gss-integration.sh` |
+
+## 6. Integration & rollout
+
+- **Discovery:** by-directory; no `scripts/test.sh` / `Makefile` edit needed.
+- **Rebuild:** `bash sdk/gss/build.sh` → `~/opt/bin/gss` (tmux-mgr runtime dependency).
+- **Skill sync:** `SKILL.md` lives under `sdk/gss/skill/`; `sync-skills` relinks on install.
+- **Manual acceptance:** in a throwaway git repo, `gss feature start` + `worker add`, confirm
+  `git -C <worktree> status --porcelain` has no `WORKER.md` and the file is at
+  `<feature>/<user>/.gss-meta/<leaf>/WORKER.md`; run an `auto-checkpoint` skip and confirm the
+  diagnostic appends there.
+
+### 6.1 Build leaves / DAG
+
+**Not broken out.** The whole change is one cohesive, sequential edit to a single package
+(`internal/feature`) whose phases share files (`worker.go`+`worker_test.go`,
+`auto.go`+`auto_test.go`) — splitting would be a false split (overlapping paths, perpetual
+rebase). Build it as **one `gss` worker / one PR**, TDD phases 1→7 in order. The path helper
+(Phase 1) is the internal "frozen interface" the later phases import, but it ships in the same PR.
+
+> Produced from the spec. Execute with TDD throughout (`superpowers:test-driven-development`).
+> Update `../index.md` state as it moves.

--- a/docs/mbo/specs/worker-md-placement.md
+++ b/docs/mbo/specs/worker-md-placement.md
@@ -2,7 +2,7 @@
 
 - **Slug:** worker-md-placement
 - **Date:** 2026-06-08
-- **Status:** Draft
+- **Status:** Approved
 - **Relates to:** issue #132 · PR #133 · design `../designs/worker-md-placement.md`
 
 ## 1. Goal
@@ -42,11 +42,13 @@ parents are best-effort removed on full-feature delete. *Acceptance:* after `don
 `os.Remove(featDir)` is not wedged by a leftover.
 
 **UC-5 — Legacy worktree migration.** *Actor:* a worktree created under the old layout (root
-`WORKER.md`). *Trigger:* the next `worker add` WRITE path **or** the next `appendAutoLog`.
-*Flow:* `migrateLegacyWorkerMD(worktree)` renames the root file to the meta path (preserving
-human edits + appended log) and, if it was git-tracked, runs `git rm --cached --quiet WORKER.md`.
-*Acceptance:* the file is at the meta path with content intact; `git status --porcelain` in the
-worktree is clean of `WORKER.md` afterward.
+`WORKER.md`). *Trigger:* the next `gss feature checkpoint --auto` over that worktree (this is the
+only path that meets a pre-existing worktree — `worker add` always creates a *fresh* one, so it
+never has a legacy file). *Flow:* `migrateLegacyWorkerMD(ctx, worktree)` runs at `AutoCheckpoint`
+entry: it renames the root file to the meta path (preserving human edits + appended log) and, if
+it was git-tracked, runs `git rm --cached --ignore-unmatch -- WORKER.md`. *Acceptance:* the file is
+at the meta path with content intact; a tracked legacy file is dropped from the index; a worktree
+with no legacy file is untouched (no git call).
 
 ## 3. Architecture
 

--- a/docs/mbo/specs/worker-md-placement.md
+++ b/docs/mbo/specs/worker-md-placement.md
@@ -1,0 +1,133 @@
+# WORKER.md placement — spec
+
+- **Slug:** worker-md-placement
+- **Date:** 2026-06-08
+- **Status:** Draft
+- **Relates to:** issue #132 · PR #133 · design `../designs/worker-md-placement.md`
+
+## 1. Goal
+
+`gss feature worker add` must seed (and `auto-checkpoint` must append to) the worker's
+`WORKER.md` scaffolding file at a location **outside** the worker's git worktree, so it can
+never appear in the consumer repo's `git status` or be swept into a commit — without touching
+any consumer-repo ignore rules. The file moves to a **leaf-keyed** path
+`<feature>/<user>/.gss-meta/<leaf>/WORKER.md`, is created/migrated transparently, and is torn
+down with the worker on `feature done`. The result: the manual "delete WORKER.md before
+`pr --ready`" chore in the gss skill is retired.
+
+## 2. Use cases
+
+**UC-1 — Add a worker (fresh).** *Actor:* a user/agent running `gss feature worker add`.
+*Trigger:* `WorkerAdd` materializes the worktree. *Flow:* the seed render is written to
+`workerMetaPath(worktree)`; the meta dir is created first. *Acceptance:* `WORKER.md` exists at
+the meta path; the worktree root contains **no** `WORKER.md`; `git status --porcelain` in the
+worktree shows no `WORKER.md` line.
+
+**UC-2 — Two workers, one (feature,user).** *Actor:* a user adding `design` then `impl` (or two
+same-purpose workers, forcing a suffix). *Trigger:* second `worker add`. *Flow:* each leaf gets
+its own `.gss-meta/<leaf>/WORKER.md`. *Acceptance:* the two `WORKER.md` files are **distinct
+paths** with independent content; neither clobbers the other. (This is the regression guard that
+proves Option B over the rejected Option A.)
+
+**UC-3 — Auto-checkpoint skip writes a diagnostic.** *Actor:* the `auto-checkpoint` path.
+*Trigger:* `autoSkip` → `appendAutoLog(worktree, reason)`. *Flow:* the `## Auto-checkpoint log`
+line is appended to `workerMetaPath(worktree)`, creating the meta dir + file if absent.
+*Acceptance:* the diagnostic lands at the meta path even when `appendAutoLog` is the **first**
+writer (no prior seed); the worktree root stays free of `WORKER.md`.
+
+**UC-4 — Tear down a worker.** *Actor:* `gss feature done <worker>`. *Trigger:* after
+`Backend.Remove(worktree)`. *Flow:* `.gss-meta/<leaf>/` is removed; empty `.gss-meta` / `<user>`
+parents are best-effort removed on full-feature delete. *Acceptance:* after `done`, no
+`.gss-meta/<leaf>/` orphan remains under `~/.config/gss/worktrees`; the existing
+`os.Remove(featDir)` is not wedged by a leftover.
+
+**UC-5 — Legacy worktree migration.** *Actor:* a worktree created under the old layout (root
+`WORKER.md`). *Trigger:* the next `worker add` WRITE path **or** the next `appendAutoLog`.
+*Flow:* `migrateLegacyWorkerMD(worktree)` renames the root file to the meta path (preserving
+human edits + appended log) and, if it was git-tracked, runs `git rm --cached --quiet WORKER.md`.
+*Acceptance:* the file is at the meta path with content intact; `git status --porcelain` in the
+worktree is clean of `WORKER.md` afterward.
+
+## 3. Architecture
+
+Single package: `sdk/gss/internal/feature`. No registry-schema change, no CLI surface change.
+
+- **`workerMetaPath(worktree string) string`** — the one pure helper; the *interface contract*
+  every touchpoint routes through. Derives solely from the leaf worktree path:
+  `filepath.Join(filepath.Dir(worktree), ".gss-meta", filepath.Base(worktree), "WORKER.md")`.
+- **`migrateLegacyWorkerMD(worktree string)`** — idempotent legacy mover; invoked from both
+  writer paths.
+- **WRITE** (`worker.go:128`) and **APPEND** (`auto.go:142`) call the helper (+ `os.MkdirAll`).
+- **CLEANUP** (`done.go`) `os.RemoveAll`s the leaf meta dir.
+- **Data flow:** `worktree path` (already in `WorkerResult`/`registry.Worker`) → helper → meta
+  path. Nothing else consumes `WORKER.md` (`checkpoint.go:61` is a stale comment, no read).
+
+## 4. Behavior / features
+
+- **F1** `workerMetaPath` helper — single source of truth for the path.
+- **F2** WRITE seeds at the meta path (dir created first).
+- **F3** APPEND writes the auto-log at the meta path (dir created first; tolerant of being the
+  first writer).
+- **F4** `done.go` removes the leaf meta dir (+ best-effort empty-parent cleanup).
+- **F5** `migrateLegacyWorkerMD` moves a pre-existing root `WORKER.md` on both writer paths,
+  preserving content and un-tracking it if it was tracked.
+- **F6** Docs/skill: remove the `WORKER.md` clause from `SKILL.md` "Cleanup (Mandatory)" (keep
+  `FEATURE.md`); fix the stale `checkpoint.go:61` comment; document the new on-disk path in
+  `sdk/gss/docs/`.
+
+## 5. Evaluation criteria (per feature)
+
+| Feature | Fires (must) | Must-not-fire | Edge | Pass predicate (→ a test) |
+| :-- | :-- | :-- | :-- | :-- |
+| **F1** helper | returns `…/<feature>/<user>/.gss-meta/<leaf>/WORKER.md` for a leaf worktree | — | suffix'd leaf (`design-foo`) keys on the full leaf base | table test: input worktree → exact expected path, incl. suffix case |
+| **F2** WRITE | `WORKER.md` present at meta path after `WorkerAdd` | `WORKER.md` present in worktree **root** | meta dir absent → created | `worker_test.go`: Stat(meta)==nil **and** Stat(root WORKER.md)!=nil |
+| **F3** APPEND | diagnostic at meta path after `autoSkip` | nothing written into worktree root | `appendAutoLog` is first writer (no seed) | `auto_test.go`: read meta path contains the conflict/diagnostic string |
+| **F4** cleanup | `.gss-meta/<leaf>/` gone after `done` | unrelated sibling leaf's meta dir removed | empty `.gss-meta` parent removed on full delete | `done_test.go`: post-`done`, meta dir does not exist; sibling survives |
+| **F5** migration | legacy root `WORKER.md` ends at meta path, content preserved | a fresh worktree (no legacy file) is disturbed | tracked legacy file → `git rm --cached`, porcelain clean | migration test: seed root file → trigger writer → assert moved + clean porcelain |
+| **F6** docs | `SKILL.md` no longer mentions deleting `WORKER.md` | `FEATURE.md` cleanup wording removed | — | grep assertion in repo test / manual review: `SKILL.md` ∌ "WORKER.md" delete clause |
+
+**Two-sibling collision guard (UC-2 / proves B>A):** add a dedicated test creating two workers
+under one `(feature,user)` and asserting `workerMetaPath(wtA) != workerMetaPath(wtB)` and the
+two files hold independent content.
+
+## 6. Verification harness
+
+- **Unit (authoritative):** `go test ./internal/feature/...` in `sdk/gss`. The existing
+  `worker_test.go` / `auto_test.go` assertions are **inverted** (file outside worktree, at meta
+  path); new tests: helper table test, two-sibling guard, `done` cleanup, legacy migration
+  (incl. tracked-file porcelain-clean). Tests use the existing temp-dir backend so the meta path
+  is a real on-disk dir.
+- **Coverage gate:** the repo's `sdk/` Go **≥60%** coverage gate (`scripts/test.sh` / `Makefile`
+  / CI) must still pass for `internal/feature`.
+- **Integration guard:** `scripts/e2e-gss-integration.sh` (the tmux-mgr↔gss guard) must pass
+  against the rebuilt binary — **rebuild `gss` via `sdk/gss/build.sh`** after the change (tmux-mgr
+  shells out to the installed binary; a stale binary silently breaks it).
+- **Human-evidenced:** one real `gss feature worker add` in a scratch repo → confirm
+  `git status` is clean of `WORKER.md` and the file exists at the meta path
+  (`superpowers:verification-before-completion`).
+
+## 7. Prerequisites / dependencies
+
+None new. Touches only `sdk/gss` (`internal/feature`, `skill/SKILL.md`, `docs/`). No new Go
+deps, no registry-schema migration, no CLI flags.
+
+## 8. Out of scope (and why)
+
+- **Option D** (no file; render `WORKER.md` from the registry on demand) — changes the
+  agent-facing contract (`auto.go` writes to it; agents `cat`/edit it); larger refactor; tracked
+  separately if pursued.
+- **A parallel `FeatureMetaPath` helper for `FEATURE.md`** — `FEATURE.md` already lives outside
+  the worktree and is cleaned by `done.go`; refactoring it is optional polish, kept out to hold
+  the diff tight.
+- **Permissions / encryption changes** — `0o644` is correct for non-secret scaffolding.
+
+## 9. Rollback
+
+Revert the `internal/feature` commit (pure path move, no schema migration). New worktrees revert
+to root-seeding; the `SKILL.md` mandate is restored in the same revert. Stranded `.gss-meta`
+dirs under `~/.config/gss/worktrees` are gss-private and removable with
+`find ~/.config/gss/worktrees -type d -name .gss-meta -prune -exec rm -rf {} +`. No
+consumer-repo footprint was ever created, so nothing to unwind in any consumer checkout.
+
+> Produced from the architecture-team design (`../designs/worker-md-placement.md`). The matching
+> plan goes in `../plans/worker-md-placement.md`. Register / update `../index.md`.

--- a/sdk/gss/docs/design.md
+++ b/sdk/gss/docs/design.md
@@ -292,10 +292,20 @@ invariant on every build.
             └── <feature-name>/
                 ├── FEATURE.md           # shared feature-level metadata
                 └── <user>/
+                    ├── .gss-meta/                   # gss-internal scaffolding, OUTSIDE the worktrees (#132)
+                    │   └── <purpose>[-<suffix>]/
+                    │       └── WORKER.md            # worker notes + resume info; auto-removed by `feature done`
                     └── <purpose>[-<suffix>]/
-                        ├── WORKER.md    # worker-specific notes + resume info
-                        └── …            # checkout of feature/<name>/<user>/<purpose>[-<sfx>]
+                        └── …            # checkout of feature/<name>/<user>/<purpose>[-<sfx>] (NO WORKER.md inside)
 ```
+
+> **WORKER.md placement (issue #132).** `WORKER.md` is **leaf-keyed** under
+> `<user>/.gss-meta/<purpose>[-<suffix>]/`, deliberately one level keyed by the
+> worker leaf so two workers under the same `<feature>/<user>/` (e.g. `api` and
+> `impl`) get **distinct** files. It is written **outside** the git worktree so
+> it can never appear in the consumer repo's `git status` — without touching the
+> consumer's `.gitignore`. `feature worker add` seeds it, `checkpoint --auto`
+> appends its log there, and `feature done` removes the leaf's `.gss-meta` dir.
 
 `registry.json` schema:
 

--- a/sdk/gss/internal/feature/auto.go
+++ b/sdk/gss/internal/feature/auto.go
@@ -56,6 +56,12 @@ func (s *Service) AutoCheckpoint(ctx context.Context, opts AutoOpts) (AutoResult
 	w := reg.Features[fi].Workers[wi]
 	res := AutoResult{Ref: ref.String()}
 
+	// Upgrade path (issue #132): a worktree seeded by an older gss has a
+	// root-level WORKER.md. Relocate it to the meta path before any diagnostic
+	// append, so the legacy file doesn't linger in `git status`. No-op on
+	// worktrees already on the new layout.
+	_ = s.migrateLegacyWorkerMD(ctx, w.Worktree)
+
 	branch, _ := s.gitOut(ctx, w.Worktree, "rev-parse", "--abbrev-ref", "HEAD")
 	if branch == "" || branch == "HEAD" {
 		return s.autoSkip(w, "detached HEAD; skipping auto-checkpoint")
@@ -140,7 +146,13 @@ func (s *Service) autoSkip(w registry.Worker, reason string) (AutoResult, error)
 }
 
 func (s *Service) appendAutoLog(worktree, reason string) {
-	path := filepath.Join(worktree, "WORKER.md")
+	// WORKER.md lives OUTSIDE the worktree (issue #132). appendAutoLog can be
+	// the first writer (a skip before any seed/manual checkpoint), so ensure
+	// the leaf meta dir exists before opening with O_CREATE.
+	path := WorkerMetaPath(worktree)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return

--- a/sdk/gss/internal/feature/auto_test.go
+++ b/sdk/gss/internal/feature/auto_test.go
@@ -95,9 +95,14 @@ func TestAuto_DetachedHEADSkipsWithDiagnostic(t *testing.T) {
 	if !strings.Contains(res.Skipped, "detached") {
 		t.Errorf("Skipped = %q; want detached-HEAD reason", res.Skipped)
 	}
-	data, _ := os.ReadFile(filepath.Join(wt, "WORKER.md"))
+	// The diagnostic lands at the meta path OUTSIDE the worktree (issue #132),
+	// even though appendAutoLog is the first writer here (empty worktree).
+	if _, err := os.Stat(filepath.Join(wt, "WORKER.md")); !os.IsNotExist(err) {
+		t.Errorf("auto-log must not write WORKER.md into the worktree root (#132); err=%v", err)
+	}
+	data, _ := os.ReadFile(feature.WorkerMetaPath(wt))
 	if !strings.Contains(string(data), "detached") {
-		t.Errorf("WORKER.md missing diagnostic:\n%s", data)
+		t.Errorf("WORKER.md (meta path) missing diagnostic:\n%s", data)
 	}
 }
 
@@ -151,9 +156,9 @@ func TestAuto_RebaseConflictSkips(t *testing.T) {
 	if !strings.Contains(res.Skipped, "rebase conflict") {
 		t.Errorf("Skipped = %q; want rebase-conflict reason", res.Skipped)
 	}
-	data, _ := os.ReadFile(filepath.Join(wt, "WORKER.md"))
+	data, _ := os.ReadFile(feature.WorkerMetaPath(wt))
 	if !strings.Contains(string(data), "rebase conflict") {
-		t.Errorf("WORKER.md missing conflict diagnostic:\n%s", data)
+		t.Errorf("WORKER.md (meta path) missing conflict diagnostic:\n%s", data)
 	}
 }
 

--- a/sdk/gss/internal/feature/checkpoint.go
+++ b/sdk/gss/internal/feature/checkpoint.go
@@ -58,7 +58,7 @@ func (s *Service) Checkpoint(ctx context.Context, opts CheckpointOpts) (Checkpoi
 	}
 
 	body := renderPRBody(feat, ref)
-	title := fmt.Sprintf("%s: %s", ref.Feature, ref.Purpose) // first H1 of WORKER.md
+	title := fmt.Sprintf("%s: %s", ref.Feature, ref.Purpose) // from worker_ref; WORKER.md is never read
 
 	// Adopt-existing-PR: a registry row may have no pr_url yet an open PR
 	// already exists on GitHub for this head branch (opened on another

--- a/sdk/gss/internal/feature/done.go
+++ b/sdk/gss/internal/feature/done.go
@@ -69,6 +69,12 @@ func (s *Service) Done(ctx context.Context, opts DoneOpts) (DoneResult, error) {
 	if err := s.Backend.Remove(w.Worktree, opts.Force); err != nil {
 		return res, fmt.Errorf("feature done: remove worktree: %w", err)
 	}
+	// Tear down the worker's external WORKER.md home (issue #132). Nothing else
+	// touches the <feature>/<user>/.gss-meta tree, so without this the meta dir
+	// would accrete forever under the worktrees root. Best-effort-remove the now
+	// possibly-empty .gss-meta parent too (fails harmlessly if a sibling remains).
+	_ = os.RemoveAll(workerMetaDir(w.Worktree))
+	_ = os.Remove(filepath.Join(filepath.Dir(w.Worktree), ".gss-meta"))
 
 	// Decide empty-feature cleanup BEFORE mutating the registry.
 	willEmpty := len(feat.Workers) == 1

--- a/sdk/gss/internal/feature/done_test.go
+++ b/sdk/gss/internal/feature/done_test.go
@@ -58,6 +58,57 @@ func oneWorker() []registry.Worker {
 	return []registry.Worker{{User: "erai", Purpose: "api", Branch: "feature/auth/erai/api", Worktree: "/wt/api", BaseBranch: "main", Description: "api", PRState: "merged"}}
 }
 
+// TestDone_RemovesMetaDir proves teardown cleans up the worker's external
+// .gss-meta/<leaf>/ dir (issue #132) without disturbing a sibling worker's
+// meta dir under the same (feature,user).
+func TestDone_RemovesMetaDir(t *testing.T) {
+	root := t.TempDir()
+	wtA := filepath.Join(root, "octo/proj/auth/erai/api")
+	wtB := filepath.Join(root, "octo/proj/auth/erai/impl")
+	for _, wt := range []string{wtA, wtB} {
+		if err := os.MkdirAll(filepath.Dir(feature.WorkerMetaPath(wt)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(feature.WorkerMetaPath(wt), []byte("# worker\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	featDir := filepath.Join(root, "octo/proj", "auth")
+	if err := os.MkdirAll(featDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(featDir, "FEATURE.md"), []byte(cleanFeatureMD(t)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := registry.NewStore(filepath.Join(root, "registry.json"))
+	if err := store.Update(func(r *registry.Registry) error {
+		*r = registry.Registry{SchemaVersion: 1, Features: []registry.Feature{{
+			Name: "auth", StartedAt: "2026-05-21T12:00:00Z", DefaultBaseBranch: "main", Description: "login work",
+			Workers: []registry.Worker{
+				{User: "erai", Purpose: "api", Branch: "feature/auth/erai/api", Worktree: wtA, BaseBranch: "main", PRState: "merged"},
+				{User: "erai", Purpose: "impl", Branch: "feature/auth/erai/impl", Worktree: wtB, BaseBranch: "main", PRState: "merged"},
+			},
+		}}}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	svc := &feature.Service{
+		Store: store, Backend: &fakeBackend{},
+		Git:          &gitfake.Runner{Default: gitfake.Response{Stdout: []byte("")}}, // clean porcelain
+		WorktreeRoot: root, NWO: "octo/proj",
+	}
+	if _, err := svc.Done(context.Background(), feature.DoneOpts{WorkerRef: "auth/erai/api"}); err != nil {
+		t.Fatalf("Done: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(feature.WorkerMetaPath(wtA))); !os.IsNotExist(err) {
+		t.Errorf("api meta dir should be removed after done; stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(feature.WorkerMetaPath(wtB))); err != nil {
+		t.Errorf("sibling impl meta dir must survive; got err=%v", err)
+	}
+}
+
 func TestDoneOnEmptyFeatureMatchingTemplate(t *testing.T) {
 	svc, store, featDir := doneService(t, cleanFeatureMD(t), "", oneWorker())
 	res, err := svc.Done(context.Background(), feature.DoneOpts{WorkerRef: "auth/erai/api"})

--- a/sdk/gss/internal/feature/paths.go
+++ b/sdk/gss/internal/feature/paths.go
@@ -1,0 +1,65 @@
+package feature
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+)
+
+// WorkerMetaPath returns the on-disk location of a worker's WORKER.md, which
+// lives OUTSIDE the worker's git worktree so it can never appear in the
+// consumer repo's `git status` or be accidentally committed (issue #132).
+//
+// The path is leaf-keyed under a `.gss-meta/` namespace one level above the
+// worktree:
+//
+//	<feature>/<user>/.gss-meta/<leaf>/WORKER.md
+//
+// where <leaf> == filepath.Base(worktree) and <feature>/<user>/ ==
+// filepath.Dir(worktree). Keying on the leaf (not the shared <feature>/<user>/
+// parent) is what makes sibling workers collision-safe: `design/` and `impl/`
+// for the same user get distinct files. It derives solely from the worktree
+// path, so every touchpoint (seed write, auto-log append, teardown) agrees
+// without a registry-schema change.
+func WorkerMetaPath(worktree string) string {
+	return filepath.Join(filepath.Dir(worktree), ".gss-meta", filepath.Base(worktree), "WORKER.md")
+}
+
+// workerMetaDir is the per-leaf directory holding WORKER.md; teardown removes
+// it wholesale (done.go).
+func workerMetaDir(worktree string) string {
+	return filepath.Join(filepath.Dir(worktree), ".gss-meta", filepath.Base(worktree))
+}
+
+// migrateLegacyWorkerMD relocates a pre-existing root-level WORKER.md (seeded
+// by an older gss into the worktree itself) to the new meta path, so upgrading
+// gss does not strand the legacy file in `git status`. It is idempotent: a
+// no-op when no legacy file exists.
+//
+// Content is preserved (os.Rename, not rewrite). If the legacy file had been
+// committed, it is dropped from the index with `git rm --cached` so it leaves
+// `git status`; --ignore-unmatch makes that a no-op for the common (untracked)
+// case. worker add always creates a FRESH worktree, so the only path that ever
+// encounters a legacy file is auto-checkpoint over an existing worktree —
+// hence this runs at AutoCheckpoint entry.
+func (s *Service) migrateLegacyWorkerMD(ctx context.Context, worktree string) error {
+	legacy := filepath.Join(worktree, "WORKER.md")
+	if _, err := os.Stat(legacy); err != nil {
+		return nil // no legacy file → nothing to migrate
+	}
+	meta := WorkerMetaPath(worktree)
+	if _, err := os.Stat(meta); os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(meta), 0o755); err != nil {
+			return err
+		}
+		if err := os.Rename(legacy, meta); err != nil {
+			return err
+		}
+	} else {
+		// meta already authoritative → drop the stray legacy working copy.
+		_ = os.Remove(legacy)
+	}
+	// Clear it from the index if it was ever committed (no-op when untracked).
+	_, _ = s.Git.Run(ctx, "-C", worktree, "rm", "--cached", "--ignore-unmatch", "--quiet", "--", "WORKER.md")
+	return nil
+}

--- a/sdk/gss/internal/feature/paths_test.go
+++ b/sdk/gss/internal/feature/paths_test.go
@@ -1,0 +1,127 @@
+// Internal tests for the WORKER.md path helper and legacy migration
+// (issue #132). These live in `package feature` because migrateLegacyWorkerMD
+// is unexported; WorkerMetaPath is exported and also exercised from the
+// external feature_test package.
+package feature
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gitfake "github.com/sfc-gh-eraigosa/dotfiles/sdk/gss/internal/git/fake"
+)
+
+func TestWorkerMetaPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		worktree string
+		want     string
+	}{
+		{
+			name:     "plain leaf",
+			worktree: "/root/wt/octo/proj/auth/erai/api",
+			want:     "/root/wt/octo/proj/auth/erai/.gss-meta/api/WORKER.md",
+		},
+		{
+			name:     "suffixed leaf keys on the full leaf base",
+			worktree: "/root/wt/octo/proj/auth/erai/api-moss",
+			want:     "/root/wt/octo/proj/auth/erai/.gss-meta/api-moss/WORKER.md",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := WorkerMetaPath(tc.worktree); got != tc.want {
+				t.Errorf("WorkerMetaPath(%q) = %q; want %q", tc.worktree, got, tc.want)
+			}
+		})
+	}
+}
+
+// metaSiblingOfWorktree asserts the documented invariant: the meta file is
+// OUTSIDE the worktree (never under it), which is the whole point of #132.
+func TestWorkerMetaPath_OutsideWorktree(t *testing.T) {
+	wt := "/root/wt/octo/proj/auth/erai/api"
+	meta := WorkerMetaPath(wt)
+	if rel, err := filepath.Rel(wt, meta); err == nil && !filepathEscapes(rel) {
+		t.Errorf("meta path %q is INSIDE the worktree %q (rel=%q); #132 requires it outside", meta, wt, rel)
+	}
+}
+
+// filepathEscapes reports whether a relative path steps out of its base
+// (begins with ".."), i.e. the target is not contained by the base.
+func filepathEscapes(rel string) bool {
+	return rel == ".." || len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator)
+}
+
+func TestMigrateLegacyWorkerMD_MovesUntracked(t *testing.T) {
+	wt := t.TempDir()
+	legacy := filepath.Join(wt, "WORKER.md")
+	if err := os.WriteFile(legacy, []byte("# seeded\nhand edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &Service{Git: &gitfake.Runner{}}
+	if err := s.migrateLegacyWorkerMD(context.Background(), wt); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("legacy root WORKER.md still present (err=%v)", err)
+	}
+	got, err := os.ReadFile(WorkerMetaPath(wt))
+	if err != nil {
+		t.Fatalf("meta file not created: %v", err)
+	}
+	if string(got) != "# seeded\nhand edit\n" {
+		t.Errorf("content not preserved: %q", got)
+	}
+}
+
+func TestMigrateLegacyWorkerMD_NoLegacyIsNoOp(t *testing.T) {
+	wt := t.TempDir()
+	gitr := &gitfake.Runner{}
+	s := &Service{Git: gitr}
+	if err := s.migrateLegacyWorkerMD(context.Background(), wt); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if len(gitr.Calls) != 0 {
+		t.Errorf("no legacy file → no git calls; got %+v", gitr.Calls)
+	}
+	if _, err := os.Stat(WorkerMetaPath(wt)); !os.IsNotExist(err) {
+		t.Errorf("no-op migration must not create the meta file")
+	}
+}
+
+func TestMigrateLegacyWorkerMD_TrackedFileDroppedFromIndex(t *testing.T) {
+	wt := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wt, "WORKER.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitr := &gitfake.Runner{}
+	s := &Service{Git: gitr}
+	if err := s.migrateLegacyWorkerMD(context.Background(), wt); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// A tracked legacy file must be removed from the index so it leaves
+	// `git status`; --ignore-unmatch makes this a no-op when untracked.
+	var sawRmCached bool
+	for _, c := range gitr.Calls {
+		if argsHas(c.Args, "rm") && argsHas(c.Args, "--cached") && argsHas(c.Args, "WORKER.md") {
+			sawRmCached = true
+		}
+	}
+	if !sawRmCached {
+		t.Errorf("expected `git rm --cached -- WORKER.md`; calls=%+v", gitr.Calls)
+	}
+}
+
+// argsHas is a tiny local contains-helper (the external test package has its
+// own argsHasFC; this internal test needs its own).
+func argsHas(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}

--- a/sdk/gss/internal/feature/worker.go
+++ b/sdk/gss/internal/feature/worker.go
@@ -125,7 +125,14 @@ func (s *Service) WorkerAdd(ctx context.Context, opts WorkerAddOpts) (WorkerResu
 	if err != nil {
 		return WorkerResult{}, err
 	}
-	if err := os.WriteFile(filepath.Join(res.Worktree, "WORKER.md"), []byte(content), 0o644); err != nil {
+	// Seed WORKER.md OUTSIDE the worktree (issue #132) so it can never appear
+	// in the consumer repo's git status. WorkerMetaPath is leaf-keyed, so
+	// sibling workers under one (feature,user) get distinct files.
+	metaPath := WorkerMetaPath(res.Worktree)
+	if err := os.MkdirAll(filepath.Dir(metaPath), 0o755); err != nil {
+		return WorkerResult{}, fmt.Errorf("feature: create WORKER.md dir: %w", err)
+	}
+	if err := os.WriteFile(metaPath, []byte(content), 0o644); err != nil {
 		return WorkerResult{}, fmt.Errorf("feature: write WORKER.md: %w", err)
 	}
 	return res, nil

--- a/sdk/gss/internal/feature/worker_test.go
+++ b/sdk/gss/internal/feature/worker_test.go
@@ -39,12 +39,44 @@ func TestWorkerAdd_CreatesWorker(t *testing.T) {
 	if n := len(reg.Features[0].Workers); n != 1 {
 		t.Fatalf("workers = %d; want 1", n)
 	}
-	// Worktree materialized via backend + WORKER.md written.
+	// Worktree materialized via backend.
 	if len(be.created) != 1 || be.created[0].Branch != res.Branch {
 		t.Errorf("backend.Create = %+v; want one with branch %s", be.created, res.Branch)
 	}
-	if _, err := os.Stat(filepath.Join(res.Worktree, "WORKER.md")); err != nil {
-		t.Errorf("WORKER.md not written: %v", err)
+	// WORKER.md is seeded OUTSIDE the worktree (issue #132): present at the
+	// meta path, absent from the worktree root so it can never appear in the
+	// consumer repo's git status.
+	if _, err := os.Stat(feature.WorkerMetaPath(res.Worktree)); err != nil {
+		t.Errorf("WORKER.md not written at meta path: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(res.Worktree, "WORKER.md")); !os.IsNotExist(err) {
+		t.Errorf("WORKER.md must NOT exist in the worktree root (#132); stat err=%v", err)
+	}
+}
+
+// TestWorkerAdd_SiblingLeavesDistinct is the regression guard that proves the
+// leaf-keyed location (Option B) over the issue's shared-parent proposal
+// (Option A): two workers under the same (feature,user) get DISTINCT WORKER.md
+// files that do not clobber each other.
+func TestWorkerAdd_SiblingLeavesDistinct(t *testing.T) {
+	svc, _, _ := startedFeature(t)
+	ctx := context.Background()
+	a, err := svc.WorkerAdd(ctx, feature.WorkerAddOpts{Feature: "auth", Purpose: "api", Description: "first"})
+	if err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	b, err := svc.WorkerAdd(ctx, feature.WorkerAddOpts{Feature: "auth", Purpose: "api", Description: "second"})
+	if err != nil {
+		t.Fatalf("second add: %v", err)
+	}
+	pa, pb := feature.WorkerMetaPath(a.Worktree), feature.WorkerMetaPath(b.Worktree)
+	if pa == pb {
+		t.Fatalf("sibling workers share a WORKER.md path %q — Option A collision", pa)
+	}
+	for _, p := range []string{pa, pb} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("sibling WORKER.md missing at %q: %v", p, err)
+		}
 	}
 }
 

--- a/sdk/gss/skill/SKILL.md
+++ b/sdk/gss/skill/SKILL.md
@@ -133,11 +133,17 @@ classic `--force-autonomous` inside a worker worktree.
 - Give every feature and worker a short, specific `--description`; it seeds
   FEATURE.md / WORKER.md and the PR body (NFC-normalised; control chars and
   injection markers stripped).
-- **Cleanup (Mandatory)**: `WORKER.md` and `FEATURE.md` are transient
-  scaffolding files used for development tracking and PR seeding. They MUST NOT
-  remain in the repository once the work is finalized. Delete and commit the
-  removal of `WORKER.md` (and `FEATURE.md` if present and unneeded) as the last
-  step before running `gss feature pr --ready` or merging.
+- **`WORKER.md` placement (issue #132)**: `WORKER.md` is seeded **outside** the
+  worker's git worktree, at
+  `<worktrees-root>/<owner>/<repo>/<feature>/<user>/.gss-meta/<leaf>/WORKER.md`,
+  so it never appears in the consumer repo's `git status` and **cannot** be
+  accidentally committed. There is **no manual cleanup step** — `gss feature
+  done` removes the worker's `.gss-meta/<leaf>/` automatically. (An older gss
+  may have left a root-level `WORKER.md` inside the worktree; the next
+  `checkpoint --auto` relocates it to the meta path.)
+- **`FEATURE.md` cleanup**: `FEATURE.md` is transient feature-level scaffolding;
+  `gss feature done` removes it when the feature empties and it carries no human
+  edits (an edited FEATURE.md is retained with a notice). No manual step needed.
 - `spawned_by` (engine/session/pane) is **informational only** — never the
   basis for a trust or control decision (design.md resolution #8).
 


### PR DESCRIPTION
**Closes #132.** Moves the gss worker `WORKER.md` outside the git worktree so it can never appear in the consumer repo's `git status` or be accidentally committed — without touching the consumer's `.gitignore`. Design → implementation in one PR (design/spec/plan + code).

## Design (architecture-team Workflow: sysarch · principal · secarch · adversary)
Evaluated four options and **rejected the issue's own proposal**:
- **Option A** (`<feature>/<user>/WORKER.md`) — *rejected*: shared by every leaf one user owns under a feature, so sibling workers clobber each other and interleave auto-logs.
- **Option C** (`.git/info/exclude`) — *rejected*: the adversary **empirically disproved** it (a linked worktree resolves `info/exclude` to the shared common file = consumer-repo pollution).
- **Decision: Option B** — leaf-keyed `<feature>/<user>/.gss-meta/<leaf>/WORKER.md`.

## Implementation (TDD, tests-first)
- `internal/feature/paths.go` (new) — exported `WorkerMetaPath` (single source of truth) + `migrateLegacyWorkerMD`.
- `worker.go` seeds at the meta path; `auto.go` appends there + migrates legacy worktrees once at `AutoCheckpoint` entry; `done.go` removes the leaf `.gss-meta` dir.
- `checkpoint.go` stale-comment fix; `SKILL.md` retires the manual cleanup mandate; `docs/design.md` layout updated.
- **Coverage 83.1%** (gate 60%); e2e-gss-integration guard passes; verified in a real scratch repo (`git status` clean, file at the meta path).

## Artifacts
`docs/mbo/{designs,specs,plans}/worker-md-placement.md` + `index.md` (state: in-review).

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **worker-md-placement**.

- **#133 — edward-raigosa/design (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->