### PR TITLE
fix(windows): correct src->sdk font-installer path in setup-apps.ps1

### DIFF
--- a/opt/Desktop/Apps/scripts/setup-apps.ps1
+++ b/opt/Desktop/Apps/scripts/setup-apps.ps1
@@ -178,7 +178,7 @@ function Install-NerdFont {
     # setup-apps.ps1 sits at opt/Desktop/Apps/scripts/; the gsl script is at
     # sdk/gsl/scripts/ — four levels up, then into sdk/gsl/scripts.
     $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
-    $fontScript = Join-Path $repoRoot 'src\gsl\scripts\install_nerd_font_windows.ps1'
+    $fontScript = Join-Path $repoRoot 'sdk\gsl\scripts\install_nerd_font_windows.ps1'
     if (-not (Test-Path $fontScript)) {
         Write-Host "Nerd Font installer not found at $fontScript -- skipping." -ForegroundColor Yellow
         return


### PR DESCRIPTION
## What
Fix a one-line stale path in `opt/Desktop/Apps/scripts/setup-apps.ps1`: the `Install-NerdFont` phase referenced `src\gsl\scripts\install_nerd_font_windows.ps1`, but the installer moved to `sdk\gsl\scripts\` during the src/->sdk/ Go-module migration. Now points at `sdk\gsl\scripts\`.

## Why
With the wrong path, `Test-Path` failed and the Windows-Terminal Font phase **silently skipped** — no Nerd Font was installed and `$TerminalFont` fell back to the literal `'MesloLGS NF'` (a font nothing installs). That name was then written into all 10 Windows Terminal profiles, so the gsl powerline/Nerd Font glyphs rendered as missing boxes — and it recurred on every provisioning run. It was the only remaining stale `src\(gss|gsl|wol|tmux-mgr)` reference in the repo.

## Impact
- Restores the **self-correcting** design: the installer registers `MesloLGS Nerd Font`, returns the family name, and `setup-apps.ps1` assigns it to `$TerminalFont` — so Terminal profiles can no longer drift from the installed font.
- No behavior change on macOS/Linux. Windows/WSL only.

## Testing
- Re-ran `setup-apps.ps1` on Windows: Font phase now executes (`Activated MesloLGS Nerd Font`) instead of skipping; Terminal phase wrote 5 schemes + 10 profiles.
- Verified live `settings.json`: 10/10 profiles now use the registered `MesloLGS Nerd Font`, 0 use the old `MesloLGS NF`. Glyphs render correctly (no terminal restart needed).