### PR TITLE
Replace .zshrc Snowflake CLI pip auto-install with a PEP 668-safe installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -203,6 +203,15 @@ if [ -f "${BASE_DIR}/opt/scripts/system/install_yq.sh" ]; then
     "${BASE_DIR}/opt/scripts/system/install_yq.sh" || echo "WARNING: yq install reported problems; continuing."
 fi
 
+# Install the Snowflake CLI (`snow`). Replaces the old .zshrc daily-maintenance
+# pip auto-install, which broke on PEP 668 (externally-managed-environment)
+# systems. macOS uses the homebrew-core formula; Linux uses pipx so the system
+# Python is untouched.
+if [ -f "${BASE_DIR}/opt/scripts/system/install_snowflake_cli.sh" ]; then
+    echo "Installing snowflake-cli..."
+    "${BASE_DIR}/opt/scripts/system/install_snowflake_cli.sh" || echo "WARNING: snowflake-cli install reported problems; continuing."
+fi
+
 # only setup these scripts when docker is installed and responsive
 if command -v docker &> /dev/null; then
     # Setup docker permissions for the current use

--- a/opt/profiles/.zshrc
+++ b/opt/profiles/.zshrc
@@ -51,10 +51,6 @@ run_daily_maintenance() {
   if [ "$(uname -s)" = "Darwin" ] && command -v brew >/dev/null 2>&1 ; then
     brew bundle check || brew bundle
   fi
-  # Ensure Snowflake CLI is available (install if missing)
-  if command -v python >/dev/null 2>&1 && command -v pip3 >/dev/null 2>&1 ; then
-    snow --version >/dev/null 2>&1 || ( pip3 install --upgrade pip && python -m pip install snowflake-cli-labs )
-  fi
 }
 
 # Trigger daily maintenance only in non-editor terminals

--- a/opt/profiles/rc_test.sh
+++ b/opt/profiles/rc_test.sh
@@ -73,8 +73,8 @@ if command -v zsh >/dev/null 2>&1; then
     STDERR_FILE="${TMPHOME}/zshrc.stderr"
     set +e
     # TERM_PROGRAM=vscode -> EDITOR_TERMINAL=true: skips the
-    # zsh-completions `git clone` (line ~146) and the Snowflake CLI
-    # `pip install` (line ~56) — both write to the host, which we MUST
+    # zsh-completions `git clone` (line ~146) and the daily-maintenance
+    # background job — both write to the host, which we MUST
     # avoid in a test. ZDOTDIR=$TMPHOME so zsh's startup files (.zshenv
     # etc.) are also sourced from the sandbox, not from $HOME.
     env -i HOME="${TMPHOME}" PATH=/usr/bin:/bin TERM=dumb \

--- a/opt/scripts/system/install_snowflake_cli.sh
+++ b/opt/scripts/system/install_snowflake_cli.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Snowflake CLI Setup — install `snow` via brew (macOS) or pipx (Linux)
+# ==============================================================================
+# Why this exists:
+#   * .zshrc used to auto-install the CLI with `pip3 install` from daily
+#     maintenance. On Debian Bookworm+ (PEP 668 externally-managed-environment)
+#     the system pip refuses, printing an error at login once a day, forever.
+#   * The supported, PEP 668-safe paths are the homebrew-core `snowflake-cli`
+#     formula on macOS and `pipx install snowflake-cli` on Linux (pipx gives
+#     the CLI its own venv, leaving the system Python untouched).
+#   * The PyPI package was renamed snowflake-cli-labs -> snowflake-cli; this
+#     script installs the current name.
+#
+# Safe to re-run: exits early when `snow` is already resolvable.
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+if command -v snow >/dev/null 2>&1; then
+    echo -e "${GREEN}snowflake-cli already installed: $(snow --version 2>&1 | head -1)${NC}"
+    exit 0
+fi
+
+case "$(uname -s)" in
+    Darwin)
+        if ! command -v brew >/dev/null 2>&1; then
+            echo -e "${RED}install_snowflake_cli: Homebrew not found — install it first: https://brew.sh/${NC}"
+            exit 1
+        fi
+        echo -e "${BLUE}Installing snowflake-cli via brew...${NC}"
+        brew install snowflake-cli
+        ;;
+    Linux)
+        # pipx is the PEP 668-safe installer for PyPI CLIs. Bootstrap it from
+        # apt when missing (Debian/Ubuntu/RPi); other distros must provide
+        # pipx themselves.
+        if ! command -v pipx >/dev/null 2>&1; then
+            if command -v apt-get >/dev/null 2>&1; then
+                echo -e "${BLUE}Installing pipx via apt...${NC}"
+                sudo apt-get install -y -qq pipx
+            else
+                echo -e "${RED}install_snowflake_cli: pipx not found and no apt-get — install pipx manually, then re-run.${NC}"
+                exit 1
+            fi
+        fi
+        echo -e "${BLUE}Installing snowflake-cli via pipx...${NC}"
+        pipx install snowflake-cli
+        # pipx installs into ~/.local/bin; make sure future shells resolve it.
+        pipx ensurepath >/dev/null 2>&1 || true
+        ;;
+    *)
+        echo -e "${RED}install_snowflake_cli: unsupported OS $(uname -s)${NC}"
+        exit 1
+        ;;
+esac
+
+if command -v snow >/dev/null 2>&1 && snow --version >/dev/null 2>&1; then
+    echo -e "${GREEN}snowflake-cli installed: $(snow --version 2>&1 | head -1)${NC}"
+else
+    echo -e "${RED}install_snowflake_cli: snow not resolvable after install — is ~/.local/bin on PATH?${NC}"
+    echo -e "${RED}                       (open a new shell or run 'pipx ensurepath' and retry)${NC}"
+fi


### PR DESCRIPTION
## What

1. Removes the Snowflake CLI auto-install block from `run_daily_maintenance` in `opt/profiles/.zshrc` (and updates the now-stale comment in `opt/profiles/rc_test.sh`).
2. Adds `opt/scripts/system/install_snowflake_cli.sh` — an idempotent installer following the `install_yq.sh`/`install_sops.sh` pattern — and wires it into `install.sh` after the yq step.

## Why

On Debian Bookworm+ hosts (e.g. Raspberry Pi), the system Python is externally managed (PEP 668), so the old `pip3 install --upgrade pip` refused and printed `error: externally-managed-environment` into the login terminal. The daily-maintenance stamp re-armed every 24h and the install never succeeded, so the error appeared at login once a day, forever.

The new installer uses PEP 668-safe paths instead:
- **macOS**: `brew install snowflake-cli` (homebrew-core formula)
- **Linux**: `pipx install snowflake-cli` (bootstraps pipx from apt when missing; the CLI gets its own venv, system Python untouched)
- Installs the current `snowflake-cli` package name (the old `snowflake-cli-labs` is deprecated).

## Impact

- No more PEP 668 error noise at login on Debian/RPi hosts.
- `snow` is now installed once at `install.sh` time (non-fatal on failure, same WARNING pattern as yq/sops) instead of retried daily from `.zshrc`.
- Re-runnable: the installer exits early when `snow` already resolves.

## Testing

- `bash opt/profiles/rc_test.sh` — all 8 checks pass (`zsh -n` parse, clean sourcing in a sandboxed `$HOME`, no stderr).
- `shellcheck opt/scripts/system/install_snowflake_cli.sh` — clean; `bash -n` passes on the script and on `install.sh`.
- `make lint-shell` failures are the pre-existing backlog (identical on `main`); no new findings introduced.

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **zshrc-pep668-fix**.

- **(no PR yet) — edward-raigosa/zshrc (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)