### PR TITLE
feat(profiles): source ~/.bashrc.local for machine-local overrides

### DIFF
--- a/opt/profiles/.bashrc
+++ b/opt/profiles/.bashrc
@@ -275,3 +275,9 @@ source <(openclaw completion --shell bash)
 
 # Claude Code CLI helpers: claude (wrapper) and claude-config (yolo/remote on/off)
 [ -f "${HOME}/.config/claude/aliases.sh" ] && . "${HOME}/.config/claude/aliases.sh"
+
+# Machine-local overrides — NOT committed to dotfiles. External tools
+# (e.g. clawdad's OpenClaw shell integration) append here instead of
+# editing this managed file. Mirrors the .zshrc.local hook in .zshrc.
+# Keep this LAST so local settings win.
+[ -f "$HOME/.bashrc.local" ] && source "$HOME/.bashrc.local"


### PR DESCRIPTION
## What

Add the missing machine-local override hook to `.bashrc`: source `~/.bashrc.local` last, when present. `.zshrc` has had the equivalent `~/.zshrc.local` hook for years; bash never got it.

## Why

External tools that need shell integration had no sanctioned extension point for bash. clawdad's OpenClaw installer appended directly to `~/.bashrc` — which is a symlink into this repo on managed machines — dirtying the dotfiles working tree on every install. With this hook, such tools write to `~/.bashrc.local` (an uncommitted machine-local artifact) and the managed profile stays pristine.

Pairs with a clawdad-side change (playground repo) that detects git-managed rc files, writes its integration to the `.local` companion, and migrates previously injected lines back out of the managed file.

## Testing

- Fresh interactive bash resolves `openclaw` through the chain `.bashrc` → `.bashrc.local` → `.openclaw.sh`
- Working tree clean after clawdad's `make shell` re-run (integration lands in the artifact, not the repo)
- Hook is a no-op when `~/.bashrc.local` doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTXac6PfzgA5Mj9YmaZGti