### PR TITLE
posix-shell-portability: impl

### DIFF
--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -54,14 +54,14 @@ jobs:
           sudo apt-get install -y shellcheck
 
       - name: Run make lint-shell
-        # WARN-ONLY: the phase-1 baseline ships ~90 shell findings (see
-        # .ci-baseline-issues.md). `continue-on-error: true` keeps shellcheck
-        # RUNNING and surfacing every finding in the step log without blocking
-        # the PR — mirroring `make lint` in docker-image.yml. The `make
-        # lint-shell` target itself is STRICT (exits non-zero); the warn-only
-        # gate is here. Drop this line once the shell backlog reaches zero so
-        # shell-portability regressions become hard failures.
-        continue-on-error: true
+        # ENFORCING gate (no longer warn-only): the shellcheck backlog was
+        # driven to ZERO, so `make lint-shell` (shellcheck -x -S warning over
+        # install.sh + opt/scripts/** + ai/** + sdk/** + src/** + opt/bin/** +
+        # the profile dotfiles) now blocks the PR on ANY finding. `make
+        # lint-shell` is STRICT (exits non-zero on warnings); with
+        # continue-on-error removed, a new shellcheck warning fails CI.
+        # Genuinely-intentional patterns carry an inline `# shellcheck
+        # disable=SCxxxx # <reason>`.
         run: make lint-shell
 
       - name: Syntax check — bash -n over all *.sh

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -99,3 +99,19 @@ jobs:
             exit 1
           fi
           echo "OK: no zsh-only 'read -A' in bash scripts"
+
+      - name: Cross-shell portability scan (dash + macOS) — WARN-only
+        # WARN-ONLY (advisory): this catches the class that shellcheck and the
+        # `bash -n` gate above MISS — dash (/bin/sh) PARSE breakage (the
+        # Raspberry Pi LightDM login-loop class: a bash `function name { … }`
+        # block in a dash-sourced profile fragment fatally aborts the Xsession)
+        # and macOS BSD-coreutil / bash-3.2 hazards. `opt/scripts/system/shell-
+        # portability-scan.sh` exits 0 and emits ::warning:: annotations, so it
+        # surfaces every finding in the run summary WITHOUT blocking the PR
+        # while the cross-shell backlog is triaged (tracking issue lists it).
+        # `continue-on-error` is belt-and-suspenders (the scanner is already
+        # non-failing). Flip the script to `--strict` once Tier 1 reaches zero
+        # so POSIX-/bin/sh regressions become hard failures. Needs dash, which
+        # is preinstalled on ubuntu-latest (it is /bin/sh).
+        continue-on-error: true
+        run: make lint-portability

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -100,18 +100,16 @@ jobs:
           fi
           echo "OK: no zsh-only 'read -A' in bash scripts"
 
-      - name: Cross-shell portability scan (dash + macOS) — WARN-only
-        # WARN-ONLY (advisory): this catches the class that shellcheck and the
-        # `bash -n` gate above MISS — dash (/bin/sh) PARSE breakage (the
+      - name: Cross-shell portability scan (dash + macOS) — ENFORCING
+        # ENFORCING gate (not warn-only): catches the class that shellcheck and
+        # the `bash -n` gate above MISS — dash (/bin/sh) PARSE breakage (the
         # Raspberry Pi LightDM login-loop class: a bash `function name { … }`
         # block in a dash-sourced profile fragment fatally aborts the Xsession)
-        # and macOS BSD-coreutil / bash-3.2 hazards. `opt/scripts/system/shell-
-        # portability-scan.sh` exits 0 and emits ::warning:: annotations, so it
-        # surfaces every finding in the run summary WITHOUT blocking the PR
-        # while the cross-shell backlog is triaged (tracking issue lists it).
-        # `continue-on-error` is belt-and-suspenders (the scanner is already
-        # non-failing). Flip the script to `--strict` once Tier 1 reaches zero
-        # so POSIX-/bin/sh regressions become hard failures. Needs dash, which
-        # is preinstalled on ubuntu-latest (it is /bin/sh).
-        continue-on-error: true
+        # and macOS BSD-coreutil / bash-3.2 hazards. `make lint-portability`
+        # runs the scanner with `--strict`, which exits non-zero on any Tier 1
+        # or Tier 2 finding, so a newly introduced non-portable script FAILS the
+        # build. The backlog is at zero; a reviewed exception is opted out with
+        # a trailing `# portability-ok: <reason>` comment on the line. Needs
+        # dash, preinstalled on ubuntu-latest (it is /bin/sh). Tier 3 (bash
+        # scripts that aren't POSIX) is informational and never gates.
         run: make lint-portability

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -45,6 +45,22 @@ Welcome to the dotfiles repository. This file serves as the entry point for agen
   coreutil traps (`sed -i`, `stat`, `date`, …), the mandatory `eval "$(tool init)"` PATH-clobber guard (the
   bug that broke macOS `install.sh`), and a per-script checklist. CI enforces the mechanical parts via
   `make lint-shell` and the `shell-lint` workflow; review enforces the rest.
+- **Cross-shell portability gate is ENFORCING — run `make lint-portability` before pushing any shell change.**
+  `opt/scripts/system/shell-portability-scan.sh --strict` runs in the `shell-lint` workflow and **fails CI**
+  on any Tier 1 (dash `/bin/sh` parse breakage — the class that caused the Raspberry Pi GUI **login loop**)
+  or Tier 2 (macOS BSD-coreutil / bash-3.2 hazard) finding. It catches what `shellcheck` and `bash -n` miss
+  (both pass bashisms). When writing or editing a script, conform to these rules so you don't trip the gate:
+  - **Shebang:** executable scripts use `#!/usr/bin/env bash` (never `#!/bin/bash` — that's the macOS 3.2
+    relic; never `#!/bin/sh` unless the script is genuinely POSIX). Sourced fragments use `# shellcheck shell=bash`.
+  - **Anything dash sources at login is POSIX-only:** `~/.profile`, `~/.xsessionrc`, and every file they
+    unconditionally dot-source (e.g. `~/.nano_profile`). Use `name() { … }` (never `function name { … }`),
+    no `[[ … ]]`, no arrays — a parse error here aborts the LightDM Xsession and bounces you to the greeter.
+  - **Use portable tools:** `command -v` not `which`; `grep -E` not `grep -P`/`\K`; `cd -- "$(dirname "$0")" && pwd -P`
+    not `readlink -f`; `sed -i.bak … && rm -f ….bak` not bare `sed -i`; probe `stat -f` then `stat -c`.
+  - **Bash-4 features** (`declare -A`, `mapfile`, `${v,,}`) break macOS system bash 3.2 — rewrite them, or
+    require bash 4+ via `#!/usr/bin/env bash` (picks up Homebrew bash 5 on macOS) and document it.
+  - **Opt-out for a reviewed exception:** add a trailing `# portability-ok: <reason>` comment on the line and
+    the scanner skips it. Use sparingly and always with a reason.
 - **Use $HOME**: Always use `${HOME}` or `~` instead of absolute home paths (e.g., `/home/wenlock` or `/Users/eraigosa`) in scripts, aliases, and configuration files to ensure they are portable across different systems and users.
 - **Avoid Hardcoded Usernames**: Never hardcode usernames in paths or instructions; use environment variables like `$USER` if needed.
 - **Avoid Hardcoded Paths**: Use relative paths or environment variables (like `BASE_DIR` in `install.sh`) whenever possible.

--- a/Makefile
+++ b/Makefile
@@ -129,12 +129,12 @@ lint-shell: ## Lint shell scripts with shellcheck
 	# scripts (build.sh, test helpers, setup scripts, utilities).
 	#
 	# This target is STRICT — it exits non-zero on any finding (shellcheck
-	# -S warning returns non-zero even for warnings). That is intentional and
-	# matches lint-go / lint-markdown: `make lint` locally surfaces the full
-	# backlog with a non-zero exit (see .ci-baseline-issues.md). The warn-only
-	# gate lives at the WORKFLOW level (`continue-on-error: true` in
-	# docker-image.yml and shell-lint.yml), NOT here — so do not add `|| true`.
-	# Drop the workflow continue-on-error once the shell backlog reaches zero.
+	# -S warning returns non-zero even for warnings) — so do not add `|| true`.
+	# The shellcheck backlog has been driven to ZERO, and the shell-lint.yml
+	# workflow now runs this WITHOUT continue-on-error: a new shellcheck warning
+	# is a hard CI failure. Genuinely-intentional patterns carry an inline
+	# `# shellcheck disable=SCxxxx # <reason>`. (docker-image.yml's broader
+	# `make lint` may still be warn-only for its own non-shell backlog.)
 	@files=$$(find opt/scripts ai sdk src opt/bin -name '*.sh' -type f ! -path '*/.*' ! -path '*/opt/google-cloud-sdk/*' 2>/dev/null) ; \
 		profile_dotfiles="opt/profiles/.bashrc opt/profiles/.profile opt/profiles/.bash_aliases opt/profiles/.bash_logout opt/profiles/.docker.sh opt/profiles/.goenv.sh opt/profiles/.nano_profile opt/profiles/.xsessionrc" ; \
 		profile_sh=$$(find opt/profiles -maxdepth 1 -name '*.sh' -type f 2>/dev/null) ; \

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,17 @@ lint-shell: ## Lint shell scripts with shellcheck
 		profile_sh=$$(find opt/profiles -maxdepth 1 -name '*.sh' -type f 2>/dev/null) ; \
 		shellcheck -x -S warning install.sh $$files $$profile_sh $$profile_dotfiles
 
+# Cross-shell / cross-OS portability scan. Catches the class that shellcheck
+# and `bash -n` MISS: dash (/bin/sh) parse breakage — the Raspberry Pi LightDM
+# login-loop class — and macOS BSD-coreutil / bash-3.2 hazards. WARN-ONLY by
+# design: the scanner exits 0 and prints ::warning:: lines, so it never blocks
+# a PR while the cross-shell backlog is triaged (see the tracking issue +
+# docs/mbo/specs/shell-portability.md). Pass --strict to make a non-empty
+# Tier-1 (POSIX breakage) a hard failure once that list reaches zero.
+.PHONY: lint-portability
+lint-portability: ## Cross-shell/OS portability scan (dash + macOS) — WARN-only
+	@opt/scripts/system/shell-portability-scan.sh
+
 .PHONY: lint-markdown
 lint-markdown: ## Lint markdown files with markdownlint-cli2
 	@echo "==> markdownlint-cli2"

--- a/Makefile
+++ b/Makefile
@@ -142,14 +142,14 @@ lint-shell: ## Lint shell scripts with shellcheck
 
 # Cross-shell / cross-OS portability scan. Catches the class that shellcheck
 # and `bash -n` MISS: dash (/bin/sh) parse breakage — the Raspberry Pi LightDM
-# login-loop class — and macOS BSD-coreutil / bash-3.2 hazards. WARN-ONLY by
-# design: the scanner exits 0 and prints ::warning:: lines, so it never blocks
-# a PR while the cross-shell backlog is triaged (see the tracking issue +
-# docs/mbo/specs/shell-portability.md). Pass --strict to make a non-empty
-# Tier-1 (POSIX breakage) a hard failure once that list reaches zero.
+# login-loop class — and macOS BSD-coreutil / bash-3.2 hazards. ENFORCING:
+# `--strict` exits non-zero on any Tier 1 (POSIX breakage) or Tier 2 (macOS
+# hazard) finding, so a newly introduced non-portable script fails CI. The
+# backlog is at zero (see docs/mbo/specs/shell-portability.md); to exempt a
+# reviewed line add a trailing `# portability-ok: <reason>` comment.
 .PHONY: lint-portability
-lint-portability: ## Cross-shell/OS portability scan (dash + macOS) — WARN-only
-	@opt/scripts/system/shell-portability-scan.sh
+lint-portability: ## Cross-shell/OS portability scan (dash + macOS) — ENFORCING
+	@opt/scripts/system/shell-portability-scan.sh --strict
 
 .PHONY: lint-markdown
 lint-markdown: ## Lint markdown files with markdownlint-cli2

--- a/ai/claude/aliases.sh
+++ b/ai/claude/aliases.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # shellcheck shell=bash
 # shellcheck disable=SC2139  # the sync-* aliases expand $HOME at definition time on purpose ($HOME is stable for the shell's lifetime)
 # Shell helpers for the Claude Code CLI.

--- a/ai/claude/scripts/sanity_check.sh
+++ b/ai/claude/scripts/sanity_check.sh
@@ -14,6 +14,7 @@ echo "PASS: claude CLI present ($(claude --version 2>/dev/null || echo unknown))
 
 # 2. Symlinked config
 echo "Verifying ~/.claude configuration links..."
+# shellcheck disable=SC2043 # single config link today; loop kept for future entries
 for link in settings.json; do
     if [ ! -L "$HOME/.claude/$link" ] && [ ! -f "$HOME/.claude/$link" ]; then
         echo "FAIL: ~/.claude/$link missing"

--- a/ai/claude/scripts/validate_hooks.sh
+++ b/ai/claude/scripts/validate_hooks.sh
@@ -36,7 +36,9 @@ hook_rc() { local path="$1" payload="$2"; printf '%s' "$payload" | bash "$path" 
 
 # Event-agnostic: gather hook commands across every hook event so this validates
 # both Claude (.hooks.PreToolUse[]) and Gemini (.hooks.BeforeTool[]) settings.
-mapfile -t HOOK_CMDS < <(jq -r '[.hooks[]?[]?.hooks[]?.command] | .[]' "$SETTINGS" 2>/dev/null)
+# mapfile is bash-4 only; use a bash-3.2-safe read loop (macOS system bash is 3.2).
+HOOK_CMDS=()
+while IFS= read -r _hc; do HOOK_CMDS+=("$_hc"); done < <(jq -r '[.hooks[]?[]?.hooks[]?.command] | .[]' "$SETTINGS" 2>/dev/null)
 STATUS_CMD="$(jq -r '.statusLine.command // empty' "$SETTINGS" 2>/dev/null)"
 
 if [ "${#HOOK_CMDS[@]}" -eq 0 ]; then

--- a/ai/gemini/aliases.sh
+++ b/ai/gemini/aliases.sh
@@ -30,6 +30,6 @@ gemini-yolo() {
     command gemini -y "$@"
 }
 
-alias sync-skills="bash $HOME/opt/scripts/system/sync-skills.sh"
-alias sync-teams="bash $HOME/opt/scripts/system/install_ai_teams.sh"
-alias sync-forks="bash $HOME/opt/scripts/../../ai/skills/sync-forks/scripts/check_and_sync_forks.sh"
+alias sync-skills="bash \$HOME/opt/scripts/system/sync-skills.sh"
+alias sync-teams="bash \$HOME/opt/scripts/system/install_ai_teams.sh"
+alias sync-forks="bash \$HOME/opt/scripts/../../ai/skills/sync-forks/scripts/check_and_sync_forks.sh"

--- a/ai/gemini/aliases.sh
+++ b/ai/gemini/aliases.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# shellcheck shell=bash
 # Shell helpers for the Gemini CLI.
 # Sourced from opt/profiles/.zshrc and opt/profiles/.bashrc after .gemini.profile.
 #

--- a/ai/skills/sync-forks/scripts/check_and_sync_forks.sh
+++ b/ai/skills/sync-forks/scripts/check_and_sync_forks.sh
@@ -42,15 +42,15 @@ check_repo() {
   local SYNC=$2
   local FORCE=$3
   
-  local REPO_INFO=$(gh api "repos/$REPO" --jq '{parent: .parent.full_name, branch: .default_branch}' 2>/dev/null || echo "")
-  local PARENT=$(echo "$REPO_INFO" | jq -r '.parent // empty')
-  local BRANCH=$(echo "$REPO_INFO" | jq -r '.branch // empty')
+  local REPO_INFO; REPO_INFO=$(gh api "repos/$REPO" --jq '{parent: .parent.full_name, branch: .default_branch}' 2>/dev/null || echo "")
+  local PARENT; PARENT=$(echo "$REPO_INFO" | jq -r '.parent // empty')
+  local BRANCH; BRANCH=$(echo "$REPO_INFO" | jq -r '.branch // empty')
 
   if [[ -n "$PARENT" && -n "$BRANCH" ]]; then
     local OWNER=${REPO%/*}
-    local COMPARE=$(gh api "repos/$PARENT/compare/$BRANCH...$OWNER:$BRANCH" 2>/dev/null || echo "")
-    local STATUS=$(echo "$COMPARE" | jq -r '.status // "unknown"')
-    local BEHIND=$(echo "$COMPARE" | jq -r '.behind_by // 0')
+    local COMPARE; COMPARE=$(gh api "repos/$PARENT/compare/$BRANCH...$OWNER:$BRANCH" 2>/dev/null || echo "")
+    local STATUS; STATUS=$(echo "$COMPARE" | jq -r '.status // "unknown"')
+    local BEHIND; BEHIND=$(echo "$COMPARE" | jq -r '.behind_by // 0')
     
     if [[ "$STATUS" == "behind" || "$STATUS" == "diverged" ]] && [[ "$BEHIND" -gt 0 ]]; then
       echo "[$REPO] Status: $STATUS, Behind by: $BEHIND commits."

--- a/ai/teams/eval/route-eval.sh
+++ b/ai/teams/eval/route-eval.sh
@@ -148,11 +148,13 @@ parse_pick() {  # stdin -> pick on stdout (empty if none)
   # 1) Prefer the model's final non-empty line as an EXACT id/squad (strict answer).
   last="$(printf '%s' "$raw" | grep -v '^[[:space:]]*$' | tail -1 | tr -d '[:space:]')"
   last="${last//\`/}"; last="${last//\"/}"; last="${last//\'/}"; last="${last//./}"; last="${last//\*/}"
+  # lowercase once via tr (bash-3.2 safe; ${v,,} is bash 4+)
+  local last_lc; last_lc="$(printf '%s' "$last" | tr '[:upper:]' '[:lower:]')"
   for i in "${!CAND_ID[@]}"; do
-    [ "${last,,}" = "${CAND_ID[$i],,}" ] && { echo "${CAND_ID[$i]}"; return; } # portability-ok: bash 4+ harness (env bash -> Homebrew bash 5 on macOS)
+    [ "$last_lc" = "$(printf '%s' "${CAND_ID[$i]}" | tr '[:upper:]' '[:lower:]')" ] && { echo "${CAND_ID[$i]}"; return; }
   done
   while IFS= read -r sq; do
-    [ -n "$sq" ] && [ "${last,,}" = "${sq,,}" ] && { echo "$sq"; return; } # portability-ok: bash 4+ harness (env bash -> Homebrew bash 5 on macOS)
+    [ -n "$sq" ] && [ "$last_lc" = "$(printf '%s' "$sq" | tr '[:upper:]' '[:lower:]')" ] && { echo "$sq"; return; }
   done < <(yq -r '.squads | keys | .[]' "$TEAMS_YAML")
   # 2) Else first roster id / squad that appears as a whole word anywhere in the output.
   for i in "${!CAND_ID[@]}"; do
@@ -224,7 +226,9 @@ run_eval() {
   local total team_hit=0 member_hit=0 scored=0
   total="$(yq '.cases | length' "$CASES")"
   declare -a MISROUTES=()
-  declare -A EXP_TEAM_CT=() GOT_TEAM_CT=() # portability-ok: bash 4+ harness (env bash -> Homebrew bash 5 on macOS)
+  # bash-3.2 portable counters: append each occurrence as a line, count later
+  # with grep -cxF (associative arrays are bash 4+).
+  local EXP_TEAM_LIST="" GOT_TEAM_LIST=""
 
   local n
   for ((n=0; n<total; n++)); do
@@ -243,12 +247,12 @@ run_eval() {
     if [ -n "$esq" ]; then
       # Squad case: a correct squad pick counts for BOTH team and member metrics.
       expect_label="$esq"
-      EXP_TEAM_CT["$esq"]=$(( ${EXP_TEAM_CT["$esq"]:-0} + 1 ))
+      EXP_TEAM_LIST="${EXP_TEAM_LIST}${esq}"$'\n'
       if [ "$pick" = "$esq" ]; then
         team_hit=$((team_hit + 1)); member_hit=$((member_hit + 1))
-        GOT_TEAM_CT["$esq"]=$(( ${GOT_TEAM_CT["$esq"]:-0} + 1 ))
+        GOT_TEAM_LIST="${GOT_TEAM_LIST}${esq}"$'\n'
       else
-        GOT_TEAM_CT["${pick:-<none>}"]=$(( ${GOT_TEAM_CT["${pick:-<none>}"]:-0} + 1 ))
+        GOT_TEAM_LIST="${GOT_TEAM_LIST}${pick:-<none>}"$'\n'
         MISROUTES+=("${task} :: expected=${esq} got=${pick:-<none>}")
       fi
       continue
@@ -266,8 +270,8 @@ run_eval() {
         fi
       done
     fi
-    EXP_TEAM_CT["$etea"]=$(( ${EXP_TEAM_CT["$etea"]:-0} + 1 ))
-    GOT_TEAM_CT["${gteam:-<none>}"]=$(( ${GOT_TEAM_CT["${gteam:-<none>}"]:-0} + 1 ))
+    EXP_TEAM_LIST="${EXP_TEAM_LIST}${etea}"$'\n'
+    GOT_TEAM_LIST="${GOT_TEAM_LIST}${gteam:-<none>}"$'\n'
 
     local th=0
     if [ "$gteam" = "$etea" ]; then team_hit=$((team_hit + 1)); th=1; fi
@@ -289,9 +293,11 @@ run_eval() {
   echo "member top-1      : ${member_hit}/${scored}  (${member_pct}%)"
   echo
   echo "--- per-team counts (expected vs predicted) ---"
-  local key
-  for key in $(printf '%s\n' "${!EXP_TEAM_CT[@]}" "${!GOT_TEAM_CT[@]}" | sort -u); do
-    printf '  %-22s expected=%-3s predicted=%-3s\n' "$key" "${EXP_TEAM_CT[$key]:-0}" "${GOT_TEAM_CT[$key]:-0}"
+  printf '%s%s' "$EXP_TEAM_LIST" "$GOT_TEAM_LIST" | grep -v '^[[:space:]]*$' | sort -u | while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    exp="$(printf '%s' "$EXP_TEAM_LIST" | grep -cxF -- "$key")"
+    got="$(printf '%s' "$GOT_TEAM_LIST" | grep -cxF -- "$key")"
+    printf '  %-22s expected=%-3s predicted=%-3s\n' "$key" "$exp" "$got"
   done
 
   if [ "${#MISROUTES[@]}" -gt 0 ]; then

--- a/ai/teams/eval/route-eval.sh
+++ b/ai/teams/eval/route-eval.sh
@@ -149,10 +149,10 @@ parse_pick() {  # stdin -> pick on stdout (empty if none)
   last="$(printf '%s' "$raw" | grep -v '^[[:space:]]*$' | tail -1 | tr -d '[:space:]')"
   last="${last//\`/}"; last="${last//\"/}"; last="${last//\'/}"; last="${last//./}"; last="${last//\*/}"
   for i in "${!CAND_ID[@]}"; do
-    [ "${last,,}" = "${CAND_ID[$i],,}" ] && { echo "${CAND_ID[$i]}"; return; }
+    [ "${last,,}" = "${CAND_ID[$i],,}" ] && { echo "${CAND_ID[$i]}"; return; } # portability-ok: bash 4+ harness (env bash -> Homebrew bash 5 on macOS)
   done
   while IFS= read -r sq; do
-    [ -n "$sq" ] && [ "${last,,}" = "${sq,,}" ] && { echo "$sq"; return; }
+    [ -n "$sq" ] && [ "${last,,}" = "${sq,,}" ] && { echo "$sq"; return; } # portability-ok: bash 4+ harness (env bash -> Homebrew bash 5 on macOS)
   done < <(yq -r '.squads | keys | .[]' "$TEAMS_YAML")
   # 2) Else first roster id / squad that appears as a whole word anywhere in the output.
   for i in "${!CAND_ID[@]}"; do
@@ -224,7 +224,7 @@ run_eval() {
   local total team_hit=0 member_hit=0 scored=0
   total="$(yq '.cases | length' "$CASES")"
   declare -a MISROUTES=()
-  declare -A EXP_TEAM_CT=() GOT_TEAM_CT=()
+  declare -A EXP_TEAM_CT=() GOT_TEAM_CT=() # portability-ok: bash 4+ harness (env bash -> Homebrew bash 5 on macOS)
 
   local n
   for ((n=0; n<total; n++)); do

--- a/docs/mbo/specs/shell-portability.md
+++ b/docs/mbo/specs/shell-portability.md
@@ -133,6 +133,7 @@ Reference implementations: `install.sh` (goenv block) and `opt/profiles/.goenv.s
 | Local/CI lint | `make lint-shell` → `shellcheck -x -S warning` | all `*.sh` + listed profile dotfiles |
 | Dedicated CI | `.github/workflows/shell-lint.yml` | **every** `*.sh` on push/PR |
 | Syntax gate | `bash -n` in the shell-test harness | per script |
+| **Portability gate (enforcing)** | `make lint-portability` → `opt/scripts/system/shell-portability-scan.sh --strict` in `shell-lint.yml` — **fails CI** on Tier 1 (dash `/bin/sh` parse breakage) or Tier 2 (BSD/bash-3.2 hazard); Tier 3 informational. Opt out a reviewed line with `# portability-ok: <reason>`. | every `*.sh` + dash-sourced profile fragments |
 | Review | This standard | everything shellcheck can't see (runtime `PATH`, BSD/GNU, bash-3.2) |
 
 `make lint-shell` historically scanned only `install.sh` + `opt/scripts/**` + `ai/**` +
@@ -160,6 +161,7 @@ shape for any tool whose flags differ across coreutils.
 
 - [ ] `#!/usr/bin/env bash` (script) **or** `# shellcheck shell=bash` (sourced fragment).
 - [ ] `shellcheck -x -S warning` clean; `bash -n` clean.
+- [ ] `make lint-portability` clean — the **enforcing** dash + macOS scan (`shell-portability-scan.sh --strict`); it fails CI on any Tier 1 (dash `/bin/sh` parse breakage) or Tier 2 (BSD/bash-3.2 hazard). Reviewed exceptions carry a trailing `# portability-ok: <reason>`.
 - [ ] No `read -A` / zsh-isms in bash; no unguarded bash-4+ in `/bin/bash`-reachable or sourced code.
 - [ ] Every coreutil flag verified on **both** BSD and GNU (or probed with a fallback).
 - [ ] Any `eval "$(tool init)"` wrapped in the §2.6 `PATH` guard.

--- a/docs/mbo/specs/shell-portability.md
+++ b/docs/mbo/specs/shell-portability.md
@@ -130,7 +130,7 @@ Reference implementations: `install.sh` (goenv block) and `opt/profiles/.goenv.s
 | Layer | Mechanism | Scope |
 | :-- | :-- | :-- |
 | Config | `.shellcheckrc` (`external-sources=true`, SC1090/91 disabled) | repo-wide |
-| Local/CI lint | `make lint-shell` → `shellcheck -x -S warning` | all `*.sh` + listed profile dotfiles |
+| Local/CI lint (enforcing) | `make lint-shell` → `shellcheck -x -S warning` — **hard-fails CI** (backlog is zero; intentional patterns carry an inline `# shellcheck disable=SCxxxx # <reason>`) | all `*.sh` + listed profile dotfiles |
 | Dedicated CI | `.github/workflows/shell-lint.yml` | **every** `*.sh` on push/PR |
 | Syntax gate | `bash -n` in the shell-test harness | per script |
 | **Portability gate (enforcing)** | `make lint-portability` → `opt/scripts/system/shell-portability-scan.sh --strict` in `shell-lint.yml` — **fails CI** on Tier 1 (dash `/bin/sh` parse breakage) or Tier 2 (BSD/bash-3.2 hazard); Tier 3 informational. Opt out a reviewed line with `# portability-ok: <reason>`. | every `*.sh` + dash-sourced profile fragments |

--- a/install.sh
+++ b/install.sh
@@ -5,14 +5,15 @@ function install_zsh_centos7() {
     sudo yum install -y git make ncurses-devel gcc autoconf man
     git clone -b zsh-5.7.1 https://github.com/zsh-users/zsh.git /tmp/zsh
     (
-        cd /tmp/zsh
+        cd /tmp/zsh || exit 1
         ./Util/preconfig
         ./configure
         sudo make -j 20 install.bin install.modules install.fns
     )
 }
 
-export BASE_DIR="$(cd "$(dirname $0)" && pwd)"
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+export BASE_DIR
 
 # --- Authenticate sudo up front -------------------------------------------
 # The rest of this installer runs several privileged steps (apt/yum installs,
@@ -91,7 +92,7 @@ if [ -f "${BASE_DIR}/opt/lib/hardware.sh" ]; then
   fi
 fi
 
-for file in $(find "${BASE_DIR}/opt/profiles" -type f); do
+while IFS= read -r file; do
     filename=$(basename "$file")
     # Skip metadata and non-profile files
     [[ "$filename" == "Brewfile" ]] && continue
@@ -99,10 +100,10 @@ for file in $(find "${BASE_DIR}/opt/profiles" -type f); do
     [[ "$filename" == "requirements.txt" ]] && continue
     [[ "$filename" == "GEMINI.md" ]] && continue
     [[ "$filename" == "CLAUDE.md" ]] && continue
-    
+
     echo "Creating symlink to $file in home directory."
     ln -sf "${file}" "${HOME}/${filename}"
-done
+done < <(find "${BASE_DIR}/opt/profiles" -type f)
 
 # force a few
 for file in ".profile" ".zshenv" ".zshrc" ".bash_logout" ".bashrc"; do
@@ -465,7 +466,7 @@ if [ -f "${HOME}/.sshd.env" ]; then
 fi
 
 if [ -f "${HOME}/.gitrepos" ] ; then
-  cd "${HOME}"
+  cd "${HOME}" || exit 1
   "${HOME}/.gitrepos"
 fi
 

--- a/install_test.sh
+++ b/install_test.sh
@@ -45,9 +45,11 @@ BAD_CD=$(grep -nE '(^|[[:space:](])cd[[:space:]]+/' "$INSTALL" \
     || true)
 assert_eq "$BAD_CD" "" "every absolute cd uses \$HOME / \$BASE_DIR / /tmp"
 
-# BASE_DIR is exported (so child scripts can reuse it).
+# BASE_DIR is exported (so child scripts can reuse it). Accept both the
+# combined `export BASE_DIR=...` and the SC2155-safe split form
+# (`BASE_DIR=...` then `export BASE_DIR` on its own line).
 assert_grep "BASE_DIR is exported" \
-    '^export[[:space:]]+BASE_DIR=' "$INSTALL"
+    '^export[[:space:]]+BASE_DIR([[:space:]]|=|$)' "$INSTALL"
 
 # === 3. Idempotency shape ===
 # An installer that re-runs cleanly must guard symlink creation: the

--- a/opt/profiles/.bash_aliases
+++ b/opt/profiles/.bash_aliases
@@ -158,7 +158,7 @@ alias vpn="osascript -e 'tell application \"Viscosity\" to connectall'"
 alias novpn="osascript -e 'tell application \"Viscosity\" to disconnectall'"
 
 export NAMESPACE="${NAMESPACE:-default}"
-alias k="kubectl --namespace=$NAMESPACE"
+alias k='kubectl --namespace=$NAMESPACE'
 alias kpodjson='k get pod -o=json'
 alias kpod='kpodjson|jq -r ".items[0].metadata.name"'
 
@@ -189,7 +189,7 @@ export DOCKER_STACK_ORCHESTRATOR=swarm
 # 1.8, 11, 12, 1.7
 if [ -d "/usr/libexec/java_home" ] ; then
   export JAVA_VERSION=1.8
-  export JAVA_HOME=$(/usr/libexec/java_home -v ${JAVA_VERSION})
+  JAVA_HOME=$(/usr/libexec/java_home -v "${JAVA_VERSION}"); export JAVA_HOME
 fi
 
 if [ "$(uname -s)" = "Darwin" ]; then
@@ -252,7 +252,7 @@ EOF
 
 function sfcode() {
     local NAME="gco2"
-    local PROJECT_FILE="~/$(whoami).code-workspace"
+    local PROJECT_FILE; PROJECT_FILE="$HOME/$(whoami).code-workspace"
     local IDE="cursor"
     
     while [[ $# -gt 0 ]]; do
@@ -330,7 +330,7 @@ function tmux4() {
         attach
 }
 alias tdev='tmux attach -t dev'
-gorun() { local f=$(mktemp -t gorun-XXXX).go; cat >"$f"; go run "$f"; rm "$f"; }
+gorun() { local f; f=$(mktemp -t gorun-XXXX).go; cat >"$f"; go run "$f"; rm "$f"; }
 alias avalanche_up='GODEBUG="x509ignoreCN=0" go run ./cmd/avaServer -yes-i-really-want-to-disable-authentication -mig-bypass-sha256 -overridedb 127.0.0.1'
 if command -v sf &> /dev/null; then
     eval "$(sf aliases)"

--- a/opt/profiles/.bash_logout
+++ b/opt/profiles/.bash_logout
@@ -7,7 +7,7 @@ if [ "$SHLVL" = 1 ]; then
     [ -x /usr/bin/clear_console ] && /usr/bin/clear_console -q
 fi
 if [ ! "$GIT_SAVE_OFF" = "true" ]; then
-  cd ~
+  cd ~ || return
   git checkout master
   git commit -a -m "bash_logout commit $(date)"
   git push origin master

--- a/opt/profiles/.bashrc
+++ b/opt/profiles/.bashrc
@@ -32,7 +32,7 @@ dotfiles_run_daily_maintenance() {
       (
         cd "${HOME}" || exit 0
         [ -d "${HOME}/.git" ] && \
-          GIT_TERMINAL_PROMPT=0 git pull origin "$(git branch | grep '*' | awk '{print $2}')" 2>/dev/null
+          GIT_TERMINAL_PROMPT=0 git pull origin "$(git branch | grep -F '*' | awk '{print $2}')" 2>/dev/null
         GIT_TERMINAL_PROMPT=0 "${HOME}/.gitrepos" > /dev/null 2>&1
       )
     fi
@@ -243,7 +243,10 @@ export PATH="$PATH:/usr/local/bin"
 export NVM_DIR="$HOME/.nvm"
 if [[ "$EDITOR_TERMINAL" == "true" ]]; then
     # Fast loading - just add node to PATH if available
-    [ -d "$NVM_DIR/versions/node" ] && export PATH="$NVM_DIR/versions/node/$(ls $NVM_DIR/versions/node | tail -1)/bin:$PATH"
+    if [ -d "$NVM_DIR/versions/node" ]; then
+        _nvm_node_latest=$(ls "$NVM_DIR/versions/node" | tail -1)
+        export PATH="$NVM_DIR/versions/node/$_nvm_node_latest/bin:$PATH"
+    fi
 else
     # Full NVM initialization
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm

--- a/opt/profiles/.profile
+++ b/opt/profiles/.profile
@@ -167,17 +167,35 @@ alias bazel='bazelisk'
 # added by Snowflake SnowSQL installer
 export PATH=${HOME}/opt/bin:$PATH
 
-# ruby docker environment aliases
+# ruby docker environment aliases + git environment shortcuts.
 #
-if [ -f ${HOME}/.ruby.env ] ; then
-    source ${HOME}/.ruby.env
-else
-    case "$-" in
-        *i*) echo ".ruby.env is missing, you can install with : . opt/scripts/docker/setup_ruby-docker.sh" ;;
-    esac
-fi
-# Source git environment shortcuts
-[ -f ${HOME}/.dindcenv ] && . ${HOME}/.dindcenv
+# ~/.ruby.env and ~/.dindcenv define interactive Docker/UCP helper aliases and
+# functions written in bash/zsh-only syntax: the `function name { ... }` form
+# and hyphenated names (e.g. dindc-login). They are NOT POSIX sh, and sourcing
+# them from the wrong shell at login breaks login on two of our platforms:
+#   * Linux / Raspberry Pi / WSL — /bin/sh is dash; a parse error in a
+#     dot-sourced file is FATAL (exit 2) even under `set +e`. On the Pi this
+#     aborts the LightDM Xsession before the desktop starts → blank screen →
+#     bounced back to the greeter (a login loop).
+#   * macOS — /bin/sh is bash in POSIX mode, which rejects the hyphenated
+#     function names ("not a valid identifier") and bails as well.
+# Every one of those failure paths is a NON-INTERACTIVE shell, and these helpers
+# are only useful interactively. So gate on an interactive shell that is real
+# bash or zsh; non-interactive logins (the Xsession, `sh -c`, ssh commands)
+# skip the block entirely and can never choke on it.
+case "$-" in
+    *i*)
+        if [ -n "$BASH_VERSION" ] || [ -n "$ZSH_VERSION" ]; then
+            if [ -f "${HOME}/.ruby.env" ] ; then
+                . "${HOME}/.ruby.env"
+            else
+                echo ".ruby.env is missing, you can install with : . opt/scripts/docker/setup_ruby-docker.sh"
+            fi
+            # Source git environment shortcuts
+            [ -f "${HOME}/.dindcenv" ] && . "${HOME}/.dindcenv"
+        fi
+        ;;
+esac
 
 # Load Gemini CLI environment
 [ -f "$HOME/.gemini.profile" ] && . "$HOME/.gemini.profile"

--- a/opt/profiles/.profile
+++ b/opt/profiles/.profile
@@ -10,6 +10,7 @@
 #umask 022
 
 if [ ! -z "${GREP_OPTIONS}" ]; then
+  # shellcheck disable=SC2139  # intentional: bake the current GREP_OPTIONS into the alias, then unset it
   alias grep="grep ${GREP_OPTIONS}"
   unset GREP_OPTIONS
 fi
@@ -41,6 +42,7 @@ if [ -d "${HOME}/.cabal/bin" ] ; then
       PATH="${HOME}/.cabal/bin:$PATH"
 fi
 
+# shellcheck disable=SC2034  # set here for parity with .bashrc/.zshrc; consumed by interactive prompt setup
 force_color_prompt=yes
 # Detect if we're in VSCode/Cursor terminal
 if [ "$TERM_PROGRAM" = "vscode" ] || [ "$TERM_PROGRAM" = "cursor" ] || [ -n "$VSCODE_PID" ] || [ -n "$CURSOR_PID" ]; then
@@ -150,7 +152,7 @@ if [ "$EDITOR_TERMINAL" = "false" ]; then
     if ! pgrep -u "${USER:-$(id -un)}" ssh-agent > /dev/null 2>&1; then
       eval "$(ssh-agent -s)" > /dev/null
     fi
-    export GPG_TTY=$(tty 2>/dev/null)
+    GPG_TTY=$(tty 2>/dev/null); export GPG_TTY
     # Only launch zsh if we are not already in it and it exists
     case "$-" in
         *i*)

--- a/opt/scripts/docker/docker_machine_setup.sh
+++ b/opt/scripts/docker/docker_machine_setup.sh
@@ -3,7 +3,7 @@ export DOCKER_MACHINE_HOME="${HOME}/opt/bin"
 export DOCKER_MACHINE_VERSION='latest'
 
 function get_detected_os {
-    uname_bin=$(which uname)
+    uname_bin=$(command -v uname)
     if [ -f "${uname_bin}" ]; then
         # uname is Darwin or Linux?
         os_type="$(uname -s)"

--- a/opt/scripts/docker/docker_machine_setup.sh
+++ b/opt/scripts/docker/docker_machine_setup.sh
@@ -46,11 +46,12 @@ if [ "$1" = "-f" ] ; then
 fi
 # setup $DOCKER_MACHINE_HOME/docker-machine
 if [ "$DOCKER_MACHINE_VERSION" = "latest" ] ; then
-    if [ -z "$(echo $(python --version 2>&1|grep Python))" ] ; then
+    if [ -z "$(python --version 2>&1|grep Python)" ] ; then
         echo "ERROR: configure DOCKER_MACHINE_VERSION or install python to download"
         exit 1
     fi
-    export DOCKER_MACHINE_VERSION=$(curl -s  https://api.github.com/repos/docker/machine/releases/latest |  python -c 'import sys, json; print json.load(sys.stdin)["name"]')
+    DOCKER_MACHINE_VERSION=$(curl -s  https://api.github.com/repos/docker/machine/releases/latest |  python -c 'import sys, json; print json.load(sys.stdin)["name"]')
+    export DOCKER_MACHINE_VERSION
 fi
 if [ ! -f $DOCKER_MACHINE_HOME/docker-machine ] ; then
     get_detected_os

--- a/opt/scripts/docker/docker_up.sh
+++ b/opt/scripts/docker/docker_up.sh
@@ -36,7 +36,6 @@ EOF
 # Read in Complete Set of Coordinates from the Command Line
 _options=
 _hostname=
-OPTION=
 _auto=0
 _clear=0
 # Default container: use jammy (22.04) as it has good multi-arch support
@@ -64,7 +63,7 @@ while [[ $# -gt 0 ]]; do
     "-t"|"--container"  ) _arg_container=$1; shift;;
     "-n"|"--name"       ) _hostname="$1"; shift;;
     "-o"|"--opts"       ) _options="$1"; shift;;
-    *                   ) echo "ERROR: Invalid option: \""$opt"\"" >&2;
+    *                   ) echo "ERROR: Invalid option: \"$opt\"" >&2;
     usage;
     exit 1;;
   esac
@@ -86,9 +85,9 @@ function dirnamef
 {
 _cwd=$(pwd); _dir=$(dirname $1);
 cd $_dir && _dir=$(git rev-parse --show-toplevel)
-cd $_dir/..
+cd $_dir/.. || return 1
   _dir=$(pwd)
-  cd $_cwd
+  cd $_cwd || return 1
   echo -n $_dir
 }
 _VOLUMES="-v $(dirnamef $0):/opt/workspace/git:rw -v /lib/modules:/lib/modules:rw"
@@ -111,7 +110,7 @@ else
   fi
   echo -n $_session > ~/.$SESSION_NAME
   echo "checking if $_session running"
-  docker ps |grep $(echo $_session|cut -c1-12)
+  docker ps |grep "$(echo $_session|cut -c1-12)"
   if [ ! $? -eq 0 ]; then
     echo "starting docker session"
     docker start $_session

--- a/opt/scripts/docker/dockerd-entrypoint.sh
+++ b/opt/scripts/docker/dockerd-entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 ## Launch Docker Daemon
 echo "==> Launching the Docker daemon..."
 LOG_FILE="/tmp/dockerd.log"
+# shellcheck disable=SC2024 # LOG_FILE is in /tmp and user-writable; redirect by the invoking shell (not sudo) is intended
 sudo dind dockerd $DOCKER_EXTRA_OPTS > "$LOG_FILE" 2>&1 &
 counter=1
 while ! docker info > /dev/null 2>&1; do

--- a/opt/scripts/docker/prepare_node_docker.sh
+++ b/opt/scripts/docker/prepare_node_docker.sh
@@ -24,7 +24,8 @@ GIT_HOME=${GIT_HOME:-~/prepare/git}
 REVIEW_SERVER=${REVIEW_SERVER:-https://review.forj.io}
 export DEBUG=${DEBUG:-0}
 export AS_ROOT=${AS_ROOT:-0}
-export SCRIPT_TEMP=$(mktemp -d)
+SCRIPT_TEMP=$(mktemp -d)
+export SCRIPT_TEMP
 trap 'rm -rf $SCRIPT_TEMP' EXIT
 
 [ $DEBUG -eq 1 ] && set -x -v
@@ -46,6 +47,7 @@ function DO_SUDO {
   if [ $AS_ROOT -eq 0 ] ; then
     sudo "$@"
   else
+    # shellcheck disable=SC2294 # eval required to honor env-var-prefixed commands (e.g. DEBIAN_FRONTEND=... apt-get) passed as args
     eval "$@"
   fi
 }
@@ -68,7 +70,7 @@ function GIT_CLONE {
 
 # prepare a node with docker installed
 # * we need puppet commandline setup, along with expected modules
-[ ! $(id -u) -eq 0 ] && [ $AS_ROOT -eq 1 ] \
+[ ! "$(id -u)" -eq 0 ] && [ $AS_ROOT -eq 1 ] \
    && ERROR_EXIT  ${LINENO} "SCRIPT should be run as sudo or root with export AS_ROOT=1" 2
 
 
@@ -132,7 +134,8 @@ DO_SUDO puppet apply $PUPPET_DEBUG -e 'user {'"'${CURRENT_USER}'"': ensure => pr
 # Portable replacement for `readlink -f` (GNU-only; absent on macOS/BSD):
 # resolve the existing parent dir with `cd ... && pwd -P` then append /docker,
 # so it works even though the docker/ dir may not exist yet (created below).
-export DOCKER_HOME="$(cd -- "$GIT_HOME/.." >/dev/null 2>&1 && pwd -P)/docker"
+DOCKER_HOME="$(cd -- "$GIT_HOME/.." >/dev/null 2>&1 && pwd -P)/docker"
+export DOCKER_HOME
 [ ! -d "${DOCKER_HOME}" ] && mkdir -p "${DOCKER_HOME}"
 [ ! -d "${DOCKER_HOME}/precise" ] && mkdir -p "${DOCKER_HOME}/precise"
 [ ! -d "${DOCKER_HOME}/trusty" ] && mkdir -p "${DOCKER_HOME}/trusty"

--- a/opt/scripts/docker/prepare_node_docker.sh
+++ b/opt/scripts/docker/prepare_node_docker.sh
@@ -129,7 +129,10 @@ DO_SUDO puppet apply $PUPPET_DEBUG -e 'user {'"'${CURRENT_USER}'"': ensure => pr
 
 # build a docker image bare_precise_puppet
 # This docker image should have puppet and required modules installed.
-export DOCKER_HOME=$(readlink -f $GIT_HOME/../docker)
+# Portable replacement for `readlink -f` (GNU-only; absent on macOS/BSD):
+# resolve the existing parent dir with `cd ... && pwd -P` then append /docker,
+# so it works even though the docker/ dir may not exist yet (created below).
+export DOCKER_HOME="$(cd -- "$GIT_HOME/.." >/dev/null 2>&1 && pwd -P)/docker"
 [ ! -d "${DOCKER_HOME}" ] && mkdir -p "${DOCKER_HOME}"
 [ ! -d "${DOCKER_HOME}/precise" ] && mkdir -p "${DOCKER_HOME}/precise"
 [ ! -d "${DOCKER_HOME}/trusty" ] && mkdir -p "${DOCKER_HOME}/trusty"

--- a/opt/scripts/docker/setup_dindc_alias.sh
+++ b/opt/scripts/docker/setup_dindc_alias.sh
@@ -25,7 +25,7 @@ SCRIPT_NAME=.dindcenv
 ALIAS_ENV_SCRIPT="$HOME/$SCRIPT_NAME"
 
 # VERIFY THAT docker is installed
-docker --version 2>&1 >/dev/null
+docker --version >/dev/null 2>&1
 DOCKER_IS_AVAILABLE=$?
 if [ $DOCKER_IS_AVAILABLE -eq 0 ]; then
     docker --version

--- a/opt/scripts/docker/setup_ruby-docker.sh
+++ b/opt/scripts/docker/setup_ruby-docker.sh
@@ -15,7 +15,7 @@ SCRIPT_NAME=.ruby.env
 ALIAS_ENV_SCRIPT="$HOME/$SCRIPT_NAME"
 
 # VERIFY THAT docker is installed
-docker --version 2>&1 >/dev/null
+docker --version >/dev/null 2>&1
 DOCKER_IS_AVAILABLE=$?
 if [ $DOCKER_IS_AVAILABLE -eq 0 ]; then
    docker --version

--- a/opt/scripts/git/git-local-master.sh
+++ b/opt/scripts/git/git-local-master.sh
@@ -6,7 +6,7 @@
 
 
 # lets make sure we're doing this on a branch other than master
-branch_name="$(printf '%s' $(git branch -l 2>&1|grep '^*'|awk -F' ' '{print $2}'))"
+branch_name="$(git branch -l 2>&1|grep '^\*'|awk -F' ' '{print $2}')"
 if [ -z "${branch_name}" ] || [ "${branch_name}" = 'master' ] ; then
   echo "ERROR no branch found or the current branch is master, you need to use a branch for this command"
   exit 1

--- a/opt/scripts/git/git-reset.sh
+++ b/opt/scripts/git/git-reset.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-branch_name="$(printf '%s' $(git branch -l 2>&1|grep '^*'|awk -F' ' '{print $2}'))"
+branch_name="$(git branch -l 2>&1|grep '^\*'|awk -F' ' '{print $2}')"
 if [ -z "${branch_name}" ]; then
   echo "ERROR no default branch found"
   exit 1

--- a/opt/scripts/git/git-rm-mybranches.sh
+++ b/opt/scripts/git/git-rm-mybranches.sh
@@ -21,13 +21,13 @@ if [ -n "${1}" ]; then
 fi
 
 if [ -z "${SEARCH_TERM}" ]; then
-    echo "Usage: $o [--force] regex"
+    echo "Usage: $0 [--force] regex"
     exit 1
 fi
 
 if [ ! "${cleanup}" = "Y" ]; then
   echo "Current directory $(pwd) and repo $(git rev-parse --show-toplevel)"
-  echo -n "Would you like to cleanup ($(printf '%s' $(git branch -l 2>&1 |grep "^\s\s${SEARCH_TERM}"|wc -l))) all branches? [Y]:" && \
+  echo -n "Would you like to cleanup ($(git branch -l 2>&1 |grep "^\s\s${SEARCH_TERM}"|wc -l|tr -d ' ')) all branches? [Y]:" && \
     read -r cleanup
 fi
 

--- a/opt/scripts/git/setup_git_alias.sh
+++ b/opt/scripts/git/setup_git_alias.sh
@@ -21,7 +21,7 @@
 #
 
 # VERIFY THAT GIT IS INSTALLED
-git --version 2>&1 >/dev/null
+git --version >/dev/null 2>&1
 GIT_IS_AVAILABLE=$?
 if [ $GIT_IS_AVAILABLE -eq 0 ]; then
     git --version
@@ -408,7 +408,7 @@ function fgit-tunelkill {
     fi
 
     fgit-isWindows
-    if [[ $? -eq 0 ]] ; then
+    if [[ \$? -eq 0 ]] ; then
         _pid=\$(ps -ef|grep "ssh -N -L" | grep -v grep | awk '{printf \$2" "}')
     else
 # Get-WmiObject win32_process -Filter "name='ssh.exe' and CommandLine like '%-N -L%'" | select ProcessID,Name,CommandLine
@@ -631,7 +631,7 @@ function fgit-createknown_host {
 
     rm ./tmp_key
     rm ./keyhost.txt
-    cd $_cwd > /dev/null 2>&1
+    cd \$_cwd > /dev/null 2>&1
     return 0
 }
 
@@ -774,7 +774,7 @@ function fgit-keys {
     popd > /dev/null 2<&1
     if [[ -f ~/.ssh/\$_key_name.pub ]] ; then
         clip < ~/.ssh/\$_key_name.pub
-        if [[ $? -eq 0 ]] ; then
+        if [[ \$? -eq 0 ]] ; then
             echo "Keys created, ~/.ssh/\${_key_name}.pub is copied to the clip-board"
         fi
     else
@@ -815,7 +815,7 @@ function fgit-login {
         export GIT_USER=\$_user
     fi
     ssh-add \$_pem_file
-    if [[ ! $? -eq 0 ]] ; then
+    if [[ ! \$? -eq 0 ]] ; then
         echo "Failed to add key, maybe agent is the problem, try running git-sshkill then this command again."
     fi
 }
@@ -1053,7 +1053,7 @@ function fgit-tunel {
     # spawn tunnel
     echo "Spawning ssh tunnel to \$_ssh_host on port \$_ssh_port"
     ssh -N -L \$_ssh_port:127.0.0.1:\$_ssh_port -i \$_pem_file \$_user@\$_ssh_host &
-    if [[ $? -eq 0 ]] ; then
+    if [[ \$? -eq 0 ]] ; then
         echo "Tunel created!  use git-testt and tunel alias to connect"
         echo "  Use git-refresh to update your origin to the tunel url."
     fi
@@ -1219,7 +1219,7 @@ function fgit-gerrit-rebase {
 }
 
 function fgit-reset-all {
-    find . -maxdepth 1 -mindepth 1 -type d  -printf "%f\n"|xargs -i bash -c 'cd {};git rev-parse --show-toplevel 2>/dev/null;if [ $? -eq 0 ]; then git reset --hard;git clean -x -d -f;git pull origin stable; else echo "{} is not a git repository"; fi;';
+    find . -maxdepth 1 -mindepth 1 -type d  -printf "%f\n"|xargs -i bash -c 'cd {};git rev-parse --show-toplevel 2>/dev/null;if [ \$? -eq 0 ]; then git reset --hard;git clean -x -d -f;git pull origin stable; else echo "{} is not a git repository"; fi;';
 }
 
 function fgit-ssl {

--- a/opt/scripts/git/setup_git_alias.sh
+++ b/opt/scripts/git/setup_git_alias.sh
@@ -32,7 +32,7 @@ else
 fi
 
 # VERIFY THAT CORKSCREW IS INSTALLED
-which corkscrew | grep -q corkscrew
+command -v corkscrew | grep -q corkscrew
 CORKSCREW_IS_AVAILABLE=$?
 
 if ! [ $CORKSCREW_IS_AVAILABLE -eq 0 ]; then
@@ -413,7 +413,7 @@ function fgit-tunelkill {
     else
 # Get-WmiObject win32_process -Filter "name='ssh.exe' and CommandLine like '%-N -L%'" | select ProcessID,Name,CommandLine
         _command="Get-WmiObject win32_process -Filter \\"name='ssh.exe' and CommandLine like '%-N -L%'\\" | select ProcessID|Format-Wide -Property ProcessID"
-        _pid=\$(\$(which powershell.exe) -NoProfile -ExecutionPolicy unrestricted -Command "\$_command")
+        _pid=\$(\$(command -v powershell.exe) -NoProfile -ExecutionPolicy unrestricted -Command "\$_command")
         _pid=\$(echo \$_pid |tr -d '\\n' | tr -d '\\r')
     fi
 
@@ -529,7 +529,7 @@ function fgit-addalias {
             echo "  Port \$_ssh_port" >> ~/.ssh/config
             echo "  ServerAliveInterval 300" >> ~/.ssh/config
             echo "  ServerAliveCountMax 120" >> ~/.ssh/config
-            echo "  ProxyCommand \$(which corkscrew) \${_current_proxy_host} \${_current_proxy_port} 8080 %h %p" >> ~/.ssh/config
+            echo "  ProxyCommand \$(command -v corkscrew) \${_current_proxy_host} \${_current_proxy_port} 8080 %h %p" >> ~/.ssh/config
             echo "  identityfile ~/.ssh/gerrit_keys" >> ~/.ssh/config
             echo "git alias, \$_alias_proxy, has been added!"
         fi
@@ -1144,9 +1144,9 @@ function fgit-reset {
     _CWD=\$(pwd)
     if git rev-parse --show-toplevel >/dev/null 2<&1 ; then
         _GIT_REPO_ROOT=\$(git rev-parse --show-toplevel)
-        # Normalize paths for comparison
-        _REAL_REPO_ROOT=\$(readlink -f "\${_GIT_REPO_ROOT}")
-        _REAL_HOME=\$(readlink -f "\$HOME")
+        # Normalize paths for comparison (portable: readlink -f is GNU-only, absent on macOS BSD)
+        _REAL_REPO_ROOT=\$(cd -- "\${_GIT_REPO_ROOT}" 2>/dev/null && pwd -P)
+        _REAL_HOME=\$(cd -- "\$HOME" 2>/dev/null && pwd -P)
         
         if [ "\${_REAL_REPO_ROOT}" = "\${_REAL_HOME}" ]; then
             echo "WARNING: you are about to reset your home folder!!! [\$_GIT_REPO_ROOT] "

--- a/opt/scripts/network/proxy.sh
+++ b/opt/scripts/network/proxy.sh
@@ -18,7 +18,7 @@
 ETH0_IP=""
 WLAN_IP=""
 TUN0_IP=""
-IFCONFIG_BIN=$(which ifconfig)
+IFCONFIG_BIN=$(command -v ifconfig)
 if [ -x "${IFCONFIG_BIN}" ] ; then
     if $IFCONFIG_BIN|grep 'Link encap'|awk '{print $1}'|grep eth0 > /dev/null ; then
         ETH0_IP=$($IFCONFIG_BIN eth0|grep 'inet addr'|awk -F: '{print $2}'|awk '{print $1}')

--- a/opt/scripts/network/proxy.sh
+++ b/opt/scripts/network/proxy.sh
@@ -63,8 +63,8 @@ echo "setting up proxy"
     export https_proxy=$http_proxy
     export HTTP_PROXY=$http_proxy
     export HTTPS_PROXY=$http_proxy
-    export ftp_proxy=$(echo $http_proxy | sed 's/^http/ftp/g')
-    export socks_proxy=$(echo $http_proxy | sed 's/^http/socks/g')
+    ftp_proxy=$(echo "$http_proxy" | sed 's/^http/ftp/g'); export ftp_proxy
+    socks_proxy=$(echo "$http_proxy" | sed 's/^http/socks/g'); export socks_proxy
     export no_proxy=localhost,127.0.0.1,10.0.0.0/16,172.0.0.0/16,15.108.25.44,169.254.169.254
     if [ "$(id -u)" = "0" ] ; then # should only be done by root
     # clear out previous setting

--- a/opt/scripts/network/remote-setup.sh
+++ b/opt/scripts/network/remote-setup.sh
@@ -30,8 +30,9 @@ install_tailscale() {
 # --- 2. NoMachine Download (High-Performance GUI) ---
 install_nomachine() {
     echo -e "${BLUE}${BOLD}[2/2] Preparing NoMachine (GUI Desktop)...${NC}"
-    NOMACHINE_VER=$(curl -s https://www.nomachine.com/download/download&id=116 | grep -oP "nomachine_\K[0-9]+\.[0-9]+" | head -n1 || echo "8.16")
-    NOMACHINE_SUB=$(curl -s https://www.nomachine.com/download/download&id=116 | grep -oP "nomachine_[0-9]+\.[0-9]+\._\K[0-9]+" | head -n1 || echo "1")
+    # grep -P/\K is GNU-only (absent on macOS BSD grep); use -oE + sed (both portable).
+    NOMACHINE_VER=$(curl -s https://www.nomachine.com/download/download&id=116 | grep -oE "nomachine_[0-9]+\.[0-9]+" | sed -E 's/^nomachine_//' | head -n1 || echo "8.16")
+    NOMACHINE_SUB=$(curl -s https://www.nomachine.com/download/download&id=116 | grep -oE "nomachine_[0-9]+\.[0-9]+\._[0-9]+" | sed -E 's/.*\._//' | head -n1 || echo "1")
     DEB_FILE="nomachine_${NOMACHINE_VER}.${NOMACHINE_SUB}_arm64.deb"
     
     if command -v nxserver >/dev/null 2>&1; then

--- a/opt/scripts/network/remote-setup.sh
+++ b/opt/scripts/network/remote-setup.sh
@@ -31,8 +31,8 @@ install_tailscale() {
 install_nomachine() {
     echo -e "${BLUE}${BOLD}[2/2] Preparing NoMachine (GUI Desktop)...${NC}"
     # grep -P/\K is GNU-only (absent on macOS BSD grep); use -oE + sed (both portable).
-    NOMACHINE_VER=$(curl -s https://www.nomachine.com/download/download&id=116 | grep -oE "nomachine_[0-9]+\.[0-9]+" | sed -E 's/^nomachine_//' | head -n1 || echo "8.16")
-    NOMACHINE_SUB=$(curl -s https://www.nomachine.com/download/download&id=116 | grep -oE "nomachine_[0-9]+\.[0-9]+\._[0-9]+" | sed -E 's/.*\._//' | head -n1 || echo "1")
+    NOMACHINE_VER=$(curl -s "https://www.nomachine.com/download/download&id=116" | grep -oE "nomachine_[0-9]+\.[0-9]+" | sed -E 's/^nomachine_//' | head -n1 || echo "8.16")
+    NOMACHINE_SUB=$(curl -s "https://www.nomachine.com/download/download&id=116" | grep -oE "nomachine_[0-9]+\.[0-9]+\._[0-9]+" | sed -E 's/.*\._//' | head -n1 || echo "1")
     DEB_FILE="nomachine_${NOMACHINE_VER}.${NOMACHINE_SUB}_arm64.deb"
     
     if command -v nxserver >/dev/null 2>&1; then

--- a/opt/scripts/system/coco_install.sh
+++ b/opt/scripts/system/coco_install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # TODO: need a way to check if cortext cli is installed and if not prompt and ask to install it
 if ! cortex --version; then

--- a/opt/scripts/system/crouton-alias.sh
+++ b/opt/scripts/system/crouton-alias.sh
@@ -58,11 +58,13 @@ function crouton-start {
        xorg) 
            echo "start using xorg"
            echo $_METHOD> ~/.config/crouton_method.config
+           # shellcheck disable=SC2033 # startunity here is the external crouton binary, not the shell alias
            sudo startunity -X xorg -n $CHROOT_NAME
            ;;
        xiwi) 
            echo "start using xiwi"
            echo $_METHOD> ~/.config/crouton_method.config
+           # shellcheck disable=SC2033 # startunity here is the external crouton binary, not the shell alias
            sudo startunity -X xiwi -n $CHROOT_NAME
            ;;
        *)
@@ -81,13 +83,13 @@ function crouton-run {
 }
 function crouton-update {
    [[ -z "$CHROOT_NAME" ]] && CHROOT_NAME=trusty
-   cd ~/Downloads
+   cd ~/Downloads || return 1
    [ ! -f ./crouton ] && curl -L https://goo.gl/fd3zc > ./crouton
    [ ! -f ./crouton-alias.sh ] && curl -L https://raw.githubusercontent.com/wenlock/myhome/master/opt/scripts/system/crouton-alias.sh > ./crouton-alias.sh
    sudo sh ./crouton -u -n $CHROOT_NAME
 }
 function crouton-clean {
-    cd ~/Downloads
+    cd ~/Downloads || return 1
     [ -f ./crouton ] && rm -f ./crouton
     [ -f ./crouton-alias.sh ] && rm -f ./crouton-alias.sh
     echo "clean done"

--- a/opt/scripts/system/enable-vmx.sh
+++ b/opt/scripts/system/enable-vmx.sh
@@ -70,7 +70,8 @@ sleep 3 && echo
 echo "## 4.Edit the config files and add 'disablevmx=off' to the config line"
 if grep --color disablevmx=off vmxoff-config$C_KERNEL.txt ; then echo; error 1 "*** Kernel already modified - exiting"; fi 
 echo -n "Editing vmxoff-config$C_KERNEL.txt to append = "
-sed -i -e 's/$/ disablevmx=off lsm.module_locking=0/' vmxoff-config$C_KERNEL.txt || ( echo; error 2 "*** Couldn't edit config file" )
+# sed -i.bak (suffix attached) is in-place on both GNU and BSD; remove the backup.
+sed -i.bak -e 's/$/ disablevmx=off lsm.module_locking=0/' vmxoff-config$C_KERNEL.txt && rm -f vmxoff-config$C_KERNEL.txt.bak || ( echo; error 2 "*** Couldn't edit config file" )
 echo "disablevmx=off"
 sleep 3 && echo
 

--- a/opt/scripts/system/enable-vmx.sh
+++ b/opt/scripts/system/enable-vmx.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -e 
+#!/usr/bin/env bash
+set -e
 C_ROOT=''
 C_KERNEL=''
 ##
@@ -97,7 +98,7 @@ sleep 3 && echo
 ## 7.If verifying works, then it should just be a matter of:
 echo "## 7.If verifying works, then it should just be a matter of:"
 echo "Copying modified kernel back to = ${ROOTDEVICEPREFIX}$C_KERNEL"
-echo -n "[ press ENTER to continue - Ctrl-C to abort ] "; read DOIT
+echo -n "[ press ENTER to continue - Ctrl-C to abort ] "; read -r _
 sudo dd if=repacked$C_KERNEL of=${ROOTDEVICEPREFIX}$C_KERNEL || ( echo; error 2 "*** Couldn't create new kernel" )
 sleep 3 && echo
 
@@ -105,6 +106,6 @@ sleep 3 && echo
 ## 8.reboot, and enjoy VT-x extensions
 echo "## 8.reboot, and enjoy VT-x extensions"
 echo "All done - rebooting..."
-echo -n "[ press ENTER to continue - Ctrl-C to abort ] "; read DOIT
+echo -n "[ press ENTER to continue - Ctrl-C to abort ] "; read -r _
 sudo reboot
 exit

--- a/opt/scripts/system/google-cli-setup.sh
+++ b/opt/scripts/system/google-cli-setup.sh
@@ -149,7 +149,7 @@ show_status() {
     echo -e "\n${BOLD}--- Google CLI Status ---${NC}"
     
     # gcloud
-    local gcloud_ver=$(get_gcloud_version)
+    local gcloud_ver; gcloud_ver=$(get_gcloud_version)
     if [[ "$gcloud_ver" != "Missing" ]]; then
         echo -e "${GREEN}[OK]${NC} gcloud CLI: $gcloud_ver"
     else

--- a/opt/scripts/system/install_ai_teams.sh
+++ b/opt/scripts/system/install_ai_teams.sh
@@ -16,7 +16,6 @@ set -euo pipefail
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 TEAMS_DIR="${BASE_DIR}/ai/teams"
 MODEL_MAP="${TEAMS_DIR}/model-map.yaml"
-TEAMS_YAML="${TEAMS_DIR}/teams.yaml"
 VALIDATE="${TEAMS_DIR}/validate.sh"
 
 # Output roots. DEST_HOME lets tests redirect every tool dir under a temp root.

--- a/opt/scripts/system/install_ai_teams_test.sh
+++ b/opt/scripts/system/install_ai_teams_test.sh
@@ -6,7 +6,6 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALLER="${HERE}/install_ai_teams.sh"
-TEAMS_DIR="$(cd "${HERE}/../../.." && pwd)/ai/teams"
 
 PASS=0; FAIL=0
 ok()   { echo "  ✓ $*"; PASS=$((PASS + 1)); }

--- a/opt/scripts/system/install_claude_skills.sh
+++ b/opt/scripts/system/install_claude_skills.sh
@@ -117,7 +117,7 @@ fi
 # never clobbers host-local memories, regenerates the index from the union. ---
 if [ -f "$BASE_DIR/opt/scripts/system/provision-claude-memory.sh" ]; then
     echo "  Provisioning Claude account memories (~/.claude/projects/<slug>/memory)"
-    BASE_DIR="$BASE_DIR" CLAUDE_HOME="$CLAUDE_HOME" \
+    env BASE_DIR="$BASE_DIR" CLAUDE_HOME="$CLAUDE_HOME" \
         bash "$BASE_DIR/opt/scripts/system/provision-claude-memory.sh" || true
 fi
 

--- a/opt/scripts/system/install_claude_skills.sh
+++ b/opt/scripts/system/install_claude_skills.sh
@@ -48,7 +48,15 @@ fi
 # preserving whatever the host had configured (the merge re-applies wiring).
 if [ -L "$SETTINGS_DEST" ]; then
     echo "  Migrating legacy settings.json symlink to a host-owned file"
-    legacy_target="$(readlink -f "$SETTINGS_DEST" 2>/dev/null || true)"
+    # Portable replacement for `readlink -f` (GNU-only; absent on macOS/BSD):
+    # plain `readlink` (BSD+GNU) reads the link, then anchor a relative target
+    # to the symlink's physical dir via `cd ... && pwd -P`.
+    legacy_link="$(readlink "$SETTINGS_DEST" 2>/dev/null || true)"
+    case "$legacy_link" in
+        "") legacy_target="" ;;
+        /*) legacy_target="$legacy_link" ;;
+        *)  legacy_target="$(cd -- "$(dirname -- "$SETTINGS_DEST")" >/dev/null 2>&1 && pwd -P)/$legacy_link" ;;
+    esac
     rm -f "$SETTINGS_DEST"
     if [ -n "$legacy_target" ] && [ -f "$legacy_target" ]; then
         cp "$legacy_target" "$SETTINGS_DEST"

--- a/opt/scripts/system/install_gemini_skills.sh
+++ b/opt/scripts/system/install_gemini_skills.sh
@@ -116,7 +116,15 @@ if [ -f "$GSETTINGS_DEST" ] && [ ! -L "$GSETTINGS_DEST" ] && [ ! -e "$GSETTINGS_
 fi
 if [ -L "$GSETTINGS_DEST" ]; then
     echo "  Migrating legacy settings.json symlink to a host-owned file"
-    legacy_target="$(readlink -f "$GSETTINGS_DEST" 2>/dev/null || true)"
+    # Portable replacement for `readlink -f` (GNU-only; absent on macOS/BSD):
+    # plain `readlink` (BSD+GNU) reads the link, then anchor a relative target
+    # to the symlink's physical dir via `cd ... && pwd -P`.
+    legacy_link="$(readlink "$GSETTINGS_DEST" 2>/dev/null || true)"
+    case "$legacy_link" in
+        "") legacy_target="" ;;
+        /*) legacy_target="$legacy_link" ;;
+        *)  legacy_target="$(cd -- "$(dirname -- "$GSETTINGS_DEST")" >/dev/null 2>&1 && pwd -P)/$legacy_link" ;;
+    esac
     rm -f "$GSETTINGS_DEST"
     if [ -n "$legacy_target" ] && [ -f "$legacy_target" ]; then
         cp "$legacy_target" "$GSETTINGS_DEST"

--- a/opt/scripts/system/retire-ahk-voice-macro.sh
+++ b/opt/scripts/system/retire-ahk-voice-macro.sh
@@ -31,8 +31,10 @@ case "${1:-}" in
 esac
 
 # Repo root, resolved from this script's location (works via the ~/opt symlink).
-SCRIPT_PATH="$(readlink -f "$0")"
-BASE_DIR="$(cd "$(dirname "$SCRIPT_PATH")/../../.." && pwd)"
+# Portable replacement for `readlink -f "$0"` (GNU-only; absent on macOS/BSD):
+# `cd ... && pwd -P` resolves symlinks to the physical script dir.
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd -P)"
+BASE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
 REPO_AHK="${BASE_DIR}/opt/Desktop/Apps/scripts/macos.ahk"
 
 # Markers that identify the retired voice block in a deployed macos.ahk.

--- a/opt/scripts/system/setup_jtop.sh
+++ b/opt/scripts/system/setup_jtop.sh
@@ -41,7 +41,8 @@ if [ -f "$JTOP_VARS" ]; then
     if ! grep -q "$TARGET_MAPPING" "$JTOP_VARS"; then
         echo "Patching $JTOP_VARS for JetPack 6.2.1 support..."
         # Insert after JP6 comment or first mapping
-        sudo sed -i '/# -------- JP6 --------/a \    "36.4.7": "6.2.1",' "$JTOP_VARS"
+        # sed -i.bak (suffix attached) is portable in-place on GNU and BSD; drop the backup.
+        sudo sed -i.bak '/# -------- JP6 --------/a \    "36.4.7": "6.2.1",' "$JTOP_VARS" && sudo rm -f "${JTOP_VARS}.bak"
         echo "Patch applied."
     else
         echo "Mapping for 36.4.7 already exists in $JTOP_VARS."

--- a/opt/scripts/system/shell-portability-scan.sh
+++ b/opt/scripts/system/shell-portability-scan.sh
@@ -23,8 +23,10 @@
 #                       bashisms, so most entries here are expected; the list is
 #                       the full "which scripts are not dash-portable" picture.
 #
-# WARN-ONLY by default: always exits 0 so it can run as a non-blocking CI gate.
-# `--strict` makes a non-empty TIER 1 exit non-zero (for a future hard gate).
+# `--strict` makes a non-empty TIER 1 or TIER 2 exit non-zero — this is the
+# enforcing CI gate (`make lint-portability`). Without it the scan is advisory
+# and always exits 0. To intentionally exempt a reviewed line, add a trailing
+# `# portability-ok: <reason>` comment and the scanner will skip it.
 # `--md` emits a GitHub-flavoured-markdown report (used to seed the issue body).
 #
 # Usage:
@@ -124,13 +126,13 @@ HAZARDS='declare[[:space:]]+-A	bash-4 associative array (breaks macOS bash 3.2)
 \$\{[A-Za-z_][A-Za-z0-9_]*(\^\^|,,|\^|,)[}/:]	bash-4 case-conversion ${v,,}/${v^^} (breaks macOS bash 3.2)
 \b(mapfile|readarray)\b	bash-4 mapfile/readarray (breaks macOS bash 3.2)
 \|&([^]]|$)	bash-4 |& pipe (breaks macOS bash 3.2)
-\bsed[[:space:]]+-i\b	sed -i: GNU vs BSD differ (BSD needs `-i ""`); use a tmpfile+mv
+\bsed[[:space:]]+-i[[:space:]]	sed -i with a space arg differs GNU vs BSD; use the portable `sed -i.bak … && rm -f …bak` (suffix attached) or a tmpfile+mv
 \bstat[[:space:]]+-c\b	stat -c is GNU; BSD uses `stat -f`
 \breadlink[[:space:]]+-f\b	readlink -f is GNU; old BSD lacks it; ship a realpath shim
 \bgrep[[:space:]]+-[A-Za-z]*P\b	grep -P (PCRE) is GNU-only; use -E (ERE)
 \bbase64[[:space:]]+-w\b	base64 -w is GNU-only; use `base64 | tr -d "\\n"`
 \bdate[[:space:]]+-d\b	date -d is GNU; BSD uses `date -r`/`-v`
-\bwhich\b	use `command -v`, not `which` (not guaranteed installed; BSD/GNU differ)
+(^|[;&|]|\$\()[[:space:]]*which[[:space:]]	use `command -v`, not `which` (not guaranteed installed; BSD/GNU differ)
 \bread[[:space:]]+-[A-Za-z]*A\b	zsh-only `read -A`; bash errors. Use `read -a`/mapfile'
 
 scan_count=0
@@ -156,6 +158,9 @@ for f in $CANDIDATES; do
 
   # --- macOS hazard heuristics (skip zsh files; read -A check also skips .zshrc handled above) ---
   is_zsh "$f" && continue
+  # The scanner's own HAZARDS table necessarily contains every pattern it greps
+  # for, so don't let it flag itself. (dash -n / Tier 1 / Tier 3 still apply.)
+  case "$f" in */shell-portability-scan.sh) continue ;; esac
   while IFS=$(printf '\t') read -r pat desc; do
     [ -n "$pat" ] || continue
     # Suppress the stat -c hazard when the file already has a BSD `stat -f`
@@ -163,8 +168,10 @@ for f in $CANDIDATES; do
     case "$desc" in
       *"stat -c"*) grep -q 'stat -f' "$f" && continue ;;
     esac
-    # Drop comment-only matches (line whose first non-space char is #).
-    hits=$(grep -nE "$pat" "$f" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+    # Drop comment-only matches (first non-space char is #) and any line that
+    # carries a `# portability-ok` opt-out (reviewed/intentional exceptions;
+    # see docs/mbo/specs/shell-portability.md + CLAUDE.md).
+    hits=$(grep -nE "$pat" "$f" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' | grep -vF 'portability-ok' || true)
     if [ -n "$hits" ]; then
       while IFS= read -r h; do
         [ -n "$h" ] || continue
@@ -224,8 +231,10 @@ else
   fi
 fi
 
-# WARN-ONLY unless --strict explicitly asks Tier 1 to gate.
-if [ "$STRICT" -eq 1 ] && [ "$n1" -gt 0 ]; then
+# In --strict mode a non-empty Tier 1 OR Tier 2 fails the gate; Tier 3 is
+# informational and never gates. Without --strict the scan is purely advisory
+# (always exits 0).
+if [ "$STRICT" -eq 1 ] && { [ "$n1" -gt 0 ] || [ "$n2" -gt 0 ]; }; then
   exit 1
 fi
 exit 0

--- a/opt/scripts/system/shell-portability-scan.sh
+++ b/opt/scripts/system/shell-portability-scan.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# shell-portability-scan.sh — cross-shell / cross-OS portability scanner.
+#
+# Catches the class of portability bugs that `shellcheck` and `bash -n` MISS,
+# per docs/mbo/specs/shell-portability.md. The motivating incident: a bash-only
+# `function name { ... }` block in a profile fragment, sourced by dash at GUI
+# login on a Raspberry Pi, fatally aborted the LightDM Xsession (dash exits 2 on
+# a parse error in a dot-sourced file, even under `set +e`) → blank screen →
+# login loop. `bash -n` passes such files; only `dash -n` catches them.
+#
+# Three tiers of findings:
+#   TIER 1  MUST-FIX  — files that MUST be POSIX (a `#!/bin/sh` shebang, or a
+#                       fragment that dash sources at login: .profile,
+#                       .xsessionrc) that FAIL `dash -n`. These are the
+#                       login-breaking class.
+#   TIER 2  macOS     — bash-4-only features (declare -A, ${v,,}, mapfile, |&)
+#           HAZARDS     and BSD-vs-GNU coreutil traps (sed -i, stat -c,
+#                       readlink -f, grep -P, base64 -w, `which`, date -d). These
+#                       break on macOS (BSD coreutils + bash 3.2).
+#   TIER 3  INFO      — every shell file that is not POSIX-clean (`dash -n`),
+#           ("everything") regardless of shebang. Bash scripts are ALLOWED to use
+#                       bashisms, so most entries here are expected; the list is
+#                       the full "which scripts are not dash-portable" picture.
+#
+# WARN-ONLY by default: always exits 0 so it can run as a non-blocking CI gate.
+# `--strict` makes a non-empty TIER 1 exit non-zero (for a future hard gate).
+# `--md` emits a GitHub-flavoured-markdown report (used to seed the issue body).
+#
+# Usage:
+#   opt/scripts/system/shell-portability-scan.sh [--strict] [--md]
+#
+# Portability: this script targets bash 3.2+ (no associative arrays, no
+# mapfile) so it runs identically on macOS system bash and CI ubuntu bash.
+
+set -u
+
+STRICT=0
+MD=0
+for arg in "$@"; do
+  case "$arg" in
+    --strict) STRICT=1 ;;
+    --md)     MD=1 ;;
+    -h|--help)
+      sed -n '2,40p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Resolve repo root from this script's location (works in a worktree too).
+unset CDPATH
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../../.." && pwd)
+cd "$REPO_ROOT" || exit 2
+
+if ! command -v dash >/dev/null 2>&1; then
+  echo "WARNING: dash not installed; cannot run the POSIX syntax check. Install with 'apt-get install dash'." >&2
+  # Not fatal in warn mode — emit an empty-ish report and exit 0.
+  [ "$STRICT" -eq 1 ] && exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Enumerate candidate shell files (tracked only), excluding vendored trees.
+# ---------------------------------------------------------------------------
+# A file is a candidate if it ends in .sh OR its first line is a shell shebang
+# OR it is one of the known sourced profile fragments.
+FRAGMENTS="opt/profiles/.profile opt/profiles/.bashrc opt/profiles/.bash_aliases opt/profiles/.bash_logout opt/profiles/.docker.sh opt/profiles/.goenv.sh opt/profiles/.nano_profile opt/profiles/.xsessionrc"
+
+# Of those, only these are dot-sourced by dash (/bin/sh) at login — directly
+# (the Xsession sources .profile and .xsessionrc) or transitively (.profile
+# unconditionally dot-sources .nano_profile). THESE must be POSIX-clean. The
+# rest (.bashrc, .bash_aliases, .docker.sh, .goenv.sh, …) are sourced only by
+# bash/zsh, so bashisms in them are legitimate and are NOT a must-fix.
+POSIX_FRAGMENTS="opt/profiles/.profile opt/profiles/.xsessionrc opt/profiles/.nano_profile"
+
+is_excluded() {
+  case "$1" in
+    */opt/google-cloud-sdk/*|opt/google-cloud-sdk/*) return 0 ;;
+    archive/*)                                        return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# zsh files must NOT be dash/bash-checked (legitimate zsh syntax).
+is_zsh() {
+  case "$1" in
+    *.zshrc|*.p10k.zsh|*.zshenv|*.zprofile) return 0 ;;
+  esac
+  head -1 "$1" 2>/dev/null | grep -qE '^#!.*zsh' && return 0
+  return 1
+}
+
+# A file is POSIX-REQUIRED if dash sources/executes it: a /bin/sh shebang, or a
+# fragment dash sources at login.
+is_posix_required() {
+  case " $POSIX_FRAGMENTS " in
+    *" $1 "*) return 0 ;;     # .profile / .xsessionrc / .nano_profile (dash-sourced)
+  esac
+  head -1 "$1" 2>/dev/null | grep -qE '^#! ?(/usr/bin/env +sh|/bin/sh)\>' && return 0
+  return 1
+}
+
+CANDIDATES=$(
+  {
+    git ls-files '*.sh'
+    for f in $FRAGMENTS; do [ -f "$f" ] && echo "$f"; done
+    # shebang-based discovery for extension-less scripts
+    git ls-files | while IFS= read -r f; do
+      [ -f "$f" ] || continue
+      head -1 "$f" 2>/dev/null | grep -qE '^#!.*(bash|/sh|zsh)\>' && echo "$f"
+    done
+  } | sort -u
+)
+
+# ---------------------------------------------------------------------------
+# 2. Run the three tiers.
+# ---------------------------------------------------------------------------
+TIER1=""   # must-fix: posix-required files failing dash -n  (file\treason)
+TIER3=""   # info: any file failing dash -n
+TIER2=""   # macOS hazards: file:line:pattern\tdescription
+
+# macOS hazard patterns: "ERE<TAB>description". Heuristic (warn-only).
+HAZARDS='declare[[:space:]]+-A	bash-4 associative array (breaks macOS bash 3.2)
+\$\{[A-Za-z_][A-Za-z0-9_]*(\^\^|,,|\^|,)[}/:]	bash-4 case-conversion ${v,,}/${v^^} (breaks macOS bash 3.2)
+\b(mapfile|readarray)\b	bash-4 mapfile/readarray (breaks macOS bash 3.2)
+\|&([^]]|$)	bash-4 |& pipe (breaks macOS bash 3.2)
+\bsed[[:space:]]+-i\b	sed -i: GNU vs BSD differ (BSD needs `-i ""`); use a tmpfile+mv
+\bstat[[:space:]]+-c\b	stat -c is GNU; BSD uses `stat -f`
+\breadlink[[:space:]]+-f\b	readlink -f is GNU; old BSD lacks it; ship a realpath shim
+\bgrep[[:space:]]+-[A-Za-z]*P\b	grep -P (PCRE) is GNU-only; use -E (ERE)
+\bbase64[[:space:]]+-w\b	base64 -w is GNU-only; use `base64 | tr -d "\\n"`
+\bdate[[:space:]]+-d\b	date -d is GNU; BSD uses `date -r`/`-v`
+\bwhich\b	use `command -v`, not `which` (not guaranteed installed; BSD/GNU differ)
+\bread[[:space:]]+-[A-Za-z]*A\b	zsh-only `read -A`; bash errors. Use `read -a`/mapfile'
+
+scan_count=0
+for f in $CANDIDATES; do
+  is_excluded "$f" && continue
+  scan_count=$((scan_count + 1))
+
+  # --- dash -n (skip zsh files) ---
+  if ! is_zsh "$f"; then
+    if command -v dash >/dev/null 2>&1; then
+      err=$(dash -n "$f" 2>&1)
+      if [ -n "$err" ]; then
+        reason=$(echo "$err" | head -1 | sed "s#^$f: *##")
+        TIER3="${TIER3}${f}	${reason}
+"
+        if is_posix_required "$f"; then
+          TIER1="${TIER1}${f}	${reason}
+"
+        fi
+      fi
+    fi
+  fi
+
+  # --- macOS hazard heuristics (skip zsh files; read -A check also skips .zshrc handled above) ---
+  is_zsh "$f" && continue
+  while IFS=$(printf '\t') read -r pat desc; do
+    [ -n "$pat" ] || continue
+    # Suppress the stat -c hazard when the file already has a BSD `stat -f`
+    # probe+fallback — the documented portable idiom (spec §4).
+    case "$desc" in
+      *"stat -c"*) grep -q 'stat -f' "$f" && continue ;;
+    esac
+    # Drop comment-only matches (line whose first non-space char is #).
+    hits=$(grep -nE "$pat" "$f" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' || true)
+    if [ -n "$hits" ]; then
+      while IFS= read -r h; do
+        [ -n "$h" ] || continue
+        TIER2="${TIER2}${f}:${h%%:*}	${desc}
+"
+      done <<EOF
+$hits
+EOF
+    fi
+  done <<EOF
+$HAZARDS
+EOF
+done
+
+# ---------------------------------------------------------------------------
+# 3. Report.
+# ---------------------------------------------------------------------------
+n1=$(printf '%s' "$TIER1" | grep -c . || true)
+n2=$(printf '%s' "$TIER2" | grep -c . || true)
+n3=$(printf '%s' "$TIER3" | grep -c . || true)
+
+if [ "$MD" -eq 1 ]; then
+  printf '## Shell portability scan\n\n'
+  printf '_Generated by `opt/scripts/system/shell-portability-scan.sh`. Targets: Raspberry Pi / WSL (dash `/bin/sh`), macOS (BSD coreutils + bash 3.2), Linux._\n\n'
+  printf 'Scanned **%s** shell files.\n\n' "$scan_count"
+  printf '### Tier 1 — MUST FIX (breaks POSIX `/bin/sh`; the login-loop class) — %s\n\n' "$n1"
+  if [ "$n1" -eq 0 ]; then printf '_None — all POSIX-required files pass `dash -n`._\n\n'; else
+    printf '| File | `dash -n` error |\n|---|---|\n'
+    printf '%s' "$TIER1" | while IFS=$(printf '\t') read -r f r; do [ -n "$f" ] && printf '| `%s` | %s |\n' "$f" "$r"; done
+    printf '\n'
+  fi
+  printf '### Tier 2 — macOS hazards (BSD coreutils / bash 3.2) — %s\n\n' "$n2"
+  if [ "$n2" -eq 0 ]; then printf '_None detected._\n\n'; else
+    printf '| File:line | Hazard |\n|---|---|\n'
+    printf '%s' "$TIER2" | while IFS=$(printf '\t') read -r fl d; do [ -n "$fl" ] && printf '| `%s` | %s |\n' "$fl" "$d"; done
+    printf '\n'
+  fi
+  printf '### Tier 3 — informational: all files not POSIX-clean (`dash -n`) — %s\n\n' "$n3"
+  printf '<details><summary>Expand (%s files — bash scripts are allowed to use bashisms)</summary>\n\n' "$n3"
+  if [ "$n3" -eq 0 ]; then printf '_None._\n'; else
+    printf '%s' "$TIER3" | while IFS=$(printf '\t') read -r f r; do [ -n "$f" ] && printf -- '- `%s` — %s\n' "$f" "$r"; done
+  fi
+  printf '\n</details>\n'
+else
+  echo "==> shell-portability-scan  (scanned $scan_count files)"
+  echo
+  echo "TIER 1 — MUST FIX (POSIX /bin/sh breakage; login-loop class): $n1"
+  if [ "$n1" -gt 0 ]; then printf '%s' "$TIER1" | while IFS=$(printf '\t') read -r f r; do [ -n "$f" ] && echo "  ✗ $f — $r"; done; fi
+  echo
+  echo "TIER 2 — macOS hazards (BSD coreutils / bash 3.2): $n2"
+  if [ "$n2" -gt 0 ]; then printf '%s' "$TIER2" | while IFS=$(printf '\t') read -r fl d; do [ -n "$fl" ] && echo "  ⚠ $fl — $d"; done; fi
+  echo
+  echo "TIER 3 — informational (all non-POSIX-clean files): $n3 (run with --md for the full list)"
+  echo
+  if [ "$n1" -gt 0 ]; then
+    echo "::warning::$n1 POSIX-required shell file(s) fail 'dash -n' — see docs/mbo/specs/shell-portability.md"
+  fi
+fi
+
+# WARN-ONLY unless --strict explicitly asks Tier 1 to gate.
+if [ "$STRICT" -eq 1 ] && [ "$n1" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/opt/scripts/system/sync-plugins.sh
+++ b/opt/scripts/system/sync-plugins.sh
@@ -10,8 +10,10 @@
 set -u
 
 # Resolve the real repo root even when invoked via the ~/opt symlink.
-SCRIPT_PATH="$(readlink -f "$0")"
-BASE_DIR="$(cd "$(dirname "$SCRIPT_PATH")/../../.." && pwd)"
+# Portable replacement for `readlink -f "$0"` (GNU-only; absent on macOS/BSD):
+# `cd ... && pwd -P` resolves symlinks to the physical script dir.
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd -P)"
+BASE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
 MANIFEST="${BASE_DIR}/ai/plugins.yaml"
 
 DRY_RUN=0

--- a/opt/scripts/system/sync-skills.sh
+++ b/opt/scripts/system/sync-skills.sh
@@ -20,6 +20,7 @@ show_help() {
     echo "Usage: sync-skills [FLAGS]"
     echo ""
     echo "Synchronizes agent skills from the dotfiles repository into both"
+    # shellcheck disable=SC2088 # literal tilde paths shown in help text, not meant to expand
     echo "~/.agents/skills (Gemini CLI) and ~/.claude/skills (Claude Code)."
     echo ""
     echo "Flags:"

--- a/opt/scripts/system/sync-skills.sh
+++ b/opt/scripts/system/sync-skills.sh
@@ -4,9 +4,10 @@
 set -e
 
 # Determine the root of the dotfiles repository
-# Use readlink -f to handle symlinks (like ~/opt) and find the physical repo root
-SCRIPT_PATH="$(readlink -f "$0")"
-BASE_DIR="$(cd "$(dirname "$SCRIPT_PATH")/../../.." && pwd)"
+# Portable replacement for `readlink -f "$0"` (GNU-only; absent on macOS/BSD):
+# `cd ... && pwd -P` resolves symlinks (like ~/opt) to the physical script dir.
+SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd -P)"
+BASE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
 
 # Destinations that receive the synced skills. Gemini CLI reads ~/.agents/skills;
 # Claude Code reads ~/.claude/skills. The SKILL.md format is shared between both

--- a/opt/scripts/system/terminal-theme.sh
+++ b/opt/scripts/system/terminal-theme.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # for chrome in console
 # prefs.js
-if [[ GEN_PREFS = "true" ]] ; then
+if [[ "${GEN_PREFS:-}" = "true" ]] ; then
 cat > prefs.js << PREFS_JS
 // Disable bold. 
 term_.prefs_.set('enable-bold', false) 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Unified testing entry point for dotfiles
+# Requires bash 4+ (associative arrays below). `env bash` selects Homebrew bash 5
+# on macOS (install.sh provides it); /bin/bash there is the unsupported 3.2 relic.
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -38,7 +40,7 @@ NC='\033[0m' # No Color
 # COVERAGE_ENFORCE=1 in the CI job) so the gate becomes strict. Real test
 # failures (a failing `go test`) are ALWAYS hard regardless of this flag —
 # only the threshold comparison is softened.
-declare -A COVERAGE_MIN=(
+declare -A COVERAGE_MIN=( # portability-ok: bash 4+ (assoc array); env bash -> Homebrew bash 5 on macOS
     [gss]=70
     [tmux-mgr]=60
     [gsl]=60
@@ -154,7 +156,7 @@ function run_integration_tests() {
     docker run --privileged --rm "$IMAGE_NAME" bash -c "source ~/.profile && gss version && tmux-mgr version && wol version"
 
     log "Verifying Script PATH Discovery..."
-    docker run --privileged --rm "$IMAGE_NAME" bash -c "source ~/.profile && which git_add.sh && which gemini_install.sh && which claude_install.sh"
+    docker run --privileged --rm "$IMAGE_NAME" bash -c "source ~/.profile && command -v git_add.sh && command -v gemini_install.sh && command -v claude_install.sh"
 
     log "Verifying GSS Technical Guardrail..."
     # gss push must refuse without a HEAD-bound approval token. v1.0 reworded

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 # Unified testing entry point for dotfiles
-# Requires bash 4+ (associative arrays below). `env bash` selects Homebrew bash 5
-# on macOS (install.sh provides it); /bin/bash there is the unsupported 3.2 relic.
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -40,12 +38,17 @@ NC='\033[0m' # No Color
 # COVERAGE_ENFORCE=1 in the CI job) so the gate becomes strict. Real test
 # failures (a failing `go test`) are ALWAYS hard regardless of this flag —
 # only the threshold comparison is softened.
-declare -A COVERAGE_MIN=( # portability-ok: bash 4+ (assoc array); env bash -> Homebrew bash 5 on macOS
-    [gss]=70
-    [tmux-mgr]=60
-    [gsl]=60
-    [wol]=60
-)
+# Per-module minimum coverage % — a function (not a bash-4 associative array) so
+# it runs under macOS system bash 3.2. Empty output = no threshold configured.
+coverage_min() {
+    case "$1" in
+        gss)      echo 70 ;;
+        tmux-mgr) echo 60 ;;
+        gsl)      echo 60 ;;
+        wol)      echo 60 ;;
+        *)        echo "" ;;
+    esac
+}
 
 # 1 = a module under its COVERAGE_MIN floor fails the build; 0 = warn only.
 # Default warn-only until the backfill PRs (#50/#51) clear the gap.
@@ -105,8 +108,8 @@ function run_unit_tests() {
         # is mature enough to gate on.
         local pct
         pct=$(coverage_total_pct "$mod_path" "$REPO_ROOT/coverage/$mod.out")
-        if [ -n "${COVERAGE_MIN[$mod]+set}" ]; then
-            local min="${COVERAGE_MIN[$mod]}"
+        local min; min="$(coverage_min "$mod")"
+        if [ -n "$min" ]; then
             if [ "$pct" -lt "$min" ]; then
                 if [ "$COVERAGE_ENFORCE" = "1" ]; then
                     echo -e "${RED}FAIL${NC}: coverage for ${mod} is ${pct}% (minimum: ${min}%)"
@@ -118,7 +121,7 @@ function run_unit_tests() {
                 echo -e "${GREEN}OK${NC}: coverage for ${mod} is ${pct}% (minimum: ${min}%)"
             fi
         else
-            echo -e "${YELLOW}WARN${NC}: no coverage threshold configured for module '${mod}' (current: ${pct}%) — add it to COVERAGE_MIN in scripts/test.sh"
+            echo -e "${YELLOW}WARN${NC}: no coverage threshold configured for module '${mod}' (current: ${pct}%) — add it to coverage_min() in scripts/test.sh"
         fi
     done
 

--- a/sdk/tmux-mgr/build.sh
+++ b/sdk/tmux-mgr/build.sh
@@ -2,7 +2,6 @@
 set -e
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$DIR/../../" && pwd)"
 BIN_DIR="${HOME}/opt/bin"
 SKILL_INSTALL_DIR="${HOME}/.agents/skills"
 

--- a/src/ssh-key-sync/ssh-key-sync.sh
+++ b/src/ssh-key-sync/ssh-key-sync.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
-SYNC=true; LIST=false; DELETE=false; PRUNE=false; KEY_NAMES=()
+SYNC=true; LIST=false; PRUNE=false; KEY_NAMES=()
 while [[ $# -gt 0 ]]; do
     case $1 in
         --no-sync) SYNC=false; shift ;;
         --list) LIST=true; shift ;;
-        --delete) DELETE=true; shift ;;
+        --delete) shift ;;
         --prune) PRUNE=true; shift ;;
         *) KEY_NAMES+=("$1"); shift ;;
     esac
@@ -13,7 +13,7 @@ done
 if [ "$PRUNE" = true ]; then
     HOSTS=""
     if [ -f "$HOME/.ssh/config" ]; then
-        HOSTS=$(grep "^Host " "$HOME/.ssh/config" | awk "{print \$2}" | grep -v "*" || true)
+        HOSTS=$(grep "^Host " "$HOME/.ssh/config" | awk "{print \$2}" | grep -vF "*" || true)
     fi
     MANAGED=""
     for k in "$HOME/.ssh"/*.pub; do
@@ -30,7 +30,7 @@ fi
 if [ "$LIST" = true ]; then
     HOSTS=""
     if [ -f "$HOME/.ssh/config" ]; then
-        HOSTS=$(grep "^Host " "$HOME/.ssh/config" | awk "{print \$2}" | grep -v "*" || true)
+        HOSTS=$(grep "^Host " "$HOME/.ssh/config" | awk "{print \$2}" | grep -vF "*" || true)
     fi
     for k in "$HOME/.ssh"/*.pub; do
         if [[ -f "$k" && ! "$k" == *authorized_keys* ]]; then
@@ -57,7 +57,7 @@ for K in "${KEY_NAMES[@]}"; do
     if [ "$SYNC" = true ]; then
         HOSTS=""
         if [ -f "$HOME/.ssh/config" ]; then
-            HOSTS=$(grep "^Host " "$HOME/.ssh/config" | awk "{print \$2}" | grep -v "*" || true)
+            HOSTS=$(grep "^Host " "$HOME/.ssh/config" | awk "{print \$2}" | grep -vF "*" || true)
         fi
         for h in $HOSTS; do
             scp "$P" "$P.pub" "$h:~/.ssh/" 2>/dev/null && ssh -n "$h" "grep -qF \"$PK\" ~/.ssh/authorized_keys || echo \"$PK\" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys" 2>/dev/null || true


### PR DESCRIPTION
Guard bash/zsh-only includes in .profile; add warn-only dash/cross-OS portability scan to CI

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **posix-shell-portability**.

- **#150 — edward-raigosa/impl (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
