### PR TITLE
gsl-ultra: iface

### DIFF
--- a/sdk/gsl/cmd/columns.go
+++ b/sdk/gsl/cmd/columns.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
+)
+
+// columns.go — the FROZEN width-resolution contract (gsl-ultra, plan §3).
+//
+// # The bug this exists to fix
+//
+// The shipped resolution order is:
+//
+//	$COLUMNS  →  ioctl(stdout)  →  80
+//
+// Both of the first two branches are DEAD in production:
+//
+//   - $COLUMNS is a SHELL variable. It is not exported to child processes.
+//     Verified: `env | grep -c '^COLUMNS='` → 0. gsl never sees it.
+//   - Claude Code invokes the status-line command with stdout PIPED, so the
+//     ioctl on stdout fails.
+//
+// Claude sends no terminal_width, and `agy status` sends no payload at all.
+// So EVERY real render falls through to the hardcoded 80 — on a 200-column
+// terminal, gsl compacts a line that had 120 columns of room to spare.
+//
+// # The fix
+//
+// A single pure, injectable resolver with an explicit precedence, which also
+// reports WHICH source won so the choice is testable and loggable.
+//
+// The load-bearing insight is the STDERR probe: Claude pipes stdout but
+// routinely leaves stderr attached to the tty. When the payload omits a width,
+// ioctl(stderr) is a free, accurate source of the REAL terminal width. Nothing
+// in the shipped code looks there.
+
+// fallbackColumns is the last resort when no source knows the width.
+//
+// 120, not 80. 80 is a teletype default that under-serves every modern
+// terminal; when we are guessing, guess generously — an over-wide guess is
+// corrected by Fit's truncation (which is now a hard guarantee), whereas an
+// under-wide guess silently discards information the user had room for.
+const fallbackColumns = 120
+
+// widthSource names the origin of the resolved column count. Returned alongside
+// the width so tests can assert WHICH branch fired (not merely that the number
+// looks plausible) and so the choice can be logged at Debug.
+const (
+	sourcePayload = "payload"       // payload.terminal_width (the host told us)
+	sourceStdout  = "ioctl:stdout"  // stdout is a tty
+	sourceStderr  = "ioctl:stderr"  // stdout piped, stderr still on the tty
+	sourceColumns = "env:COLUMNS"   // exported COLUMNS (rare; honoured if present)
+	sourceDefault = "default"       // nothing knew; fallbackColumns
+)
+
+// resolveColumns determines the terminal width and the source that supplied it.
+//
+// PURE and fully injected: env and the two tty probes are parameters, so all
+// four host scenarios (Claude piped w/ payload, Claude piped w/o payload, agy,
+// a plain shell tty) are a table test rather than a guess.
+//
+// Precedence:
+//
+//  1. payload.terminal_width — the host explicitly told us. Most authoritative.
+//  2. ioctl(stdout)          — stdout is a tty (plain shell usage).
+//  3. ioctl(stderr)          — stdout is piped but stderr is a tty (CLAUDE).
+//  4. $COLUMNS               — only if actually exported. Usually absent.
+//  5. fallbackColumns        — 120.
+//
+// Note the inversion versus the shipped code: $COLUMNS now ranks BELOW the
+// host-supplied width. Previously an exported COLUMNS would override the
+// terminal width the host itself reported, which is backwards.
+//
+// ttyStdout and ttyStderr each return (cols, ok); ok=false means "not a tty" or
+// "the ioctl failed". Either may be nil (treated as always-false).
+func resolveColumns(
+	p payload.Payload,
+	env func(string) string,
+	ttyStdout func() (int, bool),
+	ttyStderr func() (int, bool),
+) (cols int, source string) {
+	// Implemented in the `width` leaf.
+	return fallbackColumns, sourceDefault
+}

--- a/sdk/gsl/internal/mcp/status.go
+++ b/sdk/gsl/internal/mcp/status.go
@@ -1,0 +1,207 @@
+package mcp
+
+import (
+	"context"
+	"time"
+)
+
+// status.go — the FROZEN MCP status contract (gsl-ultra, plan §3).
+//
+// Everything downstream (internal/render, internal/tui, cmd) compiles against
+// the types and signatures in this file. The IMPLEMENTATIONS land in the `mcp`
+// leaf; this file exists so the dependent leaves can be built in parallel
+// against a contract that will not move under them (Interface-First).
+//
+// # Why this replaces ActiveCount/ConfiguredCount
+//
+// The shipped design collapsed MCP to a single integer via ActiveCount, which
+// was unconditionally 0 in production for two independent reasons:
+//
+//  1. parseConnectedCount matched the literal "✓ Connected" (U+2713 CHECK
+//     MARK), but `claude mcp list` emits U+2714 HEAVY CHECK MARK ("✔"). A
+//     codepoint census of real output: 6× U+2714, 5× U+2718, ZERO U+2713.
+//  2. The probe ran inline under a 500 ms deadline against a command measured
+//     at 3.45–4.10 s (it dials every server), so it was SIGKILLed every render
+//     and the cache was never even seeded.
+//
+// The contract below fixes the CLASS of bug, not just the instance:
+//
+//   - ParseStatus keys on STATUS WORDS, never on a decorated sigil, so a glyph
+//     change in a future CLI release cannot silently zero the count.
+//   - Get is CACHE-ONLY and must never spawn a subprocess, so a render can
+//     never stall on a multi-second probe.
+//   - Refresh is the only thing that shells out, and it runs OUT OF BAND.
+type State int
+
+const (
+	// StateUnknown is the zero value: the server's state could not be
+	// determined (an unparseable line, or a server we know of from config but
+	// have never probed).
+	StateUnknown State = iota
+	// StateConnected — the server responded to a health check.
+	StateConnected
+	// StateFailed — the server is configured but did not connect.
+	StateFailed
+	// StateNeedsAuth — the server requires authentication the user has not
+	// completed. Distinct from Failed: it is actionable by the user.
+	StateNeedsAuth
+	// StateConnecting — the health check was still in flight.
+	StateConnecting
+)
+
+// String renders the state as the lowercase keyword the CLI itself uses.
+func (s State) String() string {
+	switch s {
+	case StateConnected:
+		return "connected"
+	case StateFailed:
+		return "failed"
+	case StateNeedsAuth:
+		return "needs authentication"
+	case StateConnecting:
+		return "connecting"
+	default:
+		return "unknown"
+	}
+}
+
+// Scope is where a server definition came from. Precedence for de-duplication
+// is Local > Project > User > Plugin: a server defined in more than one scope
+// is counted ONCE, at its highest-precedence scope.
+//
+// The shipped ConfiguredCount SUMMED the scopes with no de-duplication (its own
+// doc comment conceded the result was "an upper bound"), so a server present
+// both globally and in .mcp.json was counted twice.
+type Scope int
+
+const (
+	ScopeUnknown Scope = iota
+	ScopeLocal         // <cwd>/.mcp.json
+	ScopeProject       // ~/.claude.json → .projects[cwd].mcpServers
+	ScopeUser          // ~/.claude.json → .mcpServers
+	ScopePlugin        // ~/.claude/plugins/cache/**/.mcp.json (gated by enabledPlugins)
+)
+
+// ServerStatus is one MCP server's identity and health.
+type ServerStatus struct {
+	Name  string
+	State State
+	Scope Scope
+}
+
+// Status is the whole MCP picture for one working directory.
+//
+// Connected/Failed/NeedsAuth are derived from a probe (Refresh); Configured is
+// the DE-DUPLICATED denominator derived from the config files. They can
+// legitimately disagree — a server can be configured but never probed — which
+// is why Configured is not simply len(Servers).
+type Status struct {
+	Connected  int
+	Failed     int
+	NeedsAuth  int
+	Configured int
+
+	Servers []ServerStatus
+
+	// FetchedAt is when the underlying probe ran. Zero when the status was
+	// synthesized from config alone (never probed).
+	FetchedAt time.Time
+	// Stale is true when this Status was served from an expired cache entry.
+	// Callers SHOULD still render it — a stale count beats no count — and MAY
+	// signal staleness in the UI. Renderers must not block to refresh it.
+	Stale bool
+}
+
+// Empty reports whether there is nothing worth rendering: no servers
+// configured and none in any probed state.
+func (s Status) Empty() bool {
+	return s.Configured == 0 && s.Connected == 0 && s.Failed == 0 && s.NeedsAuth == 0
+}
+
+// Options configures Get and Refresh. The zero value uses system defaults.
+type Options struct {
+	// CacheDir overrides the default cache directory
+	// (${XDG_CACHE_HOME:-$HOME/.cache}/gsl/mcp).
+	//
+	// The cache is keyed BY CWD (sha256(cwd)[:16]). The shipped cache used a
+	// single global path (~/.cache/gsl/mcp.json) to hold a cwd-DEPENDENT value,
+	// so a count computed in repo A was served to repo B.
+	CacheDir string
+
+	// TTL overrides how long a cache entry is considered fresh.
+	TTL time.Duration
+
+	// Now, if non-nil, replaces time.Now (tests).
+	Now func() time.Time
+}
+
+// ParseStatus extracts the health picture from `claude mcp list` output.
+//
+// PURE: no I/O, no clock, no environment. Given bytes, it returns a Status.
+//
+// It MUST classify by STATUS KEYWORD, matched case-insensitively against the
+// field after the LAST " - " on each line — "connected", "failed",
+// "needs authentication", "connecting". Decorated sigils (U+2713 ✓, U+2714 ✔,
+// U+2705 ✅, U+2718 ✘, U+2717 ✗) may be used only as a SECONDARY signal, never
+// as the primary discriminator. Matching a sigil is precisely what broke the
+// shipped parser.
+//
+// Lines that are not status lines contribute nothing. Configured is NOT set by
+// ParseStatus (it comes from the config scan) — only Connected/Failed/
+// NeedsAuth/Servers are.
+func ParseStatus(out []byte) Status {
+	// Implemented in the `mcp` leaf.
+	return Status{}
+}
+
+// Get returns the MCP status for cwd from the CACHE ONLY.
+//
+// CONTRACT — this is the load-bearing invariant of the whole design:
+//
+//	Get MUST NEVER spawn a subprocess, and MUST NEVER block on the network.
+//
+// It is called on the render hot path, once per assistant turn. `claude mcp
+// list` takes 3.4–4.1 s because it dials every server; there is no timeout at
+// which running it inline is acceptable.
+//
+// A fresh entry is returned with Stale=false. An EXPIRED entry is still
+// returned, with Stale=true — a slightly-old count is strictly better than no
+// count — and the caller SHOULD trigger an out-of-band Refresh. A cold cache
+// returns a Status carrying only the config-derived Configured count, with
+// Stale=true.
+func Get(ctx context.Context, cwd string, o Options) (Status, error) {
+	// Implemented in the `mcp` leaf.
+	return Status{}, nil
+}
+
+// Refresh runs the probe OUT OF BAND and rewrites the cwd-keyed cache entry.
+//
+// This is the ONLY function in the package that shells out. It is invoked by
+// `gsl mcp refresh` (which the render path forks in a DETACHED process when it
+// observes a stale entry) — never synchronously from a render.
+//
+// Refresh MUST be single-flight (a lockfile in the cache dir): concurrent gsl
+// processes across panes must not stampede N copies of a 4-second probe.
+// Failures MUST be cached NEGATIVELY with exponential backoff, so a broken
+// `claude` binary does not cause a respawn on every keystroke.
+func Refresh(ctx context.Context, r Runner, cwd string, o Options) error {
+	// Implemented in the `mcp` leaf.
+	return nil
+}
+
+// ConfiguredServers returns the DE-DUPLICATED set of servers configured for
+// cwd, resolved across every scope.
+//
+// Rules (plan F6):
+//   - De-duplicate by server NAME; a name in several scopes resolves to its
+//     highest-precedence scope (Local > Project > User > Plugin).
+//   - Include plugin servers from ~/.claude/plugins/cache/**/.mcp.json, gated
+//     by `enabledPlugins` in ~/.claude/settings.json.
+//   - SUBTRACT names listed in `disabledMcpjsonServers`.
+//   - Honour `enableAllProjectMcpServers`.
+//
+// A missing config file contributes nothing and is NOT an error.
+func ConfiguredServers(cwd string) ([]ServerStatus, error) {
+	// Implemented in the `mcp` leaf.
+	return nil, nil
+}

--- a/sdk/gsl/internal/render/render.go
+++ b/sdk/gsl/internal/render/render.go
@@ -58,6 +58,20 @@ type Deps struct {
 	// RegistryPath is the gss registry path for repo.PR.
 	RegistryPath string
 
+	// GitInfo is a PRE-COMPUTED git status, threaded in by the caller.
+	//
+	// cmd/statusline.go currently runs git.Status SERIALLY before Detect, purely
+	// to obtain Branch — and then DirGitSegment runs git.Status again inside
+	// Detect. That is two redundant subprocesses (4 git execs instead of 2), and
+	// the serial call happens INSIDE the shared 1s context, draining the budget
+	// the concurrent segments are about to need. Under slow git (≥250ms/call)
+	// the dirgit segment loses its deadline and vanishes from the line entirely.
+	//
+	// When GitInfo is non-nil, DirGitSegment MUST reuse it instead of shelling
+	// out again. Nil means "not pre-computed; detect it yourself" — which keeps
+	// every existing caller (tests, preview) working unchanged.
+	GitInfo *git.Info
+
 	// Runners (injected seams). Any may be nil; the affected detail is omitted.
 	Git git.Runner
 	GH  gh.Runner

--- a/sdk/gsl/internal/style/color.go
+++ b/sdk/gsl/internal/style/color.go
@@ -1,0 +1,104 @@
+package style
+
+// color.go — the FROZEN colour contract (gsl-ultra, plan §3).
+//
+// # The bug this exists to make impossible
+//
+// Colour is currently resolved in TWO places that disagree:
+//
+//   - paint()          (render/glyphs.go) — when the colour resolves to "",
+//     returns the text UNPAINTED while its neighbours are painted.
+//   - joinPowerline()  (render/glyphs.go) — nests the fg emit inside
+//     `if bg != ""` but emits the chevron UNCONDITIONALLY.
+//
+// So a theme value that resolves to empty — a literal "default", a hex value
+// (unsupported today, silently dropped), or an unknown role key — yields an
+// unpainted block, a white wedge, and a stray trailing triangle.
+//
+// Separately, joinPowerline hardcodes WHITE as the foreground of every filled
+// block regardless of its background. Against the builtin "time": "yellow",
+// that is a contrast ratio of ~1.35:1 — effectively illegible.
+//
+// The fix is structural, not a patch: ONE resolver, consumed by BOTH painters,
+// that ALWAYS returns a concrete (bg, fg) pair. A block and its chevron cannot
+// disagree if they ask the same function.
+
+// RGB is a resolved, concrete 24-bit colour. There is no "empty" RGB — that is
+// the point. Every role resolves to a real colour; the capability ladder
+// decides how it is EMITTED (truecolor / 256 / 16 / not at all), never whether
+// it exists.
+type RGB struct {
+	R, G, B uint8
+}
+
+// Role names a semantic colour slot. Roles are the vocabulary the render layer
+// and the TUI colour editor both speak.
+//
+// Segment roles map to the existing theme keys; STATE roles are new and are
+// what makes the MCP breakdown legible (connected=ok, failed=err,
+// needs-auth=warn).
+type Role string
+
+const (
+	// Segment roles (existing theme keys).
+	RoleDirGit       Role = "dirgit"
+	RoleRepoRoot     Role = "repo_root"
+	RoleRepoWorktree Role = "repo_worktree"
+	RoleAI           Role = "ai"
+	RoleTime         Role = "time"
+
+	// State roles (new — consumed by the MCP breakdown and git-dirty badges).
+	RoleOK    Role = "ok"    // healthy / connected
+	RoleWarn  Role = "warn"  // actionable by the user (needs auth, behind)
+	RoleErr   Role = "err"   // broken (failed to connect, conflicts)
+	RoleMuted Role = "muted" // de-emphasized detail
+)
+
+// ColorMode is the terminal-capability ladder. Resolution is by capability, not
+// by guess: NO_COLOR and TERM=dumb force ModeNever; COLORTERM selects the rung.
+type ColorMode int
+
+const (
+	ModeAuto      ColorMode = iota // detect from the environment
+	ModeNever                      // emit no escapes at all (NO_COLOR, TERM=dumb)
+	Mode16                         // basic ANSI
+	Mode256                        // ANSI 256-colour
+	ModeTruecolor                  // 24-bit
+)
+
+// resolveBlockColors returns the concrete (bg, fg) pair for a role.
+//
+// CONTRACT — the invariant every caller relies on:
+//
+//	It ALWAYS returns a usable pair. There is no failure mode, no empty value,
+//	no "" sentinel. An unknown role, an unparseable value, and a missing key
+//	all resolve to a defined fallback rather than to nothing.
+//
+// Resolution:
+//  1. The user's explicit config for the role ALWAYS wins (bg and/or fg).
+//  2. A value may be a named colour, a decimal ANSI-256 index, or a hex
+//     "#rrggbb" (hex is NEW — today it is silently dropped).
+//  3. When only a bg is known, fg is COMPUTED for contrast: pick whichever of
+//     the palette's light/dark foregrounds yields the higher WCAG contrast
+//     ratio against bg. This is what kills white-on-yellow.
+//
+// Downsampling to the terminal's ColorMode happens at EMIT time, not here —
+// this function always thinks in 24-bit truth.
+func resolveBlockColors(st Style, role Role) (bg, fg RGB) {
+	// Implemented in the `style` leaf.
+	return RGB{}, RGB{}
+}
+
+// ResolveBlockColors is the exported form consumed by the render layer and the
+// TUI. Same contract as resolveBlockColors.
+func ResolveBlockColors(st Style, role Role) (bg, fg RGB) {
+	return resolveBlockColors(st, role)
+}
+
+// ContrastRatio returns the WCAG 2.x contrast ratio between two colours, in
+// [1, 21]. Used both to CHOOSE a contrast-safe foreground and to GATE the
+// builtin palettes in test (every palette × role must clear 4.5:1).
+func ContrastRatio(a, b RGB) float64 {
+	// Implemented in the `style` leaf.
+	return 0
+}


### PR DESCRIPTION
**P0 / `iface` leaf (blocking base of the stack).** Freezes the plan §3 interface contracts so the downstream leaves compile against stable seams — types and signatures only, zero-value bodies, no behaviour:

- `internal/mcp/status.go` *(new)* — `Status`, `ServerStatus`, `State`/`Scope` enums; `ParseStatus` (pure), `Get` (cache-only), `Refresh` (out-of-band probe) signatures
- `internal/style/color.go` *(new)* — `Role`, `resolveBlockColors(st, role) (bg, fg)` signature
- `internal/render/render.go` — `Deps.GitInfo *git.Info` (pre-threaded for the latency leaf)
- `cmd/columns.go` *(new)* — `resolveColumns(payload, env, ttyStdout, ttyStderr) (cols, source)` signature

**Gate (P0 done-when):** `go build ./...` and `go vet ./...` green ✅ — verified 2026-07-26 after rebasing onto `main` (was 24 commits behind; clean rebase, no overlap with main's sdk/gsl changes).

Merging this PR unblocks nothing by itself — it exists so #165/#166/#167 (and the future mcp/style/tui leaves) stay function-disjoint. See plan §3 + §6.1 in #159.

<!-- gss:stack-begin -->
## Stack — gsl-ultra (#158)

- #159 — design (base: `main`) — MBO design/spec/plan docs
- #161 — iface (base: `main`) — frozen §3 interfaces (P0, blocking)
- #165 — width (base: `iface`) ∥ #166 — latency (base: `iface`) ∥ #167 — agy (base: `iface`)
- *(not started)* mcp → style → tui (plan §6.2)

Landing order: `iface` → (`width` ∥ `latency` ∥ `agy`) → `mcp` → `style` → `tui`. Review bottom-up; merge bottom-up.
<!-- gss:stack-end -->
