### PR TITLE
gsl-ultra: width

### DIFF
--- a/sdk/gsl/cmd/columns.go
+++ b/sdk/gsl/cmd/columns.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
 )
 
@@ -45,11 +48,11 @@ const fallbackColumns = 120
 // the width so tests can assert WHICH branch fired (not merely that the number
 // looks plausible) and so the choice can be logged at Debug.
 const (
-	sourcePayload = "payload"       // payload.terminal_width (the host told us)
-	sourceStdout  = "ioctl:stdout"  // stdout is a tty
-	sourceStderr  = "ioctl:stderr"  // stdout piped, stderr still on the tty
-	sourceColumns = "env:COLUMNS"   // exported COLUMNS (rare; honoured if present)
-	sourceDefault = "default"       // nothing knew; fallbackColumns
+	sourcePayload = "payload"      // payload.terminal_width (the host told us)
+	sourceStdout  = "ioctl:stdout" // stdout is a tty
+	sourceStderr  = "ioctl:stderr" // stdout piped, stderr still on the tty
+	sourceColumns = "env:COLUMNS"  // exported COLUMNS (rare; honoured if present)
+	sourceDefault = "default"      // nothing knew; fallbackColumns
 )
 
 // resolveColumns determines the terminal width and the source that supplied it.
@@ -78,6 +81,43 @@ func resolveColumns(
 	ttyStdout func() (int, bool),
 	ttyStderr func() (int, bool),
 ) (cols int, source string) {
-	// Implemented in the `width` leaf.
+	// 1. The host explicitly told us. Nothing beats that.
+	if p.TerminalWidth != nil && *p.TerminalWidth > 0 {
+		return *p.TerminalWidth, sourcePayload
+	}
+
+	// 2. stdout is a terminal (plain interactive shell usage).
+	if n, ok := probe(ttyStdout); ok {
+		return n, sourceStdout
+	}
+
+	// 3. stdout is a pipe but stderr is still on the tty. THIS is the Claude
+	//    Code case, and the branch that did not exist before.
+	if n, ok := probe(ttyStderr); ok {
+		return n, sourceStderr
+	}
+
+	// 4. An explicitly EXPORTED COLUMNS. Usually absent (it is a shell variable,
+	//    not an environment variable), but honour it when a user exports it.
+	if env != nil {
+		if n, err := strconv.Atoi(strings.TrimSpace(env("COLUMNS"))); err == nil && n > 0 {
+			return n, sourceColumns
+		}
+	}
+
+	// 5. Nothing knew.
 	return fallbackColumns, sourceDefault
+}
+
+// probe calls a tty width source defensively: a nil source, a source reporting
+// "not a tty", and a source reporting a nonsensical width are all "unknown".
+func probe(src func() (int, bool)) (int, bool) {
+	if src == nil {
+		return 0, false
+	}
+	n, ok := src()
+	if !ok || n <= 0 {
+		return 0, false
+	}
+	return n, true
 }

--- a/sdk/gsl/cmd/columns_test.go
+++ b/sdk/gsl/cmd/columns_test.go
@@ -1,0 +1,170 @@
+package cmd
+
+// columns_test.go — spec gsl-ultra E1, E2 (feature F1: width resolution).
+//
+// The four HOST scenarios, as a table. Every input is injected — the env lookup
+// and both tty probes are function parameters — so each branch is exercised
+// deterministically without a pty and without touching the process environment.
+
+import (
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
+)
+
+// tty returns a width source that reports a live terminal of n columns.
+func tty(n int) func() (int, bool) { return func() (int, bool) { return n, true } }
+
+// piped returns a width source that reports "not a terminal" — what the ioctl
+// wrapper does when the fd is a pipe, which is exactly how Claude Code invokes
+// the status-line command.
+func piped() func() (int, bool) { return func() (int, bool) { return 0, false } }
+
+// envOf builds an env lookup over a fixed map.
+func envOf(kv map[string]string) func(string) string {
+	return func(k string) string { return kv[k] }
+}
+
+func intptr(n int) *int { return &n }
+
+func TestResolveColumns(t *testing.T) {
+	tests := []struct {
+		name       string
+		p          payload.Payload
+		env        map[string]string
+		ttyStdout  func() (int, bool)
+		ttyStderr  func() (int, bool)
+		wantCols   int
+		wantSource string
+	}{
+		{
+			// E1 — the host told us the width. Most authoritative source.
+			name:       "a/payload width wins over everything, stdout piped",
+			p:          payload.Payload{TerminalWidth: intptr(200)},
+			env:        map[string]string{"COLUMNS": "90"},
+			ttyStdout:  piped(),
+			ttyStderr:  tty(80),
+			wantCols:   200,
+			wantSource: sourcePayload,
+		},
+		{
+			// E2 — THE KEY CASE. This is how Claude Code actually runs gsl:
+			// stdout is a pipe, no terminal_width in the payload, but stderr is
+			// still attached to the real tty. Nothing in the shipped code looks
+			// at stderr, so every real render fell through to the hardcoded 80.
+			name:       "b/stdout piped, no payload width, stderr is a tty (Claude)",
+			p:          payload.Payload{},
+			env:        map[string]string{},
+			ttyStdout:  piped(),
+			ttyStderr:  tty(80),
+			wantCols:   80,
+			wantSource: sourceStderr,
+		},
+		{
+			// c — plain interactive shell usage: stdout IS the terminal.
+			name:       "c/stdout is a tty",
+			p:          payload.Payload{},
+			env:        map[string]string{},
+			ttyStdout:  tty(100),
+			ttyStderr:  tty(80),
+			wantCols:   100,
+			wantSource: sourceStdout,
+		},
+		{
+			// d — neither fd is a tty, but COLUMNS was explicitly exported.
+			name:       "d/no tty anywhere, COLUMNS exported",
+			p:          payload.Payload{},
+			env:        map[string]string{"COLUMNS": "90"},
+			ttyStdout:  piped(),
+			ttyStderr:  piped(),
+			wantCols:   90,
+			wantSource: sourceColumns,
+		},
+		{
+			// e — nothing knows. 120, not the teletype-era 80.
+			name:       "e/nothing at all",
+			p:          payload.Payload{},
+			env:        map[string]string{},
+			ttyStdout:  piped(),
+			ttyStderr:  piped(),
+			wantCols:   fallbackColumns,
+			wantSource: sourceDefault,
+		},
+
+		// ── edges ────────────────────────────────────────────────────────────
+		{
+			name:       "edge/payload width 0 falls through",
+			p:          payload.Payload{TerminalWidth: intptr(0)},
+			env:        map[string]string{},
+			ttyStdout:  piped(),
+			ttyStderr:  tty(80),
+			wantCols:   80,
+			wantSource: sourceStderr,
+		},
+		{
+			name:       "edge/payload width negative falls through",
+			p:          payload.Payload{TerminalWidth: intptr(-5)},
+			env:        map[string]string{},
+			ttyStdout:  piped(),
+			ttyStderr:  piped(),
+			wantCols:   fallbackColumns,
+			wantSource: sourceDefault,
+		},
+		{
+			name:       "edge/COLUMNS unparseable falls through to default",
+			p:          payload.Payload{},
+			env:        map[string]string{"COLUMNS": "not-a-number"},
+			ttyStdout:  piped(),
+			ttyStderr:  piped(),
+			wantCols:   fallbackColumns,
+			wantSource: sourceDefault,
+		},
+		{
+			name:       "edge/COLUMNS zero falls through to default",
+			p:          payload.Payload{},
+			env:        map[string]string{"COLUMNS": "0"},
+			ttyStdout:  piped(),
+			ttyStderr:  piped(),
+			wantCols:   fallbackColumns,
+			wantSource: sourceDefault,
+		},
+		{
+			name:       "edge/nil probes are safe",
+			p:          payload.Payload{},
+			env:        map[string]string{},
+			ttyStdout:  nil,
+			ttyStderr:  nil,
+			wantCols:   fallbackColumns,
+			wantSource: sourceDefault,
+		},
+		{
+			name:       "edge/tty reports ok but zero width falls through",
+			p:          payload.Payload{},
+			env:        map[string]string{},
+			ttyStdout:  func() (int, bool) { return 0, true },
+			ttyStderr:  func() (int, bool) { return 0, true },
+			wantCols:   fallbackColumns,
+			wantSource: sourceDefault,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCols, gotSource := resolveColumns(tc.p, envOf(tc.env), tc.ttyStdout, tc.ttyStderr)
+			if gotCols != tc.wantCols || gotSource != tc.wantSource {
+				t.Errorf("resolveColumns() = (%d, %q), want (%d, %q)",
+					gotCols, gotSource, tc.wantCols, tc.wantSource)
+			}
+		})
+	}
+}
+
+// TestResolveColumns_NilEnv proves a nil env lookup does not panic (the status
+// line must never crash — UC-7).
+func TestResolveColumns_NilEnv(t *testing.T) {
+	cols, src := resolveColumns(payload.Payload{}, nil, piped(), piped())
+	if cols != fallbackColumns || src != sourceDefault {
+		t.Errorf("resolveColumns(nil env) = (%d, %q), want (%d, %q)",
+			cols, src, fallbackColumns, sourceDefault)
+	}
+}

--- a/sdk/gsl/cmd/statusline.go
+++ b/sdk/gsl/cmd/statusline.go
@@ -4,19 +4,20 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/gh"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/git"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/mcp"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/render"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/repo"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/style"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/term"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/theme"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -120,24 +121,18 @@ func runStatusLine(_ *cobra.Command, p payload.Payload, cwdHint string) error {
 	// Detect-once: ALL subprocess I/O happens here, exactly once.
 	datas := render.Detect(ctx, cfg, st, segs)
 
-	// Resolve terminal width: $COLUMNS wins, then ioctl on stdout (returns
-	// ok=false when not a TTY, e.g. piped under Claude Code), then the payload's
-	// terminal_width if present, then fallback 80.
-	cols := term.Columns(term.StdoutWidthSource())
-	columnsEnv := os.Getenv("COLUMNS")
-	var isColumnsValid bool
-	if columnsEnv != "" {
-		if val, err := strconv.Atoi(columnsEnv); err == nil && val > 0 {
-			isColumnsValid = true
-		}
+	// Resolve the terminal width through the single, testable resolver.
+	// Precedence: payload.terminal_width → ioctl(stdout) → ioctl(stderr) →
+	// $COLUMNS → cfg.FallbackColumns.
+	cols, source := resolveColumns(p, os.Getenv, term.StdoutWidthSource(), term.StderrWidthSource())
+	if source == sourceDefault {
+		cols = cfg.EffectiveFallbackColumns()
 	}
-	if !isColumnsValid {
-		if _, isTTY := term.StdoutWidthSource()(); !isTTY {
-			if p.TerminalWidth != nil && *p.TerminalWidth > 0 {
-				cols = *p.TerminalWidth
-			}
-		}
-	}
+	observe.Default().WithFields(logrus.Fields{
+		"event":  "width.resolved",
+		"cols":   cols,
+		"source": source,
+	}).Debug("resolved terminal width")
 
 	// Fit: escalate compaction levels until the output fits, or use the most
 	// compact form. No additional I/O after Detect.

--- a/sdk/gsl/internal/config/config.go
+++ b/sdk/gsl/internal/config/config.go
@@ -21,8 +21,63 @@ type Segment struct {
 	Type string `json:"type"`
 	// Enabled controls whether this segment is rendered.
 	Enabled bool `json:"enabled"`
+	// Priority is the DROP priority used by the render fit loop when text
+	// compaction alone cannot make the line fit: the LOWEST priority segment is
+	// dropped first, and the highest-priority segment is the last one standing.
+	//
+	// It is deliberately independent of the segment's POSITION in Segments,
+	// which controls only the left-to-right VISUAL order. Before this field
+	// existed the fit loop dropped the right-most slice element, so simply
+	// reordering the line silently changed which information survived a narrow
+	// terminal — the user's cosmetic preference decided what they could still
+	// read at 40 columns.
+	//
+	// 0 (the zero value, i.e. "unset") means "use the built-in default for this
+	// segment type" — see DefaultSegmentPriority. That keeps every existing
+	// config.json working unchanged.
+	Priority int `json:"priority,omitempty"`
 	// Options holds segment-specific key-value overrides.
 	Options map[string]any `json:"options,omitempty"`
+}
+
+// Built-in drop priorities. Higher survives longer; the fit loop drops the
+// lowest first. The ordering encodes "what does the user most need to still see
+// on a 40-column split pane": which repo/PR you are in beats where you are on
+// disk, beats the model, beats the clock (which every OS already shows).
+//
+// The gaps leave room for a user to interleave a custom value without having to
+// renumber the others.
+const (
+	PriorityTime   = 10 // dropped first
+	PriorityAI     = 20
+	PriorityDirGit = 30
+	PriorityRepo   = 40 // dropped last
+)
+
+// DefaultSegmentPriority returns the built-in drop priority for a segment type.
+// Unknown types sort with the first-dropped group.
+func DefaultSegmentPriority(segType string) int {
+	switch segType {
+	case "repo":
+		return PriorityRepo
+	case "dirgit":
+		return PriorityDirGit
+	case "ai":
+		return PriorityAI
+	case "time":
+		return PriorityTime
+	default:
+		return 0
+	}
+}
+
+// EffectivePriority returns the segment's drop priority: the user's explicit
+// Priority when set, otherwise the built-in default for its type.
+func (s Segment) EffectivePriority() int {
+	if s.Priority != 0 {
+		return s.Priority
+	}
+	return DefaultSegmentPriority(s.Type)
 }
 
 // Config is the top-level gsl configuration.
@@ -42,7 +97,20 @@ type Config struct {
 	// Styles holds user-defined style overrides keyed by segment type or
 	// element name. Kept as map[string]any for CP1; CP2 will type it further.
 	Styles map[string]any `json:"styles,omitempty"`
+	// FallbackColumns is the terminal width assumed when NO source knows it —
+	// no terminal_width in the payload, neither stdout nor stderr is a tty, and
+	// COLUMNS is not exported. See cmd.resolveColumns.
+	//
+	// DefaultFallbackColumns (120), not 80. 80 is a teletype default that
+	// under-serves every modern terminal; when guessing, guess generously — an
+	// over-wide guess is corrected by the fit loop's truncation (now a hard
+	// guarantee), whereas an under-wide guess silently discards information the
+	// user had room for.
+	FallbackColumns int `json:"fallback_columns,omitempty"`
 }
+
+// DefaultFallbackColumns is the assumed terminal width when nothing knows it.
+const DefaultFallbackColumns = 120
 
 // Default returns a fully usable Config with all 4 segments enabled in the
 // canonical order: dirgit, repo, ai, time.
@@ -55,11 +123,21 @@ func Default() Config {
 			{Type: "ai", Enabled: true},
 			{Type: "time", Enabled: true},
 		},
-		Timezone:   "America/Los_Angeles",
-		TimeFormat: "15:04:05",
-		DateFormat: "2006-01-02",
-		Style:      "powerline",
+		Timezone:        "America/Los_Angeles",
+		TimeFormat:      "15:04:05",
+		DateFormat:      "2006-01-02",
+		Style:           "powerline",
+		FallbackColumns: DefaultFallbackColumns,
 	}
+}
+
+// EffectiveFallbackColumns returns the configured fallback width, or
+// DefaultFallbackColumns when it is unset or nonsensical.
+func (c Config) EffectiveFallbackColumns() int {
+	if c.FallbackColumns > 0 {
+		return c.FallbackColumns
+	}
+	return DefaultFallbackColumns
 }
 
 // DefaultPath returns the default config file path, respecting

--- a/sdk/gsl/internal/config/priority_test.go
+++ b/sdk/gsl/internal/config/priority_test.go
@@ -1,0 +1,122 @@
+package config
+
+// priority_test.go — Segment.Priority and Config.FallbackColumns (gsl-ultra WS1).
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultSegmentPriority_Order(t *testing.T) {
+	// The drop order the fit loop relies on: time goes first, repo goes last.
+	if !(DefaultSegmentPriority("time") <
+		DefaultSegmentPriority("ai") &&
+		DefaultSegmentPriority("ai") < DefaultSegmentPriority("dirgit") &&
+		DefaultSegmentPriority("dirgit") < DefaultSegmentPriority("repo")) {
+		t.Errorf("want time < ai < dirgit < repo, got time=%d ai=%d dirgit=%d repo=%d",
+			DefaultSegmentPriority("time"), DefaultSegmentPriority("ai"),
+			DefaultSegmentPriority("dirgit"), DefaultSegmentPriority("repo"))
+	}
+	if got := DefaultSegmentPriority("nonesuch"); got != 0 {
+		t.Errorf("unknown type: want 0, got %d", got)
+	}
+}
+
+func TestSegment_EffectivePriority(t *testing.T) {
+	tests := []struct {
+		name string
+		seg  Segment
+		want int
+	}{
+		{"unset uses the type default", Segment{Type: "repo"}, PriorityRepo},
+		{"unset uses the type default (time)", Segment{Type: "time"}, PriorityTime},
+		{"explicit wins", Segment{Type: "time", Priority: 99}, 99},
+		{"unknown type unset", Segment{Type: "zzz"}, 0},
+		{"unknown type explicit", Segment{Type: "zzz", Priority: 7}, 7},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.seg.EffectivePriority(); got != tc.want {
+				t.Errorf("EffectivePriority() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConfig_EffectiveFallbackColumns(t *testing.T) {
+	if got := Default().EffectiveFallbackColumns(); got != DefaultFallbackColumns {
+		t.Errorf("Default(): got %d, want %d", got, DefaultFallbackColumns)
+	}
+	if got := (Config{FallbackColumns: 200}).EffectiveFallbackColumns(); got != 200 {
+		t.Errorf("explicit 200: got %d", got)
+	}
+	// Unset (0) and nonsensical (negative) both fall back to the default rather
+	// than producing a zero-width line.
+	if got := (Config{}).EffectiveFallbackColumns(); got != DefaultFallbackColumns {
+		t.Errorf("unset: got %d, want %d", got, DefaultFallbackColumns)
+	}
+	if got := (Config{FallbackColumns: -10}).EffectiveFallbackColumns(); got != DefaultFallbackColumns {
+		t.Errorf("negative: got %d, want %d", got, DefaultFallbackColumns)
+	}
+}
+
+// TestLoad_PriorityAndFallbackRoundTrip proves the new fields survive a
+// save/load cycle and that an OLD config.json (with neither field) still loads —
+// the schema is a strict superset.
+func TestLoad_PriorityAndFallbackRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("new fields round-trip", func(t *testing.T) {
+		path := filepath.Join(dir, "new.json")
+		c := Default()
+		c.FallbackColumns = 200
+		c.Segments[0].Priority = 99
+		if err := Save(path, c); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		got, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got.FallbackColumns != 200 {
+			t.Errorf("FallbackColumns = %d, want 200", got.FallbackColumns)
+		}
+		if got.Segments[0].Priority != 99 {
+			t.Errorf("Segments[0].Priority = %d, want 99", got.Segments[0].Priority)
+		}
+	})
+
+	t.Run("legacy config without the new fields still loads", func(t *testing.T) {
+		path := filepath.Join(dir, "legacy.json")
+		legacy := `{"enabled":true,"segments":[{"type":"repo","enabled":true}],"style":"powerline"}`
+		if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		got, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load legacy: %v", err)
+		}
+		// Unmarshal-over-Default keeps the default fallback.
+		if got.EffectiveFallbackColumns() != DefaultFallbackColumns {
+			t.Errorf("legacy fallback = %d, want %d", got.EffectiveFallbackColumns(), DefaultFallbackColumns)
+		}
+		// An unset Priority resolves to the type default, so an existing config
+		// keeps today's drop behaviour without being rewritten.
+		if got.Segments[0].EffectivePriority() != PriorityRepo {
+			t.Errorf("legacy repo priority = %d, want %d",
+				got.Segments[0].EffectivePriority(), PriorityRepo)
+		}
+	})
+
+	t.Run("unset priority is omitted from the serialized form", func(t *testing.T) {
+		data, err := json.Marshal(Segment{Type: "repo", Enabled: true})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(data) != `{"type":"repo","enabled":true}` {
+			t.Errorf("zero Priority must be omitempty; got %s", data)
+		}
+	})
+}

--- a/sdk/gsl/internal/render/detect.go
+++ b/sdk/gsl/internal/render/detect.go
@@ -9,6 +9,7 @@ package render
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -39,7 +40,34 @@ type detectable interface {
 type segmentData interface {
 	// format returns raw (unpainted) text and the theme colorKey at the given
 	// compaction level. PURE: no I/O. Returns ("", "") to self-omit at this level.
+	//
+	// format MUST be monotonically non-increasing in width as level rises
+	// (spec E5): a segment that ignores its level silently defeats the entire
+	// compaction ladder and forces Fit into the segment-drop tier far earlier
+	// than necessary.
 	format(st style.Style, level int) (text, colorKey string)
+}
+
+// prioritized is the optional interface a segmentData implements to declare its
+// DROP priority — which segment Fit sacrifices first when the line still does
+// not fit after text compaction.
+//
+// Priority is deliberately NOT slice position. Before this existed, Fit dropped
+// the right-most element of cfg.Segments, so a user who merely REORDERED their
+// status line (a cosmetic preference) silently changed which information they
+// could still read on a narrow terminal. Position is presentation; priority is
+// policy. They are different questions and now have different answers.
+type prioritized interface {
+	priority() int
+}
+
+// priorityOf returns d's drop priority. A segmentData that declares none sorts
+// with the first-dropped group.
+func priorityOf(d segmentData) int {
+	if p, ok := d.(prioritized); ok {
+		return p.priority()
+	}
+	return 0
 }
 
 // Detect runs the enabled segments CONCURRENTLY (one goroutine each, with a
@@ -181,6 +209,17 @@ func Format(datas []segmentData, st style.Style, level int) string {
 // Both powerline and emoji use this tier; emoji is the binding case because
 // each emoji glyph is an irreducible ~2 cols + space.
 func formatFinalTier(datas []segmentData, st style.Style) string {
+	blocks := finalTierBlocks(datas, st)
+	if len(blocks) == 0 {
+		return ""
+	}
+	return join(st, blocks)
+}
+
+// finalTierBlocks is formatFinalTier's block list, before the join. Fit's
+// truncation tier needs the blocks themselves (it has to shorten their text),
+// not the already-assembled string.
+func finalTierBlocks(datas []segmentData, st style.Style) []segmentBlock {
 	textLevel := finalCompactLevel - 1
 
 	blocks := make([]segmentBlock, 0, len(datas))
@@ -199,11 +238,7 @@ func formatFinalTier(datas []segmentData, st style.Style) string {
 		}
 		blocks = append(blocks, segmentBlock{text: text, colorKey: colorKey})
 	}
-
-	if len(blocks) == 0 {
-		return ""
-	}
-	return join(st, blocks)
+	return blocks
 }
 
 // dropLeadingGlyph removes the leading non-ASCII glyph (emoji or Nerd Font
@@ -239,55 +274,111 @@ func dropLeadingGlyph(text string) string {
 	return text
 }
 
-// Fit runs Format at escalating compaction levels (0 → finalCompactLevel)
-// and returns the first output whose term.DisplayWidth ≤ cols, or the most
-// compact if none fits.
+// Fit renders datas into a line that is GUARANTEED to be at most cols display
+// columns wide (spec E3), and non-empty whenever any segment has content (E4).
 //
-// After the final text tier (glyph-drop), Fit progressively drops segments
-// from the right (lowest priority first: time → AI → dirgit → repo) until
-// the output fits or only one segment remains.
+// The ladder, cheapest concession first:
+//
+//	Phase 1  escalate text-compaction levels 0..finalCompactLevel.
+//	Phase 2  drop whole segments, LOWEST PRIORITY FIRST (E6) — not right-most.
+//	Phase 3  truncate the survivor, grapheme-safely, with an ellipsis (E3).
+//
+// Phases 1 and 2 are best-effort: they make the line smaller, but neither can
+// make it small ENOUGH. Only phase 3 is bounded by construction. The shipped
+// code stopped after phase 2 with `for len(active) > 1`, which left the final
+// surviving segment un-truncated — a 27-column line on a 20-column terminal.
 //
 // Fit is PURE (no I/O) — all data is already in datas from a prior Detect call.
 func Fit(datas []segmentData, st style.Style, cols int) string {
-	if len(datas) == 0 {
+	if len(datas) == 0 || cols <= 0 {
 		return ""
 	}
 
-	// Phase 1: escalate through text levels 0..finalCompactLevel.
-	var last string
+	// ── Phase 1: escalate through text levels 0..finalCompactLevel. ──────────
 	for level := 0; level <= finalCompactLevel; level++ {
 		out := Format(datas, st, level)
-		last = out
+		if out == "" {
+			// Nothing to render at all (every segment self-omitted).
+			return ""
+		}
 		if term.DisplayWidth(out) <= cols {
 			return out
 		}
 	}
 
-	// Phase 2: progressively drop segments from the right end.
-	// Build the active set (indices of non-nil datas), then drop from the right.
-	active := make([]int, 0, len(datas))
-	for i, d := range datas {
-		if d != nil {
-			active = append(active, i)
-		}
-	}
+	// ── Phase 2: drop segments, lowest priority first. ───────────────────────
+	//
+	// The VISUAL order of the survivors is unchanged (pruned keeps each segment
+	// at its original index); only the DROP order is by priority.
+	pruned := make([]segmentData, len(datas))
+	copy(pruned, datas)
 
-	for len(active) > 1 {
-		// Drop the last (lowest-priority) segment.
-		active = active[:len(active)-1]
-
-		// Build a pruned datas slice.
-		pruned := make([]segmentData, len(datas))
-		for _, idx := range active {
-			pruned[idx] = datas[idx]
+	for _, idx := range dropOrder(datas) {
+		if countActive(pruned) <= 1 {
+			break
 		}
+		pruned[idx] = nil
 
 		out := formatFinalTier(pruned, st)
-		last = out
-		if out == "" || term.DisplayWidth(out) <= cols {
+		if out == "" {
+			break
+		}
+		if term.DisplayWidth(out) <= cols {
 			return out
 		}
 	}
 
-	return last
+	// ── Phase 3: truncate the survivor. ──────────────────────────────────────
+	blocks := finalTierBlocks(pruned, st)
+	if len(blocks) == 0 {
+		return ""
+	}
+
+	if fitted := truncateToWidth(blocks, st, cols); len(fitted) > 0 {
+		if out := join(st, fitted); term.DisplayWidth(out) <= cols {
+			return out
+		}
+	}
+
+	// The decoration itself does not fit (e.g. cols=2 with powerline, whose
+	// padding + chevron alone costs 3 columns). Emit an UNDECORATED, painted,
+	// grapheme-safe truncation: no padding, no separator, no chevron — just as
+	// much of the highest-priority segment as the terminal can physically hold.
+	text := truncateText(term.StripANSI(blocks[0].text), cols)
+	if text == "" {
+		return ""
+	}
+	return paint(st, blocks[0].colorKey, text)
+}
+
+// dropOrder returns the indices of the non-nil segments in the order Fit should
+// sacrifice them: ASCENDING priority, and — among equal priorities — right-most
+// first, which preserves the historical behaviour for segments that declare no
+// priority of their own.
+func dropOrder(datas []segmentData) []int {
+	order := make([]int, 0, len(datas))
+	for i, d := range datas {
+		if d != nil {
+			order = append(order, i)
+		}
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		pa, pb := priorityOf(datas[order[a]]), priorityOf(datas[order[b]])
+		if pa != pb {
+			return pa < pb
+		}
+		return order[a] > order[b]
+	})
+	return order
+}
+
+// countActive returns the number of non-nil entries in datas.
+func countActive(datas []segmentData) int {
+	n := 0
+	for _, d := range datas {
+		if d != nil {
+			n++
+		}
+	}
+	return n
 }

--- a/sdk/gsl/internal/render/fit_property_test.go
+++ b/sdk/gsl/internal/render/fit_property_test.go
@@ -1,0 +1,424 @@
+package render
+
+// fit_property_test.go — the WS1 property suite (spec gsl-ultra §5: E3, E4, E5, E6).
+//
+// These are PROPERTY tests, not examples. The shipped suite asserted Fit's width
+// invariant at four hand-picked column counts (80/60/40/30) and at cols=20 for two
+// styles. That is exactly the shape of test that lets a real defect ship: the
+// invariant is universally quantified ("for ALL inputs") but was only ever spot-checked.
+//
+// The matrix here sweeps {5 content fixtures} × {3 styles} × {worktree y/n} × {cols 1..200}
+// and asserts the invariant on every single combination.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/git"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/style"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/term"
+)
+
+// ─── fixtures ─────────────────────────────────────────────────────────────────
+
+// fitFixture describes one content scenario. The segmentData values are built
+// DIRECTLY (no Detect, no fakes, no I/O) — Fit and Format are pure, so the
+// property suite can be exhaustive and still run in well under a second.
+type fitFixture struct {
+	name   string
+	cwd    string
+	home   string
+	branch string
+	label  string // repo feature/worker label
+	model  string
+}
+
+// fitFixtures is the content axis of the matrix.
+func fitFixtures() []fitFixture {
+	return []fitFixture{
+		{
+			name:   "short",
+			cwd:    "/home/user/proj",
+			home:   "/home/user",
+			branch: "main",
+			label:  "proj",
+			model:  "Opus 4.7",
+		},
+		{
+			name:   "long-basename",
+			cwd:    "/home/user/git/gsl-ultra-tui-mcp-status",
+			home:   "/home/user",
+			branch: "main",
+			label:  "gsl-ultra-tui-mcp-status",
+			model:  "Claude Opus 4.8 (1M context)",
+		},
+		{
+			name:   "long-branch",
+			cwd:    "/home/user/git/dotfiles",
+			home:   "/home/user",
+			branch: "feature/gsl-ultra/edward-raigosa/width-and-fit-correctness",
+			label:  "gsl-ultra",
+			model:  "Claude Sonnet 4.5",
+		},
+		{
+			// East-Asian wide runes: every rune is 2 display columns, so a
+			// byte- or rune-count truncation silently overshoots the budget.
+			name:   "cjk-path",
+			cwd:    "/home/user/项目/文档目录内容",
+			home:   "/home/user",
+			branch: "主分支/开发/宽度修复",
+			label:  "项目文档",
+			model:  "Gemini 2.5 Pro",
+		},
+		{
+			// A ZWJ emoji sequence is ONE grapheme cluster made of several runes.
+			// Cutting between them produces mojibake AND a wrong width.
+			name:   "emoji-branch",
+			cwd:    "/home/user/git/rocket",
+			home:   "/home/user",
+			branch: "feat/🚀-launch-👩‍🚀-crew",
+			label:  "rocket-🚀",
+			model:  "Claude Haiku 4.5 (fast)",
+		},
+	}
+}
+
+// fitStyles is the presentation axis of the matrix.
+func fitStyles() map[string]style.Style {
+	return map[string]style.Style{
+		"powerline": powerlineStyleFixture(),
+		"emoji":     emojiStyleFixture(),
+		"ascii":     asciiStyle(),
+	}
+}
+
+// propDirGit builds a fully-populated dirGitData for the fixture.
+func propDirGit(f fitFixture) segmentData {
+	return &dirGitData{
+		cwd:  f.cwd,
+		home: f.home,
+		gitInfo: &git.Info{
+			Branch:    f.branch,
+			Staged:    1,
+			Unstaged:  2,
+			Untracked: 3,
+			Ahead:     2,
+			Behind:    1,
+			Stashes:   1,
+		},
+		hasGit: true,
+	}
+}
+
+// propRepo builds a fully-populated repoData for the fixture.
+func propRepo(f fitFixture, worktree bool) segmentData {
+	key := "repo_root"
+	count := 0
+	if worktree {
+		key = "repo_worktree"
+		count = 4
+	}
+	return &repoData{
+		themeKey:      key,
+		indicatorKey:  key,
+		label:         f.label,
+		prNumber:      157,
+		prState:       "OPEN",
+		worktreeCount: count,
+		showPR:        true,
+		showCount:     worktree,
+	}
+}
+
+// propAI builds a fully-populated aiData for the fixture.
+func propAI(f fitFixture) segmentData {
+	return &aiData{
+		modelName:     f.model,
+		ctxPct:        f64ptr(42),
+		tokenUsed:     f64ptr(84000),
+		tokenTotal:    f64ptr(200000),
+		mcpActive:     6,
+		mcpConfigured: 12,
+		rate5h:        f64ptr(80),
+		rate7d:        f64ptr(15),
+		hasPayload:    true,
+	}
+}
+
+// propTime builds a fully-populated timeData.
+func propTime() segmentData {
+	return &timeData{
+		t:          time.Date(2026, 7, 11, 14, 30, 5, 0, time.UTC),
+		dateLayout: "2006-01-02",
+		timeLayout: "15:04:05",
+		tz:         "UTC",
+	}
+}
+
+// propDatas returns the four segmentData values in canonical config order
+// (dirgit, repo, ai, time) for the fixture.
+func propDatas(f fitFixture, worktree bool) []segmentData {
+	return []segmentData{
+		propDirGit(f),
+		propRepo(f, worktree),
+		propAI(f),
+		propTime(),
+	}
+}
+
+// ─── E3 — the width invariant ─────────────────────────────────────────────────
+
+// TestFit_WidthInvariant is spec rule E3.
+//
+//	term.DisplayWidth(Fit(datas, st, cols)) <= cols   for ALL inputs.
+//
+// This must hold for EVERY combination of content, style, worktree state and
+// column count in 1..200 — no exceptions, no "except when very narrow".
+func TestFit_WidthInvariant(t *testing.T) {
+	styles := fitStyles()
+	for _, f := range fitFixtures() {
+		for styleName, st := range styles {
+			for _, worktree := range []bool{false, true} {
+				name := fmt.Sprintf("%s/%s/worktree=%v", f.name, styleName, worktree)
+				t.Run(name, func(t *testing.T) {
+					datas := propDatas(f, worktree)
+					for cols := 1; cols <= 200; cols++ {
+						out := Fit(datas, st, cols)
+						if w := term.DisplayWidth(out); w > cols {
+							t.Fatalf("E3 VIOLATED: cols=%d → DisplayWidth=%d\n  output: %q",
+								cols, w, out)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+// ─── E4 — Fit must emit something ─────────────────────────────────────────────
+
+// TestFit_NonEmpty is spec rule E4: Fit must return non-empty output whenever
+// at least one segmentData is non-nil and has content. Fitting to a narrow
+// terminal degrades the line; it must never delete it.
+func TestFit_NonEmpty(t *testing.T) {
+	styles := fitStyles()
+	for _, f := range fitFixtures() {
+		for styleName, st := range styles {
+			for _, worktree := range []bool{false, true} {
+				name := fmt.Sprintf("%s/%s/worktree=%v", f.name, styleName, worktree)
+				t.Run(name, func(t *testing.T) {
+					datas := propDatas(f, worktree)
+					for cols := 1; cols <= 200; cols++ {
+						if out := Fit(datas, st, cols); out == "" {
+							t.Fatalf("E4 VIOLATED: cols=%d → empty output with %d live segments",
+								cols, len(datas))
+						}
+					}
+				})
+			}
+		}
+	}
+
+	// A single live segment (the rest nil) must still render.
+	st := emojiStyleFixture()
+	f := fitFixtures()[1]
+	for i := 0; i < 4; i++ {
+		datas := make([]segmentData, 4)
+		datas[i] = propDatas(f, false)[i]
+		for cols := 1; cols <= 200; cols++ {
+			if out := Fit(datas, st, cols); out == "" {
+				t.Fatalf("E4 VIOLATED: lone segment idx=%d, cols=%d → empty output", i, cols)
+			}
+		}
+	}
+}
+
+// ─── E5 — per-level width monotonicity ────────────────────────────────────────
+
+// TestSegmentWidth_MonotonicInLevel is spec rule E5.
+//
+// For EVERY segmentData type, DisplayWidth(format(st, level)) must be
+// NON-INCREASING as level goes 0 → 4. A segment whose width is flat across all
+// levels is not compacting — it is silently defeating the entire Fit ladder,
+// which is what forces Fit into the segment-drop tier far earlier than it should.
+//
+// This is the test that catches repoData ignoring its level parameter.
+func TestSegmentWidth_MonotonicInLevel(t *testing.T) {
+	styles := fitStyles()
+	for _, f := range fitFixtures() {
+		for styleName, st := range styles {
+			for _, worktree := range []bool{false, true} {
+				types := map[string]segmentData{
+					"dirGitData": propDirGit(f),
+					"repoData":   propRepo(f, worktree),
+					"aiData":     propAI(f),
+					"timeData":   propTime(),
+				}
+				for typeName, d := range types {
+					name := fmt.Sprintf("%s/%s/%s/worktree=%v", typeName, f.name, styleName, worktree)
+					t.Run(name, func(t *testing.T) {
+						widths := make([]int, finalCompactLevel+1)
+						texts := make([]string, finalCompactLevel+1)
+						for level := 0; level <= finalCompactLevel; level++ {
+							text, _ := d.format(st, level)
+							texts[level] = text
+							widths[level] = term.DisplayWidth(text)
+						}
+						for level := 1; level <= finalCompactLevel; level++ {
+							if widths[level] > widths[level-1] {
+								t.Fatalf("E5 VIOLATED (grew): level %d width %d > level %d width %d\n  L%d: %q\n  L%d: %q",
+									level, widths[level], level-1, widths[level-1],
+									level-1, texts[level-1], level, texts[level])
+							}
+						}
+						// A segment that never gets narrower is not compacting at all.
+						// (Only assert this when there IS something to compact: the
+						// level-0 render is wider than a bare glyph + a few columns.)
+						if widths[0] >= 12 && widths[finalCompactLevel] == widths[0] {
+							t.Fatalf("E5 VIOLATED (flat): %s width is %d at EVERY level 0..%d — the level parameter is being ignored\n  L0: %q\n  L%d: %q",
+								typeName, widths[0], finalCompactLevel,
+								texts[0], finalCompactLevel, texts[finalCompactLevel])
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+// ─── E6 — drop order must not follow slice position ───────────────────────────
+
+// TestFit_DropOrderIndependentOfConfigOrder is spec rule E6.
+//
+// Fit drops segments when text compaction is not enough. WHICH segment survives
+// must be decided by an explicit PRIORITY, not by where the user happened to put
+// the segment in cfg.Segments. Reversing the config order must not change the
+// survivor.
+//
+// Today Fit does `active = active[:len(active)-1]` — it drops the RIGHTMOST slice
+// element. So the survivor is simply cfg.Segments[0], and reversing the config
+// changes the answer.
+func TestFit_DropOrderIndependentOfConfigOrder(t *testing.T) {
+	st := emojiStyleFixture()
+
+	// Four minimal segments with 2-column marker payloads, so that at the final
+	// tier every block renders to exactly its 2-column marker.
+	mk := func() []segmentData {
+		return []segmentData{
+			&dirGitData{cwd: "/x/Da", home: "/x"},                                                          // "Da"
+			&repoData{themeKey: "repo_root", indicatorKey: "repo_root", label: "Rb"},                       // "Rb"
+			&aiData{hasPayload: true, modelName: "Ac", mcpActive: -1},                                      // "Ac"
+			&timeData{t: time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC), timeLayout: "Td", dateLayout: "Xy"}, // "Td"
+		}
+	}
+	const (
+		markerDirGit = "Da"
+		markerRepo   = "Rb"
+		markerAI     = "Ac"
+		markerTime   = "Td"
+	)
+
+	forward := mk()
+	reversed := mk()
+	// Reverse the slice — this models the user reordering cfg.Segments.
+	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+		reversed[i], reversed[j] = reversed[j], reversed[i]
+	}
+
+	// cols = exactly the width of a lone repo block at the final tier, so exactly
+	// one segment can survive. Derived, not hardcoded.
+	repoBlockText, repoKey := mk()[1].format(st, finalCompactLevel-1)
+	repoBlockText = dropLeadingGlyph(repoBlockText)
+	cols := term.DisplayWidth(join(st, []segmentBlock{{text: repoBlockText, colorKey: repoKey}}))
+
+	gotFwd := Fit(forward, st, cols)
+	gotRev := Fit(reversed, st, cols)
+
+	survivors := func(out string) []string {
+		var s []string
+		for _, m := range []string{markerDirGit, markerRepo, markerAI, markerTime} {
+			if strings.Contains(out, m) {
+				s = append(s, m)
+			}
+		}
+		return s
+	}
+
+	fwdS, revS := survivors(gotFwd), survivors(gotRev)
+
+	if len(fwdS) != 1 || fwdS[0] != markerRepo {
+		t.Errorf("E6 VIOLATED (forward order): cols=%d → survivors %v, want [%s]\n  output: %q",
+			cols, fwdS, markerRepo, gotFwd)
+	}
+	if len(revS) != 1 || revS[0] != markerRepo {
+		t.Errorf("E6 VIOLATED (reversed order): cols=%d → survivors %v, want [%s]\n  output: %q",
+			cols, revS, markerRepo, gotRev)
+	}
+	if strings.Join(fwdS, ",") != strings.Join(revS, ",") {
+		t.Errorf("E6 VIOLATED: drop order follows slice position — forward survivors %v != reversed survivors %v",
+			fwdS, revS)
+	}
+}
+
+// TestBuildSegments_ThreadsPriority closes the loop from config.json to the fit
+// loop: a Priority set in the config must reach the constructed segment, which
+// stamps it onto the segmentData, which is what Fit sorts by. Without this the
+// E6 property above would pass on the built-in defaults while a user's explicit
+// priority silently did nothing.
+func TestBuildSegments_ThreadsPriority(t *testing.T) {
+	cfg := config.Default()
+	cfg.Segments = []config.Segment{
+		{Type: "time", Enabled: true, Priority: 99}, // explicitly promoted
+		{Type: "repo", Enabled: true},               // default
+		{Type: "ai", Enabled: false},                // disabled → skipped
+	}
+
+	segs := BuildSegments(cfg, Deps{})
+	if len(segs) != 2 {
+		t.Fatalf("want 2 enabled segments, got %d", len(segs))
+	}
+
+	ts, ok := segs[0].(*TimeSegment)
+	if !ok {
+		t.Fatalf("segs[0] is %T, want *TimeSegment", segs[0])
+	}
+	if ts.Priority != 99 {
+		t.Errorf("TimeSegment.Priority = %d, want the config's explicit 99", ts.Priority)
+	}
+
+	rs, ok := segs[1].(*RepoSegment)
+	if !ok {
+		t.Fatalf("segs[1] is %T, want *RepoSegment", segs[1])
+	}
+	if rs.Priority != config.PriorityRepo {
+		t.Errorf("RepoSegment.Priority = %d, want the built-in default %d", rs.Priority, config.PriorityRepo)
+	}
+}
+
+// TestFit_ExplicitPriorityOverridesDefault proves the user's priority actually
+// changes WHICH segment survives — the time segment, normally the first thing
+// dropped, outlives the repo segment when the user says it should.
+func TestFit_ExplicitPriorityOverridesDefault(t *testing.T) {
+	st := emojiStyleFixture()
+
+	datas := []segmentData{
+		&repoData{themeKey: "repo_root", indicatorKey: "repo_root", label: "Rb"}, // default: PriorityRepo (highest)
+		&timeData{
+			t:          time.Date(2026, 7, 11, 0, 0, 0, 0, time.UTC),
+			timeLayout: "Td",
+			dateLayout: "Xy",
+			prio:       99, // the user promoted the clock above everything
+		},
+	}
+
+	out := Fit(datas, st, 2) // room for exactly one 2-column block
+	if !strings.Contains(out, "Td") {
+		t.Errorf("explicit priority ignored: want the promoted time segment to survive, got %q", out)
+	}
+	if strings.Contains(out, "Rb") {
+		t.Errorf("want the repo segment dropped despite its higher DEFAULT priority, got %q", out)
+	}
+}

--- a/sdk/gsl/internal/render/render.go
+++ b/sdk/gsl/internal/render/render.go
@@ -88,21 +88,35 @@ type Deps struct {
 // cfg.Segments, preserving config order and skipping disabled entries.
 // Unknown segment types are skipped. The returned slice is ready to pass to
 // Render.
+//
+// Each segment also carries its DROP priority (cfg.Segment.EffectivePriority),
+// which is what Fit sacrifices by when the line will not fit. Config ORDER is
+// presentation (left-to-right); config PRIORITY is policy (what survives). They
+// are separate on purpose — see the prioritized interface in detect.go.
 func BuildSegments(cfg config.Config, deps Deps) []Segment {
 	segs := make([]Segment, 0, len(cfg.Segments))
 	for _, sc := range cfg.Segments {
 		if !sc.Enabled {
 			continue
 		}
+		prio := sc.EffectivePriority()
 		switch sc.Type {
 		case "dirgit":
-			segs = append(segs, NewDirGitSegment(deps.Cwd, deps.Git))
+			s := NewDirGitSegment(deps.Cwd, deps.Git)
+			s.Priority = prio
+			segs = append(segs, s)
 		case "repo":
-			segs = append(segs, NewRepoSegment(deps.Git, deps.GH, deps.Branch, deps.RegistryPath, sc.Options))
+			s := NewRepoSegment(deps.Git, deps.GH, deps.Branch, deps.RegistryPath, sc.Options)
+			s.Priority = prio
+			segs = append(segs, s)
 		case "ai":
-			segs = append(segs, NewAISegment(deps.Payload, deps.Cwd, deps.MCP, deps.MCPOpts))
+			s := NewAISegment(deps.Payload, deps.Cwd, deps.MCP, deps.MCPOpts)
+			s.Priority = prio
+			segs = append(segs, s)
 		case "time":
-			segs = append(segs, NewTimeSegment(deps.Clock, cfg.Timezone, cfg.TimeFormat, cfg.DateFormat))
+			s := NewTimeSegment(deps.Clock, cfg.Timezone, cfg.TimeFormat, cfg.DateFormat)
+			s.Priority = prio
+			segs = append(segs, s)
 		default:
 			// Unknown segment type: skip silently.
 		}

--- a/sdk/gsl/internal/render/seg_ai.go
+++ b/sdk/gsl/internal/render/seg_ai.go
@@ -29,6 +29,10 @@ type AISegment struct {
 	MCP mcp.Runner
 	// MCPOpts is forwarded to mcp.ActiveCount (cache file / clock injection).
 	MCPOpts mcp.ActiveCountOptions
+	// Priority is the DROP priority used by the fit loop (config.Segment.Priority,
+	// or the built-in default for this type when unset). It is independent of the
+	// segment's position in the line.
+	Priority int
 }
 
 // NewAISegment builds an AISegment.

--- a/sdk/gsl/internal/render/seg_ai_data.go
+++ b/sdk/gsl/internal/render/seg_ai_data.go
@@ -12,9 +12,12 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"unicode"
 
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/mcp"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/style"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/term"
 )
 
 // aiData is the detect-once intermediate for the AI segment.
@@ -28,6 +31,16 @@ type aiData struct {
 	rate5h        *float64
 	rate7d        *float64
 	hasPayload    bool
+	// prio is the drop priority (config.Segment.EffectivePriority).
+	prio int
+}
+
+// priority implements prioritized.
+func (d *aiData) priority() int {
+	if d.prio != 0 {
+		return d.prio
+	}
+	return config.PriorityAI
 }
 
 // detect implements detectable for AISegment. Runs all MCP subprocess I/O once.
@@ -37,7 +50,7 @@ func (s *AISegment) detect(ctx context.Context) (segmentData, bool) {
 		return nil, false
 	}
 
-	d := &aiData{hasPayload: true, mcpActive: -1}
+	d := &aiData{hasPayload: true, mcpActive: -1, prio: s.Priority}
 
 	if p.Model != nil && p.Model.DisplayName != nil {
 		d.modelName = *p.Model.DisplayName
@@ -86,9 +99,13 @@ func (d *aiData) format(st style.Style, level int) (text, colorKey string) {
 			b.WriteString(g)
 			b.WriteString(" ")
 		}
-		name := d.modelName
+		// The CANONICAL name at every level (spec UC-4: "Claude Opus 4.8 (1M
+		// context)" RENDERS AS "Opus 4.8" — the vendor prefix and the context
+		// parenthetical are 20 columns of noise the user did not ask for), and the
+		// budget-capped short form once compaction bites.
+		name := canonicalModelName(d.modelName)
 		if level >= 3 {
-			name = shortenModelName(name)
+			name = shortenModelName(d.modelName)
 		}
 		b.WriteString(name)
 		parts = append(parts, b.String())
@@ -146,20 +163,144 @@ func (d *aiData) format(st style.Style, level int) (text, colorKey string) {
 	return strings.Join(parts, " "), "ai"
 }
 
+// modelBudget is the display-width cap for a shortened model name.
+const modelBudget = 8
+
+// modelFamilies is the alias table: the model families we know how to name.
+// Matching is case-insensitive. The value is the canonical casing to render.
+//
+// Order matters only for readability; the tokens are mutually exclusive.
+var modelFamilies = map[string]string{
+	"opus":   "Opus",
+	"sonnet": "Sonnet",
+	"haiku":  "Haiku",
+	"gemini": "Gemini",
+	"gpt":    "GPT",
+}
+
 // shortenModelName returns a compact label for a model display name.
-//  1. If ≤ 8 chars, return as-is.
-//  2. Return the last whitespace-delimited word.
-//  3. Truncate to 8 chars.
+//
+// # The bug this replaces
+//
+// The shipped implementation returned the LAST whitespace-delimited word. For
+// the actual display name Claude Code sends —
+//
+//	"Claude Opus 4.8 (1M context)"
+//
+// — that word is "context)". The live status line read `🤖 context) 🧠 42%`: a
+// stray parenthesis fragment where the model name should be. The rule was never
+// right; it merely happened to look right for the two-word names it was written
+// against ("Opus 4.7" → "4.7" is already wrong, just less visibly).
+//
+// It also cut with `name[:8]` — a BYTE slice, which splits a multi-byte rune and
+// emits U+FFFD.
+//
+// # The rule now
+//
+//  1. Already within budget → return unchanged.
+//  2. ALIAS TABLE: find the family token (Opus/Sonnet/Haiku/Gemini/GPT), and keep
+//     it together with the version token that follows it → "Opus 4.8".
+//  3. Otherwise fall back to the FIRST meaningful token — the head of the name,
+//     which is where a name's identity lives, not the tail.
+//  4. Cut to budget grapheme-safely, never mid-rune.
 func shortenModelName(name string) string {
-	if len(name) <= 8 {
+	if name == "" {
+		return ""
+	}
+
+	// 2. The alias table. When it hits, its answer is already the shortest HONEST
+	//    name — no budget cut is applied on top, because "Sonnet 4.5" truncated to
+	//    8 columns ("Sonnet …") is worse than the two extra columns it costs.
+	if c := canonicalModelName(name); c != name {
+		return c
+	}
+
+	// 1. Already within budget → unchanged.
+	if term.DisplayWidth(name) <= modelBudget {
 		return name
 	}
-	parts := strings.Fields(name)
-	if len(parts) > 0 {
-		last := parts[len(parts)-1]
-		if last != name {
-			return last
+
+	tokens := strings.Fields(name)
+
+	// 3. The first MEANINGFUL token.
+	for _, tok := range tokens {
+		if isMeaningfulToken(tok) {
+			return truncateText(trimTokenPunct(tok), modelBudget)
 		}
 	}
-	return name[:8]
+
+	// 4. No meaningful token (e.g. a single unbroken string): rune-safe cut.
+	return truncateText(name, modelBudget)
+}
+
+// isMeaningfulToken reports whether tok can stand in as the model's name.
+//
+// A PARENTHESIZED token is decoration, not identity — "(beta)", "(1M", "(fast)".
+// So is a token with no letters in it (a bare version number is a qualifier of a
+// name, not a name). Treating decoration as identity is precisely the mistake
+// that rendered "context)" as a model name; the fallback must not repeat it in a
+// different costume.
+func isMeaningfulToken(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	switch []rune(tok)[0] {
+	case '(', '[', '{':
+		return false
+	}
+	for _, r := range trimTokenPunct(tok) {
+		if unicode.IsLetter(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// canonicalModelName is the model's name with the vendor prefix and the trailing
+// marketing/context parenthetical removed:
+//
+//	"Claude Opus 4.8 (1M context)" → "Opus 4.8"
+//	"Gemini 2.5 Pro"               → "Gemini 2.5"
+//
+// It looks up the family token in the alias table and keeps it together with the
+// version token that follows.
+//
+// A name whose family we do NOT recognise is returned UNCHANGED. We normalise
+// what we understand and refuse to guess at what we do not — mangling an unknown
+// vendor's name is how the status line ends up lying about which model is
+// answering, which is the one thing this segment exists to tell the truth about.
+func canonicalModelName(name string) string {
+	tokens := strings.Fields(name)
+	for i, tok := range tokens {
+		family, ok := modelFamilies[strings.ToLower(trimTokenPunct(tok))]
+		if !ok {
+			continue
+		}
+		if i+1 < len(tokens) {
+			if v := trimTokenPunct(tokens[i+1]); isVersionToken(v) {
+				return family + " " + v
+			}
+		}
+		return family
+	}
+	return name
+}
+
+// trimTokenPunct strips surrounding punctuation from a token — "(1M" → "1M",
+// "context)" → "context" — so the alias table and the version test see the word
+// rather than the typography around it.
+func trimTokenPunct(tok string) string {
+	return strings.TrimFunc(tok, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+}
+
+// isVersionToken reports whether tok looks like a model version — it starts with
+// a digit ("4.8", "2.5", "5"). Anything else after the family name (a marketing
+// word like "Pro" or "Turbo", or a parenthetical) is not the version.
+func isVersionToken(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	return unicode.IsDigit([]rune(tok)[0])
 }

--- a/sdk/gsl/internal/render/seg_ai_data_test.go
+++ b/sdk/gsl/internal/render/seg_ai_data_test.go
@@ -1,0 +1,100 @@
+package render
+
+// seg_ai_data_test.go — spec gsl-ultra E7 (feature F4: the model name).
+//
+// The live repro, captured on 2026-07-11 from a real Claude Code session:
+//
+//	🤖 context) 🧠 42%
+//
+// shortenModelName returned the LAST whitespace-delimited word of the display
+// name. For "Claude Opus 4.8 (1M context)" that word is the literal string
+// "context)" — a parenthesis fragment rendered as the model's name.
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/term"
+)
+
+// utf8ValidString is a readability alias used by the rune-safety assertions.
+func utf8ValidString(s string) bool { return utf8.ValidString(s) }
+
+func TestShortenModelName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// ── the live repro (E7) ──────────────────────────────────────────────
+		{"live repro: opus with parenthetical", "Claude Opus 4.8 (1M context)", "Opus 4.8"},
+
+		// ── the alias table: family + version ────────────────────────────────
+		{"sonnet", "Claude Sonnet 4.5", "Sonnet 4.5"},
+		{"haiku with parenthetical", "Claude Haiku 4.5 (fast)", "Haiku 4.5"},
+		{"gemini", "Gemini 2.5 Pro", "Gemini 2.5"},
+		{"gpt", "OpenAI GPT 5.2 Turbo", "GPT 5.2"},
+		{"case insensitive", "claude opus 4.8 (1m context)", "Opus 4.8"},
+		{"family with no version", "Claude Opus (preview)", "Opus"},
+
+		// ── short names pass through untouched ───────────────────────────────
+		{"already short", "Opus 4.7", "Opus 4.7"},
+		{"very short", "gpt-4", "gpt-4"},
+		{"empty", "", ""},
+
+		// ── fallback: the FIRST meaningful token, never the trailing junk ────
+		{"unknown family", "Mystery Model Nine Thousand", "Mystery"},
+		{"unknown family, leading punctuation", "(beta) Zephyrus Ultra", "Zephyrus"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shortenModelName(tc.in)
+			if got != tc.want {
+				t.Errorf("shortenModelName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShortenModelName_NeverTrailingParenthetical is the regression assertion
+// stated as the defect itself: whatever else changes, the shortened name must
+// never be the trailing parenthetical fragment.
+func TestShortenModelName_NeverTrailingParenthetical(t *testing.T) {
+	for _, in := range []string{
+		"Claude Opus 4.8 (1M context)",
+		"Claude Sonnet 4.5 (200k context)",
+		"Some Model (experimental)",
+	} {
+		got := shortenModelName(in)
+		if strings.Contains(got, ")") || strings.Contains(got, "(") {
+			t.Errorf("shortenModelName(%q) = %q — must never be a parenthetical fragment", in, got)
+		}
+		if got == "context)" {
+			t.Errorf("shortenModelName(%q) = %q — THE live bug", in, got)
+		}
+	}
+}
+
+// TestShortenModelName_RuneSafe proves the fallback prefix-cut never splits a
+// multi-byte rune. The shipped code did `name[:8]`, a BYTE slice, which cuts a
+// 3-byte CJK rune in half and emits replacement characters.
+func TestShortenModelName_RuneSafe(t *testing.T) {
+	for _, in := range []string{
+		"模型名称非常长的一个中文模型",               // CJK: every rune is 3 bytes / 2 columns
+		"Модель Очень Длинная Русская", // Cyrillic: 2 bytes per rune
+		"🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀",                   // emoji: 4 bytes per rune
+	} {
+		got := shortenModelName(in)
+		if !utf8ValidString(got) {
+			t.Errorf("shortenModelName(%q) = %q — not valid UTF-8 (byte-sliced a rune)", in, got)
+		}
+		if strings.ContainsRune(got, '�') {
+			t.Errorf("shortenModelName(%q) = %q — contains U+FFFD (split a rune)", in, got)
+		}
+		if w := term.DisplayWidth(got); w > 8 {
+			t.Errorf("shortenModelName(%q) = %q — display width %d exceeds the 8-column budget", in, got, w)
+		}
+	}
+}

--- a/sdk/gsl/internal/render/seg_dirgit.go
+++ b/sdk/gsl/internal/render/seg_dirgit.go
@@ -23,6 +23,10 @@ type DirGitSegment struct {
 	Cwd string
 	// Git is the injected git.Runner used for git.Status.
 	Git git.Runner
+	// Priority is the DROP priority used by the fit loop (config.Segment.Priority,
+	// or the built-in default for this type when unset). It is independent of the
+	// segment's position in the line.
+	Priority int
 	// home overrides $HOME for ~-abbreviation (tests). Empty → os.UserHomeDir.
 	home string
 }

--- a/sdk/gsl/internal/render/seg_dirgit_data.go
+++ b/sdk/gsl/internal/render/seg_dirgit_data.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/git"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/style"
 )
@@ -28,6 +29,16 @@ type dirGitData struct {
 	gitInfo *git.Info
 	// hasGit is true when gitInfo was populated.
 	hasGit bool
+	// prio is the drop priority (config.Segment.EffectivePriority).
+	prio int
+}
+
+// priority implements prioritized.
+func (d *dirGitData) priority() int {
+	if d.prio != 0 {
+		return d.prio
+	}
+	return config.PriorityDirGit
 }
 
 // detect implements detectable for DirGitSegment. Runs git.Status once.
@@ -49,7 +60,7 @@ func (s *DirGitSegment) detect(ctx context.Context) (segmentData, bool) {
 		}
 	}
 
-	d := &dirGitData{cwd: cwd, home: home}
+	d := &dirGitData{cwd: cwd, home: home, prio: s.Priority}
 
 	if s.Git != nil {
 		if info, err := git.Status(ctx, s.Git, cwd); err == nil {

--- a/sdk/gsl/internal/render/seg_repo.go
+++ b/sdk/gsl/internal/render/seg_repo.go
@@ -42,6 +42,11 @@ type RepoSegment struct {
 	ShowPR    bool   // default true
 	ShowCount bool   // default true
 	NameMode  string // "feature" | "worker" | "branch" | "off"; default "feature"
+
+	// Priority is the DROP priority used by the fit loop (config.Segment.Priority,
+	// or the built-in default for this type when unset). It is independent of the
+	// segment's position in the line.
+	Priority int
 }
 
 // NewRepoSegment builds a RepoSegment, applying option defaults from opts.
@@ -171,7 +176,14 @@ func workerLabel(branch string) string {
 // background block. The single trailing ansiReset for the whole segment is
 // owned by paint(), NOT by this helper.
 func prBadge(st style.Style, number int, state string) string {
-	text := "PR#" + strconv.Itoa(number)
+	return prBadgeWithPrefix(st, "PR#", number, state)
+}
+
+// prBadgeWithPrefix is prBadge with a caller-chosen prefix, so the compaction
+// ladder can shrink "PR#157" to "#157" at deeper levels without duplicating the
+// state-tinting logic.
+func prBadgeWithPrefix(st style.Style, prefix string, number int, state string) string {
+	text := prefix + strconv.Itoa(number)
 	var colorKey string
 	switch strings.ToUpper(state) {
 	case "OPEN":

--- a/sdk/gsl/internal/render/seg_repo_data.go
+++ b/sdk/gsl/internal/render/seg_repo_data.go
@@ -2,17 +2,32 @@ package render
 
 // seg_repo_data.go — repoData segmentData + RepoSegment.detect().
 //
-// The repo segment has no per-level compaction in Phase 2 (it's a "repo extra"
-// that is dropped whole in the final tier). detect() captures all the data;
-// format() renders the same content at all levels 0-3.
+// Compaction levels for the repo segment:
+//
+//	level 0: <glyph> <label> PR#157 ⑂4
+//	level 1: drop the worktree-count badge   → <glyph> <label> PR#157
+//	level 2: shorten the PR badge            → <glyph> <label> #157
+//	level 3: ellipsize the repo label        → <glyph> <lab…> #157
+//
+// Until now repoData's format signature was `format(st style.Style, _ int)` — it
+// DISCARDED the level. Its width was therefore flat (~13-44 columns depending on
+// the repo name) at every level of the ladder, which meant the repo segment never
+// contributed a single column to compaction. Fit had to reach the segment-drop
+// tier to shed any width at all, so a long repo name deleted whole segments from
+// the line that a few characters of compaction would have saved.
 
 import (
 	"context"
 	"strings"
 
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/repo"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/style"
 )
+
+// repoLabelBudget is the display-width cap applied to the repo label at the
+// deepest compaction level.
+const repoLabelBudget = 10
 
 // repoData is the detect-once intermediate for the repo segment.
 type repoData struct {
@@ -30,6 +45,18 @@ type repoData struct {
 	// showPR / showCount mirror the segment options.
 	showPR    bool
 	showCount bool
+	// prio is the drop priority (config.Segment.EffectivePriority).
+	prio int
+}
+
+// priority implements prioritized. The repo/PR you are working in is the last
+// thing worth losing from a narrow line — it is the fact that is NOT recoverable
+// from anywhere else on screen.
+func (d *repoData) priority() int {
+	if d.prio != 0 {
+		return d.prio
+	}
+	return config.PriorityRepo
 }
 
 // detect implements detectable for RepoSegment. Runs repo.Locate + repo.PR once.
@@ -62,6 +89,7 @@ func (s *RepoSegment) detect(ctx context.Context) (segmentData, bool) {
 		label:        s.nameLabel(info),
 		showPR:       s.ShowPR,
 		showCount:    s.ShowCount,
+		prio:         s.Priority,
 		worktreeCount: func() int {
 			if s.ShowCount && loc.WorktreeCount >= 2 {
 				return loc.WorktreeCount
@@ -79,30 +107,47 @@ func (s *RepoSegment) detect(ctx context.Context) (segmentData, bool) {
 }
 
 // format implements segmentData.format for repoData. Pure; no I/O.
-// The repo segment has no per-level text compaction in Phase 2 (it is dropped
-// whole by the final tier if needed).
-func (d *repoData) format(st style.Style, _ int) (text, colorKey string) {
+//
+// Width is monotonically non-increasing in level (spec E5): each level removes
+// or shortens exactly one element and never adds one back.
+func (d *repoData) format(st style.Style, level int) (text, colorKey string) {
 	var b strings.Builder
 
 	if g := glyph(st, d.indicatorKey); g != "" {
 		b.WriteString(g)
 	}
 
+	// Label. Level 3+ ellipsizes it — grapheme-safely, so a CJK or emoji repo
+	// name is cut on a cluster boundary and its true display width is respected.
 	if d.label != "" {
-		if b.Len() > 0 {
-			b.WriteString(" ")
+		label := d.label
+		if level >= 3 {
+			label = truncateText(label, repoLabelBudget)
 		}
-		b.WriteString(d.label)
+		if label != "" {
+			if b.Len() > 0 {
+				b.WriteString(" ")
+			}
+			b.WriteString(label)
+		}
 	}
 
+	// PR badge. Level 2+ drops the redundant "PR" prefix: in a status line whose
+	// segment is already the repo, "#157" is unambiguous.
 	if d.showPR && d.prNumber > 0 {
+		prefix := "PR#"
+		if level >= 2 {
+			prefix = "#"
+		}
 		if b.Len() > 0 {
 			b.WriteString(" ")
 		}
-		b.WriteString(prBadge(st, d.prNumber, d.prState))
+		b.WriteString(prBadgeWithPrefix(st, prefix, d.prNumber, d.prState))
 	}
 
-	if d.showCount && d.worktreeCount >= 2 {
+	// Worktree-count badge: the first thing to go. It is a nice-to-have, and the
+	// worktree GLYPH already tells you that you are in a linked worktree.
+	if level < 1 && d.showCount && d.worktreeCount >= 2 {
 		if b.Len() > 0 {
 			b.WriteString(" ")
 		}

--- a/sdk/gsl/internal/render/seg_time.go
+++ b/sdk/gsl/internal/render/seg_time.go
@@ -26,6 +26,10 @@ type TimeSegment struct {
 	TimeFormat string
 	// DateFormat is the Go layout for the date (default "Mon 01-02").
 	DateFormat string
+	// Priority is the DROP priority used by the fit loop (config.Segment.Priority,
+	// or the built-in default for this type when unset). It is independent of the
+	// segment's position in the line.
+	Priority int
 }
 
 // NewTimeSegment builds a TimeSegment from config values. now may be nil to use

--- a/sdk/gsl/internal/render/seg_time_data.go
+++ b/sdk/gsl/internal/render/seg_time_data.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/style"
 )
 
@@ -26,6 +27,17 @@ type timeData struct {
 	timeLayout string
 	// tz is the timezone abbreviation string (e.g. "UTC", "PST").
 	tz string
+	// prio is the drop priority (config.Segment.EffectivePriority).
+	prio int
+}
+
+// priority implements prioritized. The clock is the first thing to go: every
+// desktop environment already shows the time somewhere.
+func (d *timeData) priority() int {
+	if d.prio != 0 {
+		return d.prio
+	}
+	return config.PriorityTime
 }
 
 // detect implements detectable for TimeSegment. Captures the current time once.
@@ -58,6 +70,7 @@ func (s *TimeSegment) detect(_ context.Context) (segmentData, bool) {
 		dateLayout: dateLayout,
 		timeLayout: timeLayout,
 		tz:         t.Format("MST"),
+		prio:       s.Priority,
 	}, true
 }
 

--- a/sdk/gsl/internal/render/truncate.go
+++ b/sdk/gsl/internal/render/truncate.go
@@ -1,0 +1,168 @@
+package render
+
+// truncate.go — the last resort of the fit ladder, and the reason the width
+// invariant (spec E3) is a GUARANTEE rather than a hope.
+//
+// The shipped Fit had three tiers: escalate text-compaction levels, then drop
+// the leading glyphs, then drop whole segments. All three are BEST-EFFORT — each
+// makes the line smaller, none of them can make it small ENOUGH. The segment-drop
+// loop ran `for len(active) > 1`, so the final surviving segment was emitted
+// verbatim no matter how wide it was: a repo named "gsl-ultra-tui-mcp-status"
+// produced a 27-column line on a 20-column terminal, which wraps, which eats the
+// user's prompt line.
+//
+// Truncation is what closes that gap. It is the only tier whose output width is
+// bounded by construction rather than by luck.
+//
+// # Grapheme safety
+//
+// Cutting by BYTES splits a multi-byte rune into mojibake. Cutting by RUNES
+// splits a grapheme cluster — "👩‍🚀" is one user-perceived character built from
+// three runes joined by a zero-width joiner, and cutting it mid-sequence yields
+// two unrelated emoji. Cutting by grapheme cluster but COUNTING clusters gets the
+// width wrong: a CJK ideograph is one cluster occupying TWO terminal columns.
+//
+// So: iterate grapheme clusters (uniseg), accumulate DISPLAY WIDTH, and stop
+// before the budget is exceeded. That is the only formulation that is correct for
+// all three of ASCII, CJK, and ZWJ emoji simultaneously.
+
+import (
+	"strings"
+
+	"github.com/rivo/uniseg"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/style"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/term"
+)
+
+// ellipsis marks a string that was cut. U+2026 HORIZONTAL ELLIPSIS is a single
+// display column — the cheapest possible "there is more here" signal.
+const ellipsis = "…"
+
+// truncateText returns the longest grapheme-safe prefix of s whose display width
+// is at most cols, with an ellipsis appended when s was actually cut.
+//
+// Guarantees, for every input:
+//   - term.DisplayWidth(result) <= cols
+//   - result is valid UTF-8 and never splits a grapheme cluster
+//   - result is non-empty whenever cols >= 1 and s is non-empty
+//
+// s must be RAW text (no ANSI escapes) — see truncateToWidth, which strips first.
+func truncateText(s string, cols int) string {
+	if cols <= 0 || s == "" {
+		return ""
+	}
+	if term.DisplayWidth(s) <= cols {
+		return s
+	}
+	// One column of room: all we can say is "there was something here".
+	if cols == 1 {
+		return ellipsis
+	}
+
+	budget := cols - 1 // reserve one column for the ellipsis
+	var b strings.Builder
+	width := 0
+	g := uniseg.NewGraphemes(s)
+	for g.Next() {
+		cluster := g.Str()
+		cw := uniseg.StringWidth(cluster)
+		if width+cw > budget {
+			break
+		}
+		b.WriteString(cluster)
+		width += cw
+	}
+	return b.String() + ellipsis
+}
+
+// joinOverhead returns the number of display columns that join() spends on
+// DECORATION for the given block count — padding, separators, and powerline
+// chevrons — i.e. everything that is not segment text.
+//
+// It is measured, not assumed, because the two join paths (powerline-with-fill
+// vs the classic separator path) have different per-block costs and a style can
+// disable the chevron glyph entirely. Measuring the real join keeps this correct
+// even if the join layer changes.
+//
+// The overhead depends only on the NUMBER of blocks, not on their text, so it is
+// still valid after the text has been truncated.
+func joinOverhead(st style.Style, blocks []segmentBlock) int {
+	if len(blocks) == 0 {
+		return 0
+	}
+	total := term.DisplayWidth(join(st, blocks))
+	for _, b := range blocks {
+		total -= term.DisplayWidth(b.text)
+	}
+	if total < 0 {
+		return 0
+	}
+	return total
+}
+
+// truncateToWidth shortens blocks so that join(st, result) fits within cols.
+//
+// It is the frozen §3 contract: pure, grapheme-safe, and it never touches I/O.
+//
+// Returns nil when the decoration alone (padding + separators + chevrons) is
+// already wider than cols — i.e. when NO decorated line can fit, however empty.
+// A nil return is the caller's signal to fall back to an undecorated line; it is
+// not an error.
+func truncateToWidth(blocks []segmentBlock, st style.Style, cols int) []segmentBlock {
+	if len(blocks) == 0 || cols <= 0 {
+		return nil
+	}
+	// Fast path: it already fits, so leave the styling entirely alone.
+	if term.DisplayWidth(join(st, blocks)) <= cols {
+		return blocks
+	}
+
+	// Strip ANSI before cutting. A block's text is supposed to be raw (the
+	// segment.go:12 invariant), but prBadge currently embeds an SGR tint — and a
+	// cut that lands inside "\x1b[38;5;2m" would spray "38;5;2m" onto the line.
+	// The join layer re-applies the block's colour anyway, so nothing visible is
+	// lost by dropping the sub-field tint in this last-resort path.
+	work := make([]segmentBlock, len(blocks))
+	for i, b := range blocks {
+		work[i] = segmentBlock{text: term.StripANSI(b.text), colorKey: b.colorKey}
+	}
+
+	// Shed trailing blocks until the decoration leaves at least one column for
+	// text. (Fit normally hands us a single survivor, but truncateToWidth must be
+	// correct for any block count.)
+	for len(work) > 1 && joinOverhead(st, work) >= cols {
+		work = work[:len(work)-1]
+	}
+	budget := cols - joinOverhead(st, work)
+	if budget <= 0 {
+		return nil
+	}
+
+	// Spend the budget left to right. A block that cannot get at least one column
+	// is dropped; the block that runs out of budget mid-way is ellipsized.
+	//
+	// Dropping blocks here only REDUCES the decoration overhead below what
+	// `budget` was computed against, so the result is never wider than cols.
+	out := make([]segmentBlock, 0, len(work))
+	remaining := budget
+	for _, b := range work {
+		w := term.DisplayWidth(b.text)
+		if w <= remaining {
+			out = append(out, b)
+			remaining -= w
+			continue
+		}
+		if remaining >= 1 {
+			out = append(out, segmentBlock{
+				text:     truncateText(b.text, remaining),
+				colorKey: b.colorKey,
+			})
+		}
+		break
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/sdk/gsl/internal/render/truncate_test.go
+++ b/sdk/gsl/internal/render/truncate_test.go
@@ -1,0 +1,164 @@
+package render
+
+// truncate_test.go — unit tests for the truncation tier (spec E3's guarantee).
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/term"
+)
+
+func TestTruncateText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		cols int
+		want string
+	}{
+		{"fits exactly", "hello", 5, "hello"},
+		{"fits with room", "hello", 20, "hello"},
+		{"cut ascii", "hello world", 8, "hello w…"},
+		{"one column", "hello", 1, "…"},
+		{"zero columns", "hello", 0, ""},
+		{"negative columns", "hello", -3, ""},
+		{"empty input", "", 10, ""},
+		// A CJK ideograph is ONE grapheme occupying TWO columns. A rune-count cut
+		// would fit 4 of them in a 5-column budget; a column-count cut fits 2 plus
+		// the ellipsis.
+		{"cjk is two columns per rune", "文档目录内容", 5, "文档…"},
+		{"cjk exact", "文档", 4, "文档"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateText(tc.in, tc.cols)
+			if got != tc.want {
+				t.Errorf("truncateText(%q, %d) = %q, want %q", tc.in, tc.cols, got, tc.want)
+			}
+			if w := term.DisplayWidth(got); w > tc.cols && tc.cols > 0 {
+				t.Errorf("truncateText(%q, %d) = %q has width %d > %d", tc.in, tc.cols, got, w, tc.cols)
+			}
+		})
+	}
+}
+
+// TestTruncateText_NeverExceedsWidth sweeps every budget over inputs whose
+// grapheme clusters are hostile to naive cutting.
+func TestTruncateText_NeverExceedsWidth(t *testing.T) {
+	inputs := []string{
+		"plain-ascii-repository-name",
+		"文档目录内容非常长的中文路径",         // 2 cols/rune, 3 bytes/rune
+		"feat/🚀-launch-👩‍🚀-crew", // ZWJ cluster: 1 grapheme, many runes
+		"Ünïcödé-áccèntéd-repo",  // combining-capable Latin
+		"🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀",           // all wide emoji
+	}
+	for _, in := range inputs {
+		for cols := 1; cols <= 40; cols++ {
+			got := truncateText(in, cols)
+			if w := term.DisplayWidth(got); w > cols {
+				t.Fatalf("truncateText(%q, %d) = %q → width %d > %d", in, cols, got, w, cols)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("truncateText(%q, %d) = %q → invalid UTF-8", in, cols, got)
+			}
+			if strings.ContainsRune(got, '�') {
+				t.Fatalf("truncateText(%q, %d) = %q → contains U+FFFD (split a rune)", in, cols, got)
+			}
+			if got == "" {
+				t.Fatalf("truncateText(%q, %d) = \"\" → must never delete the content entirely", in, cols)
+			}
+		}
+	}
+}
+
+// TestTruncateText_DoesNotSplitZWJCluster proves the ZWJ astronaut survives or
+// disappears WHOLE — it is never cut into its constituent emoji.
+func TestTruncateText_DoesNotSplitZWJCluster(t *testing.T) {
+	const astronaut = "👩‍🚀" // U+1F469 U+200D U+1F680 — one grapheme cluster
+	in := "ab" + astronaut + "cd"
+
+	for cols := 1; cols <= term.DisplayWidth(in); cols++ {
+		got := truncateText(in, cols)
+		// The cluster's PARTS must never appear without the whole cluster.
+		hasWhole := strings.Contains(got, astronaut)
+		hasWoman := strings.Contains(got, "\U0001F469")
+		if hasWoman && !hasWhole {
+			t.Fatalf("cols=%d: truncateText split the ZWJ cluster: %q", cols, got)
+		}
+		if strings.HasSuffix(got, "‍") {
+			t.Fatalf("cols=%d: truncateText left a dangling ZWJ: %q", cols, got)
+		}
+	}
+}
+
+func TestTruncateToWidth(t *testing.T) {
+	st := emojiStyleFixture() // Separator "thin", Fill false → 3-column separator
+
+	blocks := []segmentBlock{
+		{text: "dotfiles", colorKey: "dirgit"},
+		{text: "gsl-ultra", colorKey: "repo_root"},
+	}
+
+	t.Run("already fits: returned untouched", func(t *testing.T) {
+		got := truncateToWidth(blocks, st, 100)
+		if len(got) != 2 || got[0].text != "dotfiles" || got[1].text != "gsl-ultra" {
+			t.Errorf("want blocks unchanged, got %+v", got)
+		}
+	})
+
+	t.Run("narrow: joined result fits", func(t *testing.T) {
+		for cols := 1; cols <= 40; cols++ {
+			got := truncateToWidth(blocks, st, cols)
+			if len(got) == 0 {
+				continue // decoration alone cannot fit; caller falls back
+			}
+			if w := term.DisplayWidth(join(st, got)); w > cols {
+				t.Fatalf("cols=%d: joined truncation width %d > %d (%q)", cols, w, cols, join(st, got))
+			}
+		}
+	})
+
+	t.Run("empty input and non-positive cols", func(t *testing.T) {
+		if got := truncateToWidth(nil, st, 20); got != nil {
+			t.Errorf("nil blocks: want nil, got %+v", got)
+		}
+		if got := truncateToWidth(blocks, st, 0); got != nil {
+			t.Errorf("cols=0: want nil, got %+v", got)
+		}
+	})
+
+	t.Run("strips embedded ANSI before cutting", func(t *testing.T) {
+		// prBadge embeds an SGR tint inside the segment text. A byte-cut landing
+		// inside "\x1b[38;5;2m" would spray "8;5;2m" onto the line.
+		painted := []segmentBlock{{text: "repo \x1b[38;5;2mPR#157\x1b[0m", colorKey: "repo_root"}}
+		got := truncateToWidth(painted, st, 8)
+		if len(got) != 1 {
+			t.Fatalf("want 1 block, got %d", len(got))
+		}
+		if strings.Contains(got[0].text, "\x1b") {
+			t.Errorf("truncated text still carries an escape byte: %q", got[0].text)
+		}
+		if strings.Contains(got[0].text, "38;5;2") {
+			t.Errorf("truncated text leaked an escape body as literal text: %q", got[0].text)
+		}
+	})
+}
+
+func TestJoinOverhead(t *testing.T) {
+	// Overhead must depend only on the block COUNT, not on the text — otherwise
+	// the budget computed before truncation is wrong after it, and the width
+	// invariant becomes an accident rather than a guarantee.
+	for name, st := range fitStyles() {
+		t.Run(name, func(t *testing.T) {
+			short := []segmentBlock{{text: "a", colorKey: "dirgit"}, {text: "b", colorKey: "repo_root"}}
+			long := []segmentBlock{{text: "aaaaaaaaaaaa", colorKey: "dirgit"}, {text: "bbbbbbbb", colorKey: "repo_root"}}
+			if o1, o2 := joinOverhead(st, short), joinOverhead(st, long); o1 != o2 {
+				t.Errorf("overhead depends on text: %d (short) != %d (long)", o1, o2)
+			}
+			if got := joinOverhead(st, nil); got != 0 {
+				t.Errorf("joinOverhead(nil) = %d, want 0", got)
+			}
+		})
+	}
+}

--- a/sdk/gsl/internal/term/width.go
+++ b/sdk/gsl/internal/term/width.go
@@ -32,6 +32,22 @@ import (
 
 // Columns resolves the current terminal column count.
 //
+// Deprecated: Columns implements the SUPERSEDED resolution order and must not be
+// used on any new path. Use cmd.resolveColumns (spec F1) instead, which resolves
+// payload.terminal_width → ioctl(stdout) → ioctl(stderr) → $COLUMNS →
+// cfg.FallbackColumns and reports which source won.
+//
+// Two defects are preserved here only because internal/preview still calls this
+// for its pre-WindowSizeMsg first frame:
+//
+//   - $COLUMNS is ranked ABOVE the ioctl probes. It is a shell variable that is
+//     not exported to child processes, so in practice it is absent — but when a
+//     user DOES export it, it wrongly overrides the real terminal width.
+//   - There is no ioctl(stderr) probe, and the hard fallback is 80. Claude Code
+//     pipes stdout, so this function returns 80 on a 200-column terminal. That is
+//     precisely the bug the width leaf exists to fix; do not reintroduce it by
+//     reaching for this helper.
+//
 // Resolution order:
 //  1. $COLUMNS environment variable (if set and parses as a positive integer).
 //  2. The injected source (production: wraps ioctl TIOCGWINSZ on stdout).
@@ -74,6 +90,33 @@ func StdoutWidthSource() func() (int, bool) {
 		return w, true
 	}
 }
+
+// StderrWidthSource returns an ioctl width source for os.Stderr.
+//
+// This is the source that makes gsl work under Claude Code. Claude invokes the
+// status-line command with stdout attached to a PIPE (it captures the line), so
+// the stdout ioctl always fails — but it leaves stderr attached to the real
+// terminal. Probing stderr is therefore a free, accurate read of the user's
+// actual terminal width in exactly the case where every other source is blind.
+//
+// Returns (0, false) when stderr is not a TTY or GetSize fails.
+func StderrWidthSource() func() (int, bool) {
+	return func() (int, bool) {
+		w, _, err := cxterm.GetSize(os.Stderr.Fd())
+		if err != nil || w <= 0 {
+			return 0, false
+		}
+		return w, true
+	}
+}
+
+// StripANSI removes ANSI SGR escape sequences from s, returning the raw text.
+//
+// Truncation must operate on raw text: cutting a string mid-escape-sequence
+// emits the sequence's tail as literal garbage. Callers that need to shorten a
+// possibly-painted string strip first, cut second, and let the paint layer
+// re-apply the colour.
+func StripANSI(s string) string { return ansiStripper(s) }
 
 // ansiStripper removes ANSI SGR escape sequences (ESC [ ... m) from s.
 // It handles only the SGR form this codebase emits; other OSC / DEC sequences


### PR DESCRIPTION
**WS1 / `width` leaf.** Fixes the headline defect "the line is always 80 columns" and everything downstream of it — the width is now resolved from real signals and the rendered line actually fits it:

- `cmd/columns.go` — `resolveColumns` with the F1 precedence: `payload.terminal_width` → `ioctl(stdout)` → `ioctl(stderr)` → `$COLUMNS` → `cfg.FallbackColumns` (120); returns `source` for the log (E1, E2)
- `render/detect.go` + `render/truncate.go` — `Fit` gets an explicit priority drop order and a final grapheme-safe truncation pass, so `Fit(20)` can no longer return a 27–33-col line (E3, E4, E6)
- `render/seg_repo_data.go` — repo segment honours compaction `level` (drop worktree count → short ref → ellipsize) instead of rendering flat across levels (E5)
- `render/seg_ai_data.go` — `shortenModelName` alias table, rune-safe; kills the `context)` model-name render (E7)
- `render/fit_property_test.go` — the width invariant as a **property test** (~1150 cases) + level monotonicity, per the plan's must-fix

**Gate (P1 done-when):** full `go test ./...` green ✅ (property suite included) — verified 2026-07-26 after restacking onto the rebased iface (#161).

<!-- gss:stack-begin -->
## Stack — gsl-ultra (#158)

- #159 — design (base: `main`) — MBO design/spec/plan docs
- #161 — iface (base: `main`) — frozen §3 interfaces (P0, blocking)
- #165 — width (base: `iface`) ∥ #166 — latency (base: `iface`) ∥ #167 — agy (base: `iface`)
- *(not started)* mcp → style → tui (plan §6.2)

Landing order: `iface` → (`width` ∥ `latency` ∥ `agy`) → `mcp` → `style` → `tui`. Review bottom-up; merge bottom-up.
<!-- gss:stack-end -->
