### PR TITLE
gss-auto-checkpoint-push: fix

### DIFF
--- a/sdk/gss/internal/feature/auto.go
+++ b/sdk/gss/internal/feature/auto.go
@@ -37,8 +37,10 @@ type AutoResult struct {
 //     untracked files in the commit body;
 //   - never prompts: on detached HEAD / rebase conflict it skips, writes a
 //     diagnostic to WORKER.md, and returns a non-zero (error) result;
-//   - only ever touches DRAFT PRs (a ready PR gets a body refresh, no new
-//     commits pushed);
+//   - only ever touches DRAFT PRs: a ready PR gets a body refresh but new
+//     commits are never pushed — and because reaching that state means work
+//     is pending, it is reported as a SKIP (non-zero + WORKER.md
+//     diagnostic), never as silent success;
 //   - --dry-run prints the plan without executing.
 func (s *Service) AutoCheckpoint(ctx context.Context, opts AutoOpts) (AutoResult, error) {
 	ref, err := identity.ParseWorkerRef(opts.WorkerRef)
@@ -111,13 +113,19 @@ func (s *Service) AutoCheckpoint(ctx context.Context, opts AutoOpts) (AutoResult
 	}
 
 	// Only ever touch draft PRs: a ready PR gets a body refresh, never new
-	// pushed commits (avoids surprising reviewers).
+	// pushed commits (avoids surprising reviewers). Reaching here means there
+	// IS something to push (the clean+synced case no-opped above), so this is
+	// a prompt-condition and must surface as a SKIP — not silent success. The
+	// pre-fix behaviour ("updated the draft PR", exit 0, branch still ahead of
+	// origin) was the worst failure shape for an unattended hook.
 	if w.PRURL != "" {
 		if pr, err := s.GH.PRView(ctx, prNumber(w.PRURL)); err == nil && !pr.IsDraft {
 			if err := s.GH.PREdit(ctx, prNumber(w.PRURL), gh.PREditOpts{Body: renderPRBody(reg.Features[fi], ref)}); err != nil {
 				return res, err
 			}
-			return res, nil
+			skipped, err := s.autoSkip(w, "PR is ready-for-review; auto-checkpoint is draft-only and did NOT push local commits (body refreshed). Run 'gss feature checkpoint' to push, or convert the PR back to draft.")
+			skipped.Committed = res.Committed // a WIP commit may have landed above; it stays local
+			return skipped, err
 		}
 	}
 

--- a/sdk/gss/internal/feature/auto_test.go
+++ b/sdk/gss/internal/feature/auto_test.go
@@ -162,19 +162,32 @@ func TestAuto_RebaseConflictSkips(t *testing.T) {
 	}
 }
 
-func TestAuto_ReadyPRBodyOnlyNoNewCommits(t *testing.T) {
+func TestAuto_ReadyPRWithPendingWorkSkipsLoudly(t *testing.T) {
+	// The silent-success shape this guards against (observed live on PR #153):
+	// a ready-for-review PR + local commits ahead of origin → the pre-fix code
+	// refreshed the body, pushed NOTHING, printed "updated the draft PR", and
+	// exited 0. A ready PR with pending work is a prompt-condition: body
+	// refresh is fine, but the result must be a SKIP (non-zero) with a
+	// diagnostic, never success.
 	ghc := ghfake.NewClient()
 	ghc.SeedPR(gh.PR{Number: 9, Head: "feature/auth/erai/api", State: "OPEN", IsDraft: false, URL: "https://github.com/o/r/pull/9"})
-	// dirty → commit, then ready-PR → body edit only (no fetch/rebase/push).
-	svc, gitr, _ := autoService(t, "https://github.com/o/r/pull/9",
+	// dirty → WIP commit, then ready-PR → body edit + loud skip (no fetch/rebase/push).
+	svc, gitr, wt := autoService(t, "https://github.com/o/r/pull/9",
 		[]gitfake.Response{resp("feature/auth/erai/api"), resp(" M a.go\n"), resp("aaa"), resp("bbb"), resp(""), resp("")}, ghc)
 
-	if _, err := svc.AutoCheckpoint(context.Background(), feature.AutoOpts{WorkerRef: "auth/erai/api"}); err != nil {
-		t.Fatalf("AutoCheckpoint: %v", err)
+	res, err := svc.AutoCheckpoint(context.Background(), feature.AutoOpts{WorkerRef: "auth/erai/api"})
+	if err == nil {
+		t.Fatal("ready PR with pending work: want non-zero (skip) result, got success")
 	}
-	// A ready PR must NOT get new pushed commits → Checkpoint never runs → no fetch.
-	if gitCallsHave(gitr, "fetch") {
-		t.Error("ready PR must not push new commits (no fetch/rebase via Checkpoint)")
+	if !strings.Contains(res.Skipped, "ready-for-review") || !strings.Contains(res.Skipped, "NOT push") {
+		t.Errorf("Skipped = %q; want ready-for-review draft-only reason", res.Skipped)
+	}
+	if !res.Committed {
+		t.Error("the WIP commit made before the ready-PR check should be reported")
+	}
+	// A ready PR must NOT get new pushed commits → Checkpoint never runs → no fetch/push.
+	if gitCallsHave(gitr, "fetch") || gitCallsHave(gitr, "push") {
+		t.Error("ready PR must not push new commits (no fetch/rebase/push via Checkpoint)")
 	}
 	edited := false
 	for _, c := range ghc.Calls() {
@@ -183,6 +196,11 @@ func TestAuto_ReadyPRBodyOnlyNoNewCommits(t *testing.T) {
 		}
 	}
 	if !edited {
-		t.Error("ready PR should get a body refresh (PREdit)")
+		t.Error("ready PR should still get a body refresh (PREdit)")
+	}
+	// The skip diagnostic must land in the worker's meta WORKER.md.
+	data, _ := os.ReadFile(feature.WorkerMetaPath(wt))
+	if !strings.Contains(string(data), "ready-for-review") {
+		t.Errorf("WORKER.md (meta path) missing ready-PR diagnostic:\n%s", data)
 	}
 }


### PR DESCRIPTION
Root-cause + failing test + fix for the auto sync verb skipping the push while reporting success

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **gss-auto-checkpoint-push**.

- **(no PR yet) — edward-raigosa/fix (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
