### PR TITLE
fix(gemini-teardown): sudo-escalate npm uninstall on system-wide npm prefix

### DIFF
--- a/opt/scripts/system/gemini_teardown.sh
+++ b/opt/scripts/system/gemini_teardown.sh
@@ -132,7 +132,20 @@ fi
 # --- Cleanup ---------------------------------------------------------------
 if [ "$NPM_HAS_GEMINI" = "1" ]; then
     echo "  Removing @google/gemini-cli (npm)..."
-    npm uninstall -g @google/gemini-cli || true
+    # A system-wide npm prefix (/usr, /usr/local via apt/system node) makes the
+    # global node_modules root-owned, so an unprivileged uninstall dies with
+    # EACCES; escalate like google-cli-setup.sh does for install.
+    NPM_SUDO=""
+    NPM_ROOT="$(npm root -g 2>/dev/null || true)"
+    if [ -n "$NPM_ROOT" ] && [ -e "$NPM_ROOT" ] && [ ! -w "$NPM_ROOT" ]; then
+        if command -v sudo >/dev/null 2>&1; then
+            NPM_SUDO="sudo"
+            echo "  (global npm prefix is system-wide ($NPM_ROOT); using sudo)"
+        else
+            echo "  NOTE: $NPM_ROOT is not writable and sudo is unavailable; run 'npm uninstall -g @google/gemini-cli' as root."
+        fi
+    fi
+    $NPM_SUDO npm uninstall -g @google/gemini-cli || true
 fi
 # A gemini binary that survives the npm uninstall (or was never npm-managed)
 # only gets removed from user-owned locations; system installs are reported.

--- a/opt/scripts/system/gemini_teardown_test.sh
+++ b/opt/scripts/system/gemini_teardown_test.sh
@@ -107,7 +107,60 @@ OUT3b="$(run_teardown "$H3" </dev/null)"
 assert_contains "$OUT3b" "leftovers found" "--reset re-enables the ask"
 rm -rf "$H3"
 
-# === 6. Interactive 'k' answer persists the marker ===
+# === 6. System-wide npm prefix (EACCES case) -> escalates via sudo ===
+H5="$(make_sandbox)"
+# Non-writable global node_modules, like /usr/lib/node_modules on apt-node hosts.
+mkdir -p "$H5/npmroot/@google/gemini-cli"
+chmod 555 "$H5/npmroot"
+cat > "$H5/bin/npm" <<NPM
+#!/usr/bin/env bash
+case "\$1 \$2" in
+    "ls -g") exit 0 ;;
+    "root -g") echo "$H5/npmroot"; exit 0 ;;
+    "uninstall -g") echo "NPM_UNINSTALL_CALLED \$3" >> "$H5/npm.log"; rm -f "$H5/bin/gemini"; exit 0 ;;
+esac
+exit 0
+NPM
+chmod +x "$H5/bin/npm"
+# Fake sudo: logs the escalation, then runs the command (finds the fake npm).
+cat > "$H5/bin/sudo" <<SUDO
+#!/usr/bin/env bash
+echo "SUDO_CALLED \$*" >> "$H5/sudo.log"
+exec "\$@"
+SUDO
+chmod +x "$H5/bin/sudo"
+OUT5="$(run_teardown "$H5" --yes)"
+assert_in_subshell "system prefix: npm uninstall escalated via sudo" "grep -q 'SUDO_CALLED npm uninstall -g @google/gemini-cli' '$H5/sudo.log'"
+assert_in_subshell "system prefix: uninstall reached npm" "grep -q 'NPM_UNINSTALL_CALLED @google/gemini-cli' '$H5/npm.log'"
+assert_contains "$OUT5" "using sudo" "system prefix: escalation is announced"
+chmod 755 "$H5/npmroot"
+rm -rf "$H5"
+
+# User-writable global node_modules -> no escalation.
+H6="$(make_sandbox)"
+mkdir -p "$H6/npmroot/@google/gemini-cli"
+cat > "$H6/bin/npm" <<NPM
+#!/usr/bin/env bash
+case "\$1 \$2" in
+    "ls -g") exit 0 ;;
+    "root -g") echo "$H6/npmroot"; exit 0 ;;
+    "uninstall -g") echo "NPM_UNINSTALL_CALLED \$3" >> "$H6/npm.log"; rm -f "$H6/bin/gemini"; exit 0 ;;
+esac
+exit 0
+NPM
+chmod +x "$H6/bin/npm"
+cat > "$H6/bin/sudo" <<SUDO
+#!/usr/bin/env bash
+echo "SUDO_CALLED \$*" >> "$H6/sudo.log"
+exec "\$@"
+SUDO
+chmod +x "$H6/bin/sudo"
+run_teardown "$H6" --yes >/dev/null
+assert_in_subshell "writable prefix: no sudo escalation" "[ ! -e '$H6/sudo.log' ]"
+assert_in_subshell "writable prefix: uninstall still runs" "grep -q 'NPM_UNINSTALL_CALLED @google/gemini-cli' '$H6/npm.log'"
+rm -rf "$H6"
+
+# === 7. Interactive 'k' answer persists the marker ===
 H4="$(make_sandbox)"
 # Feed 'k' on stdin; the script only prompts on a TTY, so emulate via script(1)
 # when available, else fall back to asserting the --keep path (covered above).


### PR DESCRIPTION
## What
`gemini_teardown.sh` now checks whether the global `npm root -g` is user-writable before uninstalling `@google/gemini-cli`; if it isn't (e.g. `/usr/lib/node_modules` from an apt/system Node), it escalates via `sudo` — announcing it — mirroring the existing logic in `google-cli-setup.sh`. If sudo is unavailable it prints the exact command to run as root instead of failing cryptically.

## Why
On hosts with a system-wide npm prefix (`/usr`), the teardown's bare `npm uninstall -g` died with `EACCES: permission denied, rename '/usr/lib/node_modules/@google/gemini-cli' ...` during `install.sh`, leaving the retired Gemini CLI half-cleaned. The very next install step already detects this case and uses sudo; the teardown never got the same treatment.

## Impact
- Consent semantics unchanged: prompt / `--yes` / `--keep` / non-TTY behavior identical; `~/.gemini` still never touched.
- User-writable npm prefixes (nvm, `~/.npm-global`) take the exact same path as before — no sudo.

## Testing
- Extended `gemini_teardown_test.sh` (test-first): a non-writable fake npm root must trigger the sudo path (logging fake `sudo`), and a writable root must not escalate. 25/25 PASS.
- `make lint-portability`: 0 Tier 1/2 findings; `shellcheck` clean on both files.
- Verified on the failing host: re-ran the fixed teardown — `@google/gemini-cli@0.38.2` removed via sudo, `gemini` binary gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJQ2L5z6GDmDgcvievPFxA