### PR TITLE
fix-macos-install-path: impl

### DIFF
--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -76,3 +76,26 @@ jobs:
           done < <(find . -name '*.sh' -type f ! -path '*/.*' ! -path '*/opt/google-cloud-sdk/*')
           if [ "$rc" -eq 0 ]; then echo "All *.sh files are bash-syntax-valid"; fi
           exit "$rc"
+
+      - name: Guard — no zsh-only `read -A` in bash scripts
+        # ENFORCING gate (not warn-only): `read -A` is zsh array-read; under
+        # bash it errors ("read: -A: invalid option") — the exact failure that
+        # collapsed macOS install.sh. shellcheck does NOT flag it, so we guard
+        # explicitly. Scans *.sh plus the bash-sourced profile dotfiles, but
+        # NOT .zshrc (where `read -A` is legitimate zsh). Comment lines are
+        # ignored. See docs/mbo/specs/shell-portability.md §2.3.
+        run: |
+          bash_profiles="opt/profiles/.bashrc opt/profiles/.profile opt/profiles/.bash_aliases opt/profiles/.bash_logout opt/profiles/.docker.sh opt/profiles/.goenv.sh opt/profiles/.nano_profile opt/profiles/.xsessionrc"
+          sh_files=$(find . -name '*.sh' -type f ! -path '*/.*' ! -path '*/opt/google-cloud-sdk/*')
+          # grep -H always prints filename; drop comment-only matches (… :NN: #…).
+          # SC2086 intentionally suppressed: $sh_files / $bash_profiles MUST
+          # word-split to expand into the argument list grep scans.
+          # shellcheck disable=SC2086
+          hits=$(grep -nHE 'read[[:space:]]+-[A-Za-z]*A([[:space:]]|$)' $sh_files $bash_profiles 2>/dev/null \
+                   | grep -vE ':[0-9]+:[[:space:]]*#' || true)
+          if [ -n "$hits" ]; then
+            echo "$hits"
+            echo "::error::zsh-only 'read -A' found in a bash script. Use 'read -a' or mapfile/readarray. See docs/mbo/specs/shell-portability.md §2.3"
+            exit 1
+          fi
+          echo "OK: no zsh-only 'read -A' in bash scripts"

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -1,0 +1,78 @@
+name: Shell Lint
+
+# Shell Lint — dedicated CI job that runs shellcheck over all *.sh files
+# and detects shell-portability issues (issue #46 / shell-portability spec).
+# This workflow is path-filtered to avoid running on every repo push; it
+# runs when shell-related files change or the workflow itself is updated.
+#
+# Pin-to-SHA convention (issue #46 phase 5): Every third-party GitHub
+# Action is pinned to a full 40-char commit SHA with a trailing `# vX.Y.Z`
+# comment. See docker-image.yml for the full rationale.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.sh'
+      - '**/.bashrc'
+      - '**/.profile'
+      - 'Makefile'
+      - '.shellcheckrc'
+      - 'opt/profiles/**'
+      - '.github/workflows/shell-lint.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/*.sh'
+      - '**/.bashrc'
+      - '**/.profile'
+      - 'Makefile'
+      - '.shellcheckrc'
+      - 'opt/profiles/**'
+      - '.github/workflows/shell-lint.yml'
+  workflow_dispatch:
+
+concurrency:
+  # Cancel in-flight runs of the same workflow if a new push arrives on the
+  # same branch/ref. This reduces runner usage when a developer pushes
+  # multiple commits in quick succession.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell-lint:
+    name: Shell Lint (shellcheck)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Run make lint-shell
+        # WARN-ONLY: the phase-1 baseline ships ~90 shell findings (see
+        # .ci-baseline-issues.md). `continue-on-error: true` keeps shellcheck
+        # RUNNING and surfacing every finding in the step log without blocking
+        # the PR — mirroring `make lint` in docker-image.yml. The `make
+        # lint-shell` target itself is STRICT (exits non-zero); the warn-only
+        # gate is here. Drop this line once the shell backlog reaches zero so
+        # shell-portability regressions become hard failures.
+        continue-on-error: true
+        run: make lint-shell
+
+      - name: Syntax check — bash -n over all *.sh
+        # ENFORCING gate (not warn-only): a real bash syntax error is never
+        # "backlog", so it must block. Excludes .zshrc (zsh syntax), dotfiles
+        # /.git, and opt/google-cloud-sdk (vendored). find's exit status does
+        # NOT reflect -exec failures, so track failures explicitly and exit.
+        run: |
+          rc=0
+          while IFS= read -r f; do
+            bash -n "$f" || { echo "::error file=$f::bash -n reported a syntax error"; rc=1; }
+          done < <(find . -name '*.sh' -type f ! -path '*/.*' ! -path '*/opt/google-cloud-sdk/*')
+          if [ "$rc" -eq 0 ]; then echo "All *.sh files are bash-syntax-valid"; fi
+          exit "$rc"

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -38,6 +38,13 @@ Welcome to the dotfiles repository. This file serves as the entry point for agen
 
 ## Portability & Best Practices
 
+- **Shell Portability Standard (read before writing any `.sh`)**: All shell scripts and sourced
+  profile fragments MUST follow [docs/mbo/specs/shell-portability.md](./docs/mbo/specs/shell-portability.md) —
+  the normative contract for working identically across **WSL2-Ubuntu, macOS (zsh + BSD coreutils + bash 3.2),
+  and Linux (Raspberry Pi / Jetson Nano)**. It covers shebang policy, banned zsh-isms (`read -A`), BSD-vs-GNU
+  coreutil traps (`sed -i`, `stat`, `date`, …), the mandatory `eval "$(tool init)"` PATH-clobber guard (the
+  bug that broke macOS `install.sh`), and a per-script checklist. CI enforces the mechanical parts via
+  `make lint-shell` and the `shell-lint` workflow; review enforces the rest.
 - **Use $HOME**: Always use `${HOME}` or `~` instead of absolute home paths (e.g., `/home/wenlock` or `/Users/eraigosa`) in scripts, aliases, and configuration files to ensure they are portable across different systems and users.
 - **Avoid Hardcoded Usernames**: Never hardcode usernames in paths or instructions; use environment variables like `$USER` if needed.
 - **Avoid Hardcoded Paths**: Use relative paths or environment variables (like `BASE_DIR` in `install.sh`) whenever possible.

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ lint-go: ## Lint Go modules (gofmt + golangci-lint, per-module)
 
 .PHONY: lint-shell
 lint-shell: ## Lint shell scripts with shellcheck
-	@echo "==> shellcheck (opt/scripts, ai, opt/profiles, install.sh)"
+	@echo "==> shellcheck (all *.sh files)"
 	# Phase 5 (issue #46) extended the scope to opt/profiles/ so the
 	# user-facing shell entrypoints (.bashrc, .profile, .bash_aliases,
 	# .docker.sh, .goenv.sh, .nano_profile, .xsessionrc, .bash_logout)
@@ -123,7 +123,19 @@ lint-shell: ## Lint shell scripts with shellcheck
 	# fail the whole job regardless of `-S warning`. Zsh-specific linting
 	# would need a different tool (zsh-syntax-check or `zsh -n`); see
 	# .ci-baseline-issues.md for the deferred-work note.
-	@files=$$(find opt/scripts ai -name '*.sh' -type f 2>/dev/null) ; \
+	#
+	# Phase 8 (issue #46 / shell-portability) extended coverage to sdk/**,
+	# src/**, and opt/bin/** to close the gap on ~17 previously-unlinted
+	# scripts (build.sh, test helpers, setup scripts, utilities).
+	#
+	# This target is STRICT — it exits non-zero on any finding (shellcheck
+	# -S warning returns non-zero even for warnings). That is intentional and
+	# matches lint-go / lint-markdown: `make lint` locally surfaces the full
+	# backlog with a non-zero exit (see .ci-baseline-issues.md). The warn-only
+	# gate lives at the WORKFLOW level (`continue-on-error: true` in
+	# docker-image.yml and shell-lint.yml), NOT here — so do not add `|| true`.
+	# Drop the workflow continue-on-error once the shell backlog reaches zero.
+	@files=$$(find opt/scripts ai sdk src opt/bin -name '*.sh' -type f ! -path '*/.*' ! -path '*/opt/google-cloud-sdk/*' 2>/dev/null) ; \
 		profile_dotfiles="opt/profiles/.bashrc opt/profiles/.profile opt/profiles/.bash_aliases opt/profiles/.bash_logout opt/profiles/.docker.sh opt/profiles/.goenv.sh opt/profiles/.nano_profile opt/profiles/.xsessionrc" ; \
 		profile_sh=$$(find opt/profiles -maxdepth 1 -name '*.sh' -type f 2>/dev/null) ; \
 		shellcheck -x -S warning install.sh $$files $$profile_sh $$profile_dotfiles

--- a/docs/mbo/index.md
+++ b/docs/mbo/index.md
@@ -24,6 +24,7 @@ done` (also `parked`, `superseded`).
 | `mbo` | this folder + the `mbo-plan` skill (`ai/skills/mbo-plan/`) | — | — | — | #127 | in-review |
 | `worker-md-placement` | [design](./designs/worker-md-placement.md) | [spec](./specs/worker-md-placement.md) | [plan](./plans/worker-md-placement.md) | [#132](https://github.com/sfc-gh-eraigosa/dotfiles/issues/132) | #133 | merged |
 | `memory-provisioning` | [design](./designs/memory-provisioning.md) | [spec](./specs/memory-provisioning.md) | [plan](./plans/memory-provisioning.md) | [#134](https://github.com/sfc-gh-eraigosa/dotfiles/issues/134) | #135 | in-review |
+| `shell-portability` | — | [spec](./specs/shell-portability.md) | — | — | (this PR) | building |
 
 ## Merged / historical (pre-MBO — tracking columns best-effort)
 

--- a/docs/mbo/specs/shell-portability.md
+++ b/docs/mbo/specs/shell-portability.md
@@ -1,0 +1,146 @@
+# Shell Portability Standard
+
+**Status:** specifying → building · **Slug:** `shell-portability` · **Owner:** edward-raigosa
+
+The contract every shell script and sourced profile fragment in this repo MUST follow so
+that one checkout behaves identically across our three supported host families. This standard
+is **normative**: CI (`make lint-shell` + the `shell-lint` workflow) enforces the mechanical
+parts, and code review enforces the rest.
+
+> **Why this exists.** `./install.sh` on macOS catastrophically failed when
+> `eval "$(goenv init -)"` clobbered `PATH`, after which *every* coreutil
+> (`tr`, `uname`, `git`, `mkdir`, `curl`, `bash`…) became `command not found`
+> and the remainder of the install silently collapsed. The same checkout also
+> surfaced a `read -A` (zsh-only) error from a drifted local copy. Both are
+> classic cross-shell / cross-OS portability failures. This document captures
+> the rules that prevent the whole class.
+
+---
+
+## 1. Target platform matrix
+
+| Family | Login shell | Script interpreter | Coreutils | Notes |
+| :-- | :-- | :-- | :-- | :-- |
+| **WSL2 + Ubuntu** (20.04 LTS and newer) | bash (often zsh) | bash 5.x | GNU | Windows interop on `PATH`; `uname -r` ends in `-microsoft-*`/`-Microsoft`. |
+| **macOS** (Apple Silicon & Intel) | **zsh** (default since Catalina) | **bash 3.2** system bash, or Homebrew bash 5 | **BSD** (+ optional `coreutils` keg) | The single biggest source of portability bugs — BSD tools and an ancient `/bin/bash`. |
+| **Linux** — Raspberry Pi OS, Jetson **Nano**, generic | bash | bash 5.x | GNU | ARM; sometimes minimal images (no `curl`, no `git` until installed). |
+
+A script is "portable" only if it works on **all three** without modification.
+
+---
+
+## 2. The rules
+
+### 2.1 Shebang & shell declaration
+- **Executable scripts:** first line MUST be `#!/usr/bin/env bash` (not `#!/bin/bash` — on
+  macOS `/bin/bash` is the 3.2 relic; `env bash` picks up Homebrew bash 5 when present).
+- **Sourced profile fragments** (`.bashrc`, `.zshrc`, `.goenv.sh`, `.docker.sh`, …) have **no
+  shebang** because they are `source`d. They are read by **both bash and zsh**, so their code
+  MUST be dual-shell safe (see §2.3). Add a `# shellcheck shell=bash` directive at the top so
+  shellcheck lints them deterministically.
+
+### 2.2 Two shell worlds — keep them straight
+1. **Scripts** run under bash → bash features are fine **subject to the bash-3.2 caveat (§2.4)**.
+2. **Sourced fragments** run under whatever the user's login shell is (bash *or* zsh) → restrict
+   to constructs that mean the same thing in both, or guard by `$ZSH_VERSION` / `$BASH_VERSION`.
+
+### 2.3 Banned cross-shell-isms
+- **`read -A`** is zsh array-read; in bash it is an error (`read: -A: invalid option`). In a
+  bash script use `read -a` (or `mapfile`/`readarray`, bash 4+). In a **sourced fragment** that
+  both shells read, avoid array reads entirely or branch on `$ZSH_VERSION`.
+- No `setopt`, `${(s:x:)var}`, `${~var}`, `=command`, or zsh glob qualifiers in bash scripts.
+- Conversely, no bash-only `declare -A`, `${var,,}`, `mapfile` in sourced fragments unless
+  guarded — zsh chokes on them.
+- Prefer `[[ … ]]` (works in bash **and** zsh) over `[ … ]` only when you need its features;
+  pure-POSIX `[ … ]` is always safe.
+
+### 2.4 macOS bash is 3.2 (2007) — avoid bash-4+ features in `/bin/bash`-reachable code
+Associative arrays (`declare -A`), `${var,,}` / `${var^^}` case conversion, `mapfile`/`readarray`,
+and `|&` are bash-4+. They break under macOS system bash. Either (a) require `#!/usr/bin/env bash`
+**and** ensure Homebrew bash is installed, or (b) write 3.2-compatible code. Document which path a
+script takes.
+
+### 2.5 BSD vs GNU coreutils (macOS ships BSD) — the high-frequency traps
+| Tool | GNU (Linux/WSL) | BSD (macOS) | Portable approach |
+| :-- | :-- | :-- | :-- |
+| `sed -i` | `sed -i 's/…/…/' f` | `sed -i '' 's/…/…/' f` | Use a tmpfile + `mv`, or `perl -pi -e`. |
+| `stat` mtime | `stat -c %Y f` | `stat -f %m f` | Try one, fall back to the other (see §4). |
+| `date` | `date -d @123` | `date -r 123` / `date -v` | Branch on OS, or compute in shell. |
+| `readlink -f` | yes | no (old BSD) | Ship a `realpath()` shell shim or use `cd … && pwd`. |
+| `grep -P` (PCRE) | yes | no | Use `-E` (ERE) and rewrite the pattern. |
+| `base64 -w0` | yes | no `-w` | `base64 | tr -d '\n'`. |
+| `find -printf` | yes | no | `find … -exec` / `-print0 | while read`. |
+| `timeout` | yes | not by default | Guard with `command -v timeout`. |
+
+### 2.6 `eval "$(tool init -)"` MUST NOT be able to clobber `PATH`
+`goenv`/`pyenv`/`rbenv`/`nvm` init evals can (and on macOS *did*) emit a `PATH` assignment that
+drops the system bin dirs. **Always guard** so `/usr/bin` survives — capture a known-good `PATH`
+before the eval and restore it if the system dirs vanish:
+
+```sh
+__path_safe="$PATH"
+eval "$(goenv init -)"
+case ":${PATH}:" in
+    *":/usr/bin:"*) : ;;                      # system PATH survived
+    *) PATH="${PATH}:${__path_safe}" ;;       # init clobbered PATH; restore
+esac
+export PATH
+unset __path_safe
+```
+
+This guard is itself POSIX (`case` + parameter expansion) so it is safe in bash **and** zsh.
+Reference implementations: `install.sh` (goenv block) and `opt/profiles/.goenv.sh`.
+
+### 2.7 PATH & command hygiene
+- Never assume any binary exists — `command -v foo >/dev/null || { echo "need foo"; … }`.
+- Use `command -v`, never `which` (not guaranteed installed; BSD/GNU differ).
+- Keep `/usr/bin:/bin:/usr/sbin:/sbin` on `PATH`; prepend tool dirs, never replace.
+
+### 2.8 Portability-safe defaults
+- Quote every expansion (`"${var}"`); `set -euo pipefail` is encouraged for **scripts** (never
+  in sourced fragments — it would change the user's interactive shell).
+- Use `$HOME`/`~`, never hardcoded `/Users/...` or `/home/...` (see root `CLAUDE.md`).
+- Detect WSL via `uname -r` matching `-[Mm]icrosoft`; detect macOS via `[ "$(uname -s)" = Darwin ]`.
+
+---
+
+## 3. Enforcement
+
+| Layer | Mechanism | Scope |
+| :-- | :-- | :-- |
+| Config | `.shellcheckrc` (`external-sources=true`, SC1090/91 disabled) | repo-wide |
+| Local/CI lint | `make lint-shell` → `shellcheck -x -S warning` | all `*.sh` + listed profile dotfiles |
+| Dedicated CI | `.github/workflows/shell-lint.yml` | **every** `*.sh` on push/PR |
+| Syntax gate | `bash -n` in the shell-test harness | per script |
+| Review | This standard | everything shellcheck can't see (runtime `PATH`, BSD/GNU, bash-3.2) |
+
+`make lint-shell` historically scanned only `install.sh` + `opt/scripts/**` + `ai/**` +
+`opt/profiles/*`. The shell-lint workflow closes the coverage gap to include `sdk/**`, `src/**`,
+and `opt/bin/**` (≈17 previously-unlinted scripts).
+
+---
+
+## 4. Worked example — the `stat` mtime fallback (already in `opt/profiles/.goenv.sh`)
+
+```sh
+if mtime=$(stat -f %m "${file}" 2>/dev/null); then   # BSD / macOS
+    :
+else
+    mtime=$(stat -c %Y "${file}" 2>/dev/null || echo 0)  # GNU / Linux
+fi
+```
+
+Try the BSD form, fall back to GNU, default to `0`. This is the canonical "probe, don't assume"
+shape for any tool whose flags differ across coreutils.
+
+---
+
+## 5. Checklist for a new / changed shell script
+
+- [ ] `#!/usr/bin/env bash` (script) **or** `# shellcheck shell=bash` (sourced fragment).
+- [ ] `shellcheck -x -S warning` clean; `bash -n` clean.
+- [ ] No `read -A` / zsh-isms in bash; no unguarded bash-4+ in `/bin/bash`-reachable or sourced code.
+- [ ] Every coreutil flag verified on **both** BSD and GNU (or probed with a fallback).
+- [ ] Any `eval "$(tool init)"` wrapped in the §2.6 `PATH` guard.
+- [ ] No hardcoded home paths; binaries checked with `command -v` before use.
+- [ ] Mentally run it on macOS-zsh, WSL-Ubuntu, and a Pi/Nano before claiming done.

--- a/docs/mbo/specs/shell-portability.md
+++ b/docs/mbo/specs/shell-portability.md
@@ -72,14 +72,35 @@ script takes.
 | `find -printf` | yes | no | `find … -exec` / `-print0 | while read`. |
 | `timeout` | yes | not by default | Guard with `command -v timeout`. |
 
-### 2.6 `eval "$(tool init -)"` MUST NOT be able to clobber `PATH`
-`goenv`/`pyenv`/`rbenv`/`nvm` init evals can (and on macOS *did*) emit a `PATH` assignment that
-drops the system bin dirs. **Always guard** so `/usr/bin` survives — capture a known-good `PATH`
-before the eval and restore it if the system dirs vanish:
+### 2.6 `eval "$(tool init -)"` — pass the shell explicitly, and guard `PATH`
+Two distinct hazards, both real and both observed on macOS:
+
+**(a) Pass the shell name — do not let the tool infer it.** `goenv init -` (and
+`pyenv`/`rbenv`) infer the target shell from **`$SHELL`**, *not* the shell actually running the
+script. On a host whose login shell is zsh (`$SHELL=…/zsh`), a **bash** script that runs bare
+`eval "$(goenv init -)"` gets **zsh** code back — including a `while IFS=: read -rA … done <<<
+"$PATH"` PATH-rebuild loop. Bash errors `read: -A: invalid option`, the loop's accumulator stays
+empty, and the trailing `export PATH="$_NEW_PATH"` **wipes PATH** — after which every coreutil is
+"command not found". Always name the shell:
+
+```sh
+eval "$(goenv init - bash)"        # in a bash script — forces bash-safe output
+```
+
+In a fragment sourced by *either* shell (`.goenv.sh`), detect the live shell and pass it
+(`$ZSH_VERSION` → `zsh`, `$BASH_VERSION` → `bash`, empty → let the tool detect):
+
+```sh
+if [ -n "${ZSH_VERSION:-}" ]; then _sh=zsh; elif [ -n "${BASH_VERSION:-}" ]; then _sh=bash; else _sh=""; fi
+eval "$(goenv init - "$_sh")"
+```
+
+**(b) Guard `PATH` anyway (belt-and-suspenders).** Even with (a), keep a restore guard so any
+future tool/version that drops the system bin dirs cannot break the rest of the script:
 
 ```sh
 __path_safe="$PATH"
-eval "$(goenv init -)"
+eval "$(goenv init - bash)"
 case ":${PATH}:" in
     *":/usr/bin:"*) : ;;                      # system PATH survived
     *) PATH="${PATH}:${__path_safe}" ;;       # init clobbered PATH; restore

--- a/install.sh
+++ b/install.sh
@@ -247,15 +247,17 @@ fi
 # Falls back to "latest" only if .go-version is missing.
 export PATH="${HOME}/.goenv/bin:${PATH}"
 if command -v goenv &> /dev/null; then
-  # PATH-clobber guard (macOS): a misconfigured `goenv init -` — observed on
-  # Homebrew goenv builds — can emit a PATH assignment that drops the system
-  # bin dirs (/usr/bin, /bin, …). When that happens every subsequent coreutil
-  # (tr, uname, git, mkdir, curl…) becomes "command not found" and the rest of
-  # the install silently collapses. Capture a known-good PATH first; if the
-  # eval strips the system dirs, restore it. See the shell-portability standard
-  # referenced in CLAUDE.md (docs/mbo/specs/shell-portability.md).
+  # Pass the shell to `goenv init` EXPLICITLY. Bare `goenv init -` infers the
+  # shell from $SHELL, so on a host whose login shell is zsh it emits zsh code
+  # (a `while IFS=: read -rA …` PATH loop) even though this script runs under
+  # bash — bash then errors `read: -A: invalid option`, the loop's `_NEW_PATH`
+  # stays empty, and `export PATH="$_NEW_PATH"` wipes PATH, after which every
+  # coreutil (tr, uname, git…) is "command not found" and the install collapses.
+  # `goenv init - bash` forces bash-safe output. The guard below is a belt-and-
+  # suspenders backstop: if any goenv build still drops the system bin dirs,
+  # restore a known-good PATH. See docs/mbo/specs/shell-portability.md.
   __goenv_path_safe="${PATH}"
-  eval "$(goenv init -)"
+  eval "$(goenv init - bash)"
   case ":${PATH}:" in
     *":/usr/bin:"*) : ;;                          # system PATH survived
     *) PATH="${PATH}:${__goenv_path_safe}" ;;     # init clobbered PATH; restore

--- a/install.sh
+++ b/install.sh
@@ -247,7 +247,21 @@ fi
 # Falls back to "latest" only if .go-version is missing.
 export PATH="${HOME}/.goenv/bin:${PATH}"
 if command -v goenv &> /dev/null; then
+  # PATH-clobber guard (macOS): a misconfigured `goenv init -` — observed on
+  # Homebrew goenv builds — can emit a PATH assignment that drops the system
+  # bin dirs (/usr/bin, /bin, …). When that happens every subsequent coreutil
+  # (tr, uname, git, mkdir, curl…) becomes "command not found" and the rest of
+  # the install silently collapses. Capture a known-good PATH first; if the
+  # eval strips the system dirs, restore it. See the shell-portability standard
+  # referenced in CLAUDE.md (docs/mbo/specs/shell-portability.md).
+  __goenv_path_safe="${PATH}"
   eval "$(goenv init -)"
+  case ":${PATH}:" in
+    *":/usr/bin:"*) : ;;                          # system PATH survived
+    *) PATH="${PATH}:${__goenv_path_safe}" ;;     # init clobbered PATH; restore
+  esac
+  export PATH
+  unset __goenv_path_safe
   if [ -f "${BASE_DIR}/.go-version" ]; then
     PINNED_GO_VERSION=$(tr -d '[:space:]' < "${BASE_DIR}/.go-version")
     echo "Ensuring Go ${PINNED_GO_VERSION} is installed (pinned via .go-version)..."

--- a/opt/profiles/.bash_aliases
+++ b/opt/profiles/.bash_aliases
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 #
 # alias files
 #
@@ -29,7 +30,9 @@ alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo
 # See /usr/share/doc/bash-doc/examples in the bash-doc package.
 
 alias dockerup='bash ~/opt/bin/docker_up.sh'
+# shellcheck disable=SC2142 # novassh and novassh1 are intentional wrapper aliases around functions
 alias novassh='function nova_ssh { ssh-keygen -f ~/.ssh/known_hosts -R $1;ssh -i ~/.ssh/nova-USWest-AZ3.pem -l ubuntu $1;};nova_ssh'
+# shellcheck disable=SC2142
 alias novassh1='function nova_ssh1 { ssh-keygen -f ~/.ssh/known_hosts -R $1;ssh -i ~/.ssh/nova-USWest-AZ1.pem -l ubuntu $1;};nova_ssh1'
 alias sshhost='cat ~/.ssh/config|grep "Host\s"|sed "s/Host /ssh /g"'
 alias irc=irssi

--- a/opt/profiles/.bash_logout
+++ b/opt/profiles/.bash_logout
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # ~/.bash_logout: executed by bash(1) when login shell exits.
 
 # when leaving the console clear the screen to increase privacy

--- a/opt/profiles/.bashrc
+++ b/opt/profiles/.bashrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # ~/.bashrc: executed by bash(1) for non-login shells.
 
 # Detect if we're in VSCode/Cursor terminal

--- a/opt/profiles/.goenv.sh
+++ b/opt/profiles/.goenv.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # goenv configuration
 export GOENV_ROOT="$HOME/go"
 export GOENV_PATH_ORDER=front
@@ -24,7 +25,19 @@ if [[ "$(uname -r | awk -F'-' '{print $3}')" = "Microsoft" ]] ; then
 fi
 
 # Initialize goenv
+# PATH-clobber guard (macOS): a misconfigured `goenv init -` can emit a PATH
+# assignment that drops the system bin dirs (/usr/bin, /bin, …), breaking every
+# coreutil in the login shell. Capture a known-good PATH and restore it if the
+# eval strips the system dirs. Shell-agnostic (bash + zsh). See the
+# shell-portability standard referenced in CLAUDE.md.
+__goenv_path_safe="$PATH"
 eval "$(goenv init -)"
+case ":${PATH}:" in
+    *":/usr/bin:"*) : ;;                          # system PATH survived
+    *) PATH="${PATH}:${__goenv_path_safe}" ;;     # init clobbered PATH; restore
+esac
+export PATH
+unset __goenv_path_safe
 
 # Set shell version to latest installed version if not already set by .go-version or local
 if [ -z "$GOENV_VERSION" ]; then

--- a/opt/profiles/.goenv.sh
+++ b/opt/profiles/.goenv.sh
@@ -24,20 +24,24 @@ if [[ "$(uname -r | awk -F'-' '{print $3}')" = "Microsoft" ]] ; then
     alias go='go.exe'
 fi
 
-# Initialize goenv
-# PATH-clobber guard (macOS): a misconfigured `goenv init -` can emit a PATH
-# assignment that drops the system bin dirs (/usr/bin, /bin, …), breaking every
-# coreutil in the login shell. Capture a known-good PATH and restore it if the
-# eval strips the system dirs. Shell-agnostic (bash + zsh). See the
-# shell-portability standard referenced in CLAUDE.md.
+# Initialize goenv. Pass the CURRENT shell explicitly: bare `goenv init -`
+# infers it from $SHELL, so a bash session sourcing this while $SHELL=zsh would
+# eval zsh code (a `read -rA` PATH loop) under bash and error out, emptying PATH.
+# Detect the live shell instead; empty falls back to goenv's own detection.
+if [ -n "${ZSH_VERSION:-}" ]; then _goenv_shell=zsh
+elif [ -n "${BASH_VERSION:-}" ]; then _goenv_shell=bash
+else _goenv_shell=""; fi
+# PATH-clobber guard (belt-and-suspenders): if any goenv build still drops the
+# system bin dirs (/usr/bin, /bin, …), restore a known-good PATH so the login
+# shell keeps working. See the shell-portability standard referenced in CLAUDE.md.
 __goenv_path_safe="$PATH"
-eval "$(goenv init -)"
+eval "$(goenv init - "${_goenv_shell}")"
 case ":${PATH}:" in
     *":/usr/bin:"*) : ;;                          # system PATH survived
     *) PATH="${PATH}:${__goenv_path_safe}" ;;     # init clobbered PATH; restore
 esac
 export PATH
-unset __goenv_path_safe
+unset __goenv_path_safe _goenv_shell
 
 # Set shell version to latest installed version if not already set by .go-version or local
 if [ -z "$GOENV_VERSION" ]; then

--- a/opt/profiles/.nano_profile
+++ b/opt/profiles/.nano_profile
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Nano Platform Path Configuration
 
 if [ -d "$HOME/opt/nano/bin" ]; then

--- a/opt/profiles/.profile
+++ b/opt/profiles/.profile
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # ~/.profile: executed by the command interpreter for login shells.
 # This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login
 # exists.

--- a/opt/profiles/Brewfile
+++ b/opt/profiles/Brewfile
@@ -33,6 +33,13 @@ brew 'pinentry'
 brew 'readline'
 brew 'sqlite'
 brew 'sops'
+# util-linux provides `setsid`, which macOS lacks natively. sync-plugins.sh runs
+# `claude`/`gemini` plugin installs under setsid so they get no controlling
+# terminal and fall back to non-interactive mode — without it a fresh
+# `claude plugin install` opens /dev/tty, renders its TUI, and hangs until the
+# timeout SIGKILLs it. Keg-only; sync-plugins.sh probes `brew --prefix util-linux`.
+brew 'util-linux'
+
 # for node manager
 brew 'nvm'
 # act tool https://github.com/nektos/act

--- a/opt/scripts/docker/setup_ruby-docker.sh
+++ b/opt/scripts/docker/setup_ruby-docker.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
 #    You may obtain a copy of the License at

--- a/opt/scripts/system/crouton-alias.sh
+++ b/opt/scripts/system/crouton-alias.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 echo "crouton aliases installed, use crouton-help for more info."
 alias startchroot='sudo enter-chroot -n precise'
 alias startxfce4='sudo startxfce4 -n ${CHROOT_NAME:-xfce}'

--- a/opt/scripts/system/sync-plugins.sh
+++ b/opt/scripts/system/sync-plugins.sh
@@ -36,6 +36,20 @@ TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
 # can't open /dev/tty, and fall back to non-interactive mode. Empty on macOS
 # (no setsid); the per-call </dev/null + timeout guards still apply there.
 SETSID_BIN="$(command -v setsid || true)"
+# macOS ships no native setsid, so the detach guard above no-ops there — and a
+# FRESH `claude plugin install` then opens /dev/tty, renders its TUI, and hangs
+# until the timeout SIGKILLs it (≈CMD_TIMEOUT *per uninstalled plugin* on a clean
+# machine — tens of minutes). Homebrew's keg-only util-linux provides a working
+# setsid but does not symlink it onto PATH, so probe the keg explicitly. Install
+# it via opt/profiles/Brewfile (`brew 'util-linux'`). No-op when util-linux is
+# absent: the </dev/null + timeout guards remain the (slower) fallback.
+if [ -z "$SETSID_BIN" ] && command -v brew >/dev/null 2>&1; then
+    _ul_prefix="$(brew --prefix util-linux 2>/dev/null || true)"
+    for _ul_cand in "$_ul_prefix/bin/setsid" "$_ul_prefix/sbin/setsid"; do
+        if [ -n "$_ul_prefix" ] && [ -x "$_ul_cand" ]; then SETSID_BIN="$_ul_cand"; break; fi
+    done
+    unset _ul_prefix _ul_cand
+fi
 # Per-call ceiling so a hung network fetch or an unexpected interactive prompt
 # can't wedge install.sh indefinitely (the orphaned-process failure mode this
 # guards against). Override with SYNC_PLUGINS_TIMEOUT for slow links.

--- a/opt/scripts/system/sync-plugins_test.sh
+++ b/opt/scripts/system/sync-plugins_test.sh
@@ -177,6 +177,46 @@ EOF
     assert_contains "$TTYOUT" "headless-ok" "setsid detaches the controlling terminal so claude runs headless"
 fi
 
+# --- Behavioral: macOS keg-only util-linux setsid is discovered via brew -------
+# On macOS `command -v setsid` fails (no native setsid), so sync-plugins must
+# probe Homebrew's keg-only util-linux (`brew --prefix util-linux`) — otherwise
+# the detach guard no-ops and a fresh `claude plugin install` hangs on /dev/tty.
+# Simulate macOS: a curated PATH with NO setsid, a fake `brew` whose
+# `--prefix util-linux` points at a keg holding a fake setsid, and fake CLIs.
+# Assert the keg setsid actually gets invoked.
+KEG_ROOT="$(mktemp -d)"
+mkdir -p "$KEG_ROOT/bin"
+cat > "$KEG_ROOT/bin/setsid" <<'EOF'
+#!/usr/bin/env bash
+echo "KEG_SETSID_USED" >&2
+[ "$1" = "-w" ] && shift   # sync-plugins passes -w; then exec the rest
+exec "$@"
+EOF
+chmod +x "$KEG_ROOT/bin/setsid"
+KEGBIN="$(mktemp -d)"
+# Curated PATH: symlink the real tools sync-plugins needs, but deliberately NOT
+# setsid (so the keg probe is exercised) and NOT timeout (so GUARD = setsid only).
+for _t in bash sh env yq grep egrep awk sed tr cat head cut sort uniq dirname basename readlink mktemp; do
+    _src="$(command -v "$_t" 2>/dev/null)" && ln -s "$_src" "$KEGBIN/$_t" 2>/dev/null
+done
+cat > "$KEGBIN/brew" <<EOF
+#!/usr/bin/env bash
+[ "\$1" = "--prefix" ] && [ "\$2" = "util-linux" ] && { printf '%s\n' "$KEG_ROOT"; exit 0; }
+exit 0
+EOF
+cat > "$KEGBIN/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$KEGBIN/gemini" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$KEGBIN/brew" "$KEGBIN/claude" "$KEGBIN/gemini"
+KEGOUT="$(PATH="$KEGBIN" bash "$SYNC" 2>&1 || true)"
+rm -rf "$KEGBIN" "$KEG_ROOT"
+assert_contains "$KEGOUT" "KEG_SETSID_USED" "discovers keg-only util-linux setsid via 'brew --prefix' when setsid is off PATH (macOS)"
+
 echo "----"
 echo "PASS=$PASS FAIL=$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Fix goenv PATH-clobber in install.sh; add docs/mbo shell-portability spec; CLAUDE.md/GEMINI.md refs; shellcheck-all CI workflow

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **fix-macos-install-path**.

- **#143 — edward-raigosa/impl (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
