### PR TITLE
gsl-ultra: latency

### DIFF
--- a/sdk/gsl/cmd/degraded_test.go
+++ b/sdk/gsl/cmd/degraded_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+// degraded_test.go — E24 / UC-7.
+//
+// gsl is invoked on EVERY assistant turn. A panic or a stack trace on stdout
+// would be pasted straight into the user's status line, and a non-zero exit
+// would make the host disable the status line entirely. So the four hostile
+// environments below must each yield: exit 0, no panic, no stack trace.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
+)
+
+// withStdin points os.Stdin at a file containing s for the duration of f.
+func withStdin(t *testing.T, s string, f func()) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "stdin")
+	if err := os.WriteFile(path, []byte(s), 0o600); err != nil {
+		t.Fatalf("write stdin fixture: %v", err)
+	}
+	fh, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open stdin fixture: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = fh
+	defer func() { os.Stdin = orig; _ = fh.Close() }()
+	f()
+}
+
+// assertNoPanicOutput fails when out looks like a Go panic / stack trace.
+func assertNoPanicOutput(t *testing.T, label, out string) {
+	t.Helper()
+	for _, needle := range []string{"panic:", "goroutine ", "runtime error", ".go:"} {
+		if strings.Contains(out, needle) {
+			t.Errorf("%s: stdout contains %q — gsl leaked a panic/stack trace into the "+
+				"status line (E24/UC-7). stdout:\n%s", label, needle, out)
+		}
+	}
+}
+
+// TestDegradedPaths is E24: each hostile environment, exercised independently.
+func TestDegradedPaths(t *testing.T) {
+	// A corrupt ~/.claude.json is the MCP-detect input; garbage must not
+	// propagate.  "$HOME unset" is its own subtest, so each case configures the
+	// environment it needs from scratch.
+	cases := []struct {
+		name  string
+		stdin string
+		// setup runs inside the subtest, after the shared temp-HOME wiring.
+		setup func(t *testing.T, home string)
+	}{
+		{
+			name:  "corrupt ~/.claude.json",
+			stdin: `{"cwd":"/tmp"}`,
+			setup: func(t *testing.T, home string) {
+				t.Helper()
+				corrupt := "{ this is not json ]]] \x00\xff"
+				if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(corrupt), 0o600); err != nil {
+					t.Fatalf("write corrupt .claude.json: %v", err)
+				}
+			},
+		},
+		{
+			name:  "not a git repo",
+			stdin: `{"cwd":"/tmp"}`,
+			setup: func(t *testing.T, _ string) {
+				t.Helper()
+				// A bare temp dir: no .git anywhere up the tree we control.
+				t.Chdir(t.TempDir())
+			},
+		},
+		{
+			name:  "malformed stdin payload",
+			stdin: `{"model": 12345, "cwd": [1,2,3], "truncated`,
+			setup: func(t *testing.T, _ string) { t.Helper() },
+		},
+		{
+			name:  "$HOME unset",
+			stdin: `{"cwd":"/tmp"}`,
+			setup: func(t *testing.T, _ string) {
+				t.Helper()
+				t.Setenv("HOME", "")
+				t.Setenv("XDG_CONFIG_HOME", "")
+				t.Setenv("XDG_CACHE_HOME", "")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			// A segment panic is RECOVERED by Detect, so it never reaches stdout
+			// — which is precisely how a test stays green on a panicking path.
+			// Watch the log for it instead.
+			logPath := filepath.Join(home, "gsl.log")
+			t.Setenv("GSL_LOG_FILE", logPath)
+			t.Setenv("GSL_LOG_LEVEL", "error")
+			observe.ResetDefaultForTest()
+			t.Cleanup(observe.ResetDefaultForTest)
+			// Keep the render hermetic-ish and off the network: a scratch cache
+			// dir and a scratch config dir, and run from a non-repo cwd.
+			t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+			t.Chdir(t.TempDir())
+
+			if err := config.Save(config.DefaultPath(), config.Default()); err != nil {
+				t.Fatalf("setup: config.Save: %v", err)
+			}
+
+			tc.setup(t, home)
+
+			var out string
+			var runErr error
+			withStdin(t, tc.stdin, func() {
+				out = captureStdout(t, func() {
+					// A panic here fails the test outright — which is the point.
+					runErr = runRender(renderCmd, nil)
+				})
+			})
+
+			// Exit 0: RunE returning nil is what makes the process exit 0.
+			if runErr != nil {
+				t.Errorf("runRender returned %v; want nil (gsl must exit 0 on every "+
+					"degraded path — E24/UC-7)", runErr)
+			}
+			assertNoPanicOutput(t, tc.name, out)
+
+			// No segment may have panicked — even though the recover() would have
+			// hidden it from stdout.
+			if data, err := os.ReadFile(logPath); err == nil {
+				if strings.Contains(string(data), `"event":"segment.panic"`) {
+					t.Errorf("%s: a segment PANICKED (recovered, so invisible on stdout). log:\n%s",
+						tc.name, data)
+				}
+			}
+			if n := strings.Count(strings.TrimRight(out, "\n"), "\n"); n != 0 {
+				t.Errorf("%s: stdout has %d extra newlines; the status line must be a "+
+					"single line (or empty). stdout:\n%q", tc.name, n, out)
+			}
+		})
+	}
+}

--- a/sdk/gsl/cmd/statusline.go
+++ b/sdk/gsl/cmd/statusline.go
@@ -87,10 +87,20 @@ func runStatusLine(_ *cobra.Command, p payload.Payload, cwdHint string) error {
 		}
 	}
 
-	// Best-effort branch from git.Status.
+	// Git status, computed EXACTLY ONCE (WS3 / F12).
+	//
+	// The repo segment needs the branch before Detect starts (BuildSegments takes
+	// it as a construction arg), so this one call cannot be folded into the
+	// concurrent phase. What CAN go is the duplicate: DirGitSegment used to run
+	// git.Status a second time inside Detect, for 4 git execs where 2 suffice —
+	// and those two extra execs were spent inside the SHARED 1s context, draining
+	// the budget the concurrent segments were about to need. Threading the result
+	// through Deps.GitInfo makes the segment reuse it.
 	branch := ""
+	var gitInfo *git.Info
 	if cwd != "" {
 		if info, err := git.Status(ctx, gitRunner, cwd); err == nil {
+			gitInfo = &info
 			branch = info.Branch
 		}
 	}
@@ -107,6 +117,7 @@ func runStatusLine(_ *cobra.Command, p payload.Payload, cwdHint string) error {
 		Payload:      p,
 		Cwd:          cwd,
 		Branch:       branch,
+		GitInfo:      gitInfo,
 		RegistryPath: repo.DefaultRegistryPath(),
 		Git:          gitRunner,
 		GH:           ghRunner,

--- a/sdk/gsl/internal/exec/classify.go
+++ b/sdk/gsl/internal/exec/classify.go
@@ -1,0 +1,36 @@
+package exec
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// IsExpectedExit reports whether err is a ROUTINE non-zero exit from a command
+// that ran to completion and simply answered "no": `git status` outside a repo,
+// `gh pr view` on a branch with no PR, `claude mcp list` with no servers.
+//
+// It exists for one reason: log level. Those exits are the NORMAL case — a
+// session produced ~1.6k of them — and logging them at Warn buried the records
+// that actually matter (segment.panic) in noise. They belong at Debug.
+//
+// It is deliberately FALSE for everything that is not routine, so those keep
+// their Warn:
+//
+//   - a process we SIGKILLed on cancellation (ProcessState.ExitCode() == -1 for
+//     a signal death, so the ExitCode() > 0 test excludes it);
+//   - exec.ErrWaitDelay — the command exited but leaked an orphan holding the
+//     pipes, which is exactly the containment failure we are hunting;
+//   - a context deadline / cancellation;
+//   - a missing binary (*exec.Error), which is a real misconfiguration.
+func IsExpectedExit(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		return false
+	}
+	// ExitCode() is -1 when the process was terminated by a signal or has not
+	// exited — neither is a routine "the command answered no".
+	return ee.ExitCode() > 0
+}

--- a/sdk/gsl/internal/exec/classify_test.go
+++ b/sdk/gsl/internal/exec/classify_test.go
@@ -1,0 +1,120 @@
+package exec_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	gslexec "github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/exec"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
+)
+
+// TestIsExpectedExit_RoutineNonZeroExit — `git status` outside a repo, `gh pr
+// view` with no PR: the command ran and answered "no". Routine ⇒ Debug.
+func TestIsExpectedExit_RoutineNonZeroExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell")
+	}
+	err := exec.Command("/bin/sh", "-c", "exit 1").Run()
+	if err == nil {
+		t.Fatal("expected a non-zero exit")
+	}
+	if !gslexec.IsExpectedExit(err) {
+		t.Errorf("IsExpectedExit(exit 1) = false; want true (a routine non-zero exit is "+
+			"the NORMAL case on the hot path and must not be logged at Warn). err=%v", err)
+	}
+}
+
+// TestIsExpectedExit_Success / _Nil — no error is not an "expected exit".
+func TestIsExpectedExit_Nil(t *testing.T) {
+	if gslexec.IsExpectedExit(nil) {
+		t.Error("IsExpectedExit(nil) = true; want false")
+	}
+	if gslexec.IsExpectedExit(errors.New("some other error")) {
+		t.Error("IsExpectedExit(plain error) = true; want false")
+	}
+}
+
+// TestIsExpectedExit_SignalDeath is the load-bearing exclusion: a process WE
+// killed on cancellation must NOT be filed as a routine exit — that is the
+// timeout we are trying to make visible.
+func TestIsExpectedExit_SignalDeath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX signals")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "sleep 5")
+	gslexec.Harden(cmd)
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected an error from the cancelled command")
+	}
+	if gslexec.IsExpectedExit(err) {
+		t.Errorf("IsExpectedExit(signal death) = true; want false — a process killed by "+
+			"our own deadline is an operational failure (Warn), not a routine 'no' (Debug). err=%v", err)
+	}
+}
+
+// TestIsExpectedExit_MissingBinary — a missing gh/claude is a real
+// misconfiguration and stays at Warn.
+func TestIsExpectedExit_MissingBinary(t *testing.T) {
+	err := exec.Command("gsl-definitely-not-a-real-binary-xyz").Run()
+	if err == nil {
+		t.Fatal("expected a lookup error")
+	}
+	if gslexec.IsExpectedExit(err) {
+		t.Errorf("IsExpectedExit(missing binary) = true; want false. err=%v", err)
+	}
+}
+
+// TestLogSubprocessError_Levels pins the split end to end through the logger.
+func TestLogSubprocessError_Levels(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell")
+	}
+
+	read := func(t *testing.T, f func()) string {
+		t.Helper()
+		logPath := filepath.Join(t.TempDir(), "gsl.log")
+		t.Setenv("GSL_LOG_FILE", logPath)
+		t.Setenv("GSL_LOG_LEVEL", "debug")
+		observe.ResetDefaultForTest()
+		t.Cleanup(observe.ResetDefaultForTest)
+		f()
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			t.Fatalf("read log: %v", err)
+		}
+		return string(data)
+	}
+
+	t.Run("routine exit is debug", func(t *testing.T) {
+		err := exec.Command("/bin/sh", "-c", "exit 1").Run()
+		got := read(t, func() {
+			gslexec.LogSubprocessError("git", "git", []string{"status"}, err)
+		})
+		if !strings.Contains(got, `"event":"git.subprocess_error"`) {
+			t.Fatalf("missing event record: %s", got)
+		}
+		if !strings.Contains(got, `"level":"debug"`) {
+			t.Errorf("want level=debug for a routine non-zero exit; got: %s", got)
+		}
+	})
+
+	t.Run("real failure is warn", func(t *testing.T) {
+		got := read(t, func() {
+			gslexec.LogSubprocessError("gh", "gh", []string{"pr", "view"}, context.DeadlineExceeded)
+		})
+		if !strings.Contains(got, `"level":"warning"`) {
+			t.Errorf("want level=warning for a deadline; got: %s", got)
+		}
+	})
+}

--- a/sdk/gsl/internal/exec/log.go
+++ b/sdk/gsl/internal/exec/log.go
@@ -1,0 +1,31 @@
+package exec
+
+import (
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
+	"github.com/sirupsen/logrus"
+)
+
+// LogSubprocessError emits a seam's structured failure record at the level the
+// failure DESERVES. seam is "git" | "gh" | "mcp"; the event key is
+// "<seam>.subprocess_error", unchanged, so existing log consumers keep working.
+//
+// Why the level matters: a routine non-zero exit ("not a git repository", "no
+// pull requests found for branch") is the NORMAL case on a hot path that runs
+// on every assistant turn. Logged at Warn it produced ~1.6k records per session
+// and buried the handful of segment.panic entries that mean gsl is actually
+// broken. Routine exits are now Debug; genuine operational failures — a
+// timeout, a WaitDelay overrun from a leaked orphan, a missing binary — stay at
+// Warn. See IsExpectedExit for the exact split.
+func LogSubprocessError(seam, bin string, args []string, err error) {
+	entry := observe.Default().WithFields(logrus.Fields{
+		"event":   seam + ".subprocess_error",
+		"command": bin,
+		"args":    args,
+		"error":   err.Error(),
+	})
+	if IsExpectedExit(err) {
+		entry.Debug(seam + " subprocess exited non-zero (expected; degrading)")
+		return
+	}
+	entry.Warn(seam + " subprocess failed")
+}

--- a/sdk/gsl/internal/exec/procgroup.go
+++ b/sdk/gsl/internal/exec/procgroup.go
@@ -1,0 +1,78 @@
+// Package exec hardens *os/exec.Cmd against the two ways a subprocess defeats
+// a deadline. It is the shared helper behind the three seams (internal/git,
+// internal/gh, internal/mcp); it never RUNS a command itself — it only
+// configures one — so the seam gate in scripts/check-deps.sh still holds.
+//
+// # The bug this exists to fix (spec F12 / rule E18)
+//
+// The seams point cmd.Stdout at a *bytes.Buffer. os/exec cannot hand a
+// non-*os.File to the child, so it allocates an os.Pipe and copies from it in a
+// goroutine. Wait() then blocks until EVERY writer closes the write end — and
+// the child's own children INHERIT that write end.
+//
+// So a command that exits instantly but leaves a grandchild behind (the exact
+// shape of `claude mcp list`, which dials every server, and of `gh`, which forks
+// git) pins Wait() open for as long as the GRANDCHILD lives. Measured against an
+// 800 ms deadline, a 5 s grandchild made git.Run take 5004 ms and a 30 s
+// grandchild made it take 30006 ms: the context deadline was decorative.
+//
+// Cancelling the context did not help either, because os/exec's default Cancel
+// kills only the DIRECT child. The orphan lives on, still holding the pipe.
+//
+// # The fix
+//
+// Harden applies all three parts, which only work together:
+//
+//   - Setpgid — the child leads its own process group, so its descendants are
+//     addressable as a unit.
+//   - Cancel — on ctx cancellation, SIGKILL the whole GROUP (a negative pid),
+//     not just the direct child.
+//   - WaitDelay — bound the time Wait() will block on I/O pipes that an orphan
+//     we could not reach may still hold open. This is the backstop that makes
+//     the deadline unconditional.
+package exec
+
+import (
+	"os/exec"
+	"time"
+)
+
+// DefaultWaitDelay bounds how long Wait() may block on the child's I/O pipes
+// after the process has exited (or after the context was cancelled).
+//
+// 200 ms is deliberately far below the render budget: gsl runs on every
+// assistant turn, so the worst case a user can experience from an orphaned
+// grandchild is deadline + 200 ms, not deadline + <however long the orphan
+// feels like living>.
+const DefaultWaitDelay = 200 * time.Millisecond
+
+// Harden configures cmd for containment with DefaultWaitDelay.
+//
+// cmd MUST have been created with exec.CommandContext: os/exec rejects a Cancel
+// func on a command with no context ("exec: command with Cancel but no Context").
+// All three seams do exactly that.
+//
+// Harden is a no-op on a nil cmd.
+func Harden(cmd *exec.Cmd) { HardenWithDelay(cmd, DefaultWaitDelay) }
+
+// HardenWithDelay is Harden with an explicit WaitDelay. A zero or negative delay
+// restores the os/exec default (block on the pipes until EOF), which is exactly
+// the behaviour E18 exists to prevent — pass a positive delay.
+func HardenWithDelay(cmd *exec.Cmd, delay time.Duration) {
+	if cmd == nil {
+		return
+	}
+	setPgid(cmd)
+	if delay > 0 {
+		cmd.WaitDelay = delay
+	}
+	cmd.Cancel = func() error { return KillGroup(cmd) }
+}
+
+// KillGroup SIGKILLs the whole process group led by cmd's process — the child
+// AND every grandchild it spawned.
+//
+// It returns an error wrapping os.ErrProcessDone when there is nothing left to
+// kill; os/exec treats that as "the command already finished" and preserves the
+// command's real exit status instead of reporting a cancellation error.
+func KillGroup(cmd *exec.Cmd) error { return killGroup(cmd) }

--- a/sdk/gsl/internal/exec/procgroup_test.go
+++ b/sdk/gsl/internal/exec/procgroup_test.go
@@ -1,0 +1,114 @@
+package exec_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	gslexec "github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/exec"
+)
+
+// TestHarden_SetsWaitDelayAndCancel asserts the three knobs are actually set.
+// They only work together: Setpgid makes the group addressable, Cancel kills it,
+// WaitDelay is the backstop for an orphan we could not reach.
+func TestHarden_SetsWaitDelayAndCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "true")
+	gslexec.Harden(cmd)
+
+	if cmd.WaitDelay != gslexec.DefaultWaitDelay {
+		t.Errorf("WaitDelay = %v; want %v — without it, Wait() blocks on a pipe an "+
+			"orphaned grandchild still holds (E18)", cmd.WaitDelay, gslexec.DefaultWaitDelay)
+	}
+	if cmd.Cancel == nil {
+		t.Error("Cancel is nil; ctx cancellation would kill only the direct child")
+	}
+	if runtime.GOOS != "windows" {
+		if cmd.SysProcAttr == nil {
+			t.Fatal("SysProcAttr is nil; Setpgid was not applied and the grandchildren " +
+				"are in gsl's OWN process group — a negative-pid kill would signal gsl itself")
+		}
+	}
+}
+
+// TestHarden_NilCmd_NoPanic — a nil cmd is a no-op, not a crash.
+func TestHarden_NilCmd_NoPanic(t *testing.T) {
+	gslexec.Harden(nil)
+	gslexec.HardenWithDelay(nil, time.Second)
+}
+
+// TestHardenWithDelay_ZeroLeavesDefault documents that a non-positive delay does
+// NOT set WaitDelay (0 means "block until EOF", the very behaviour E18 forbids),
+// so a caller must pass a positive value to get the guarantee.
+func TestHardenWithDelay_ZeroLeavesDefault(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "true")
+	gslexec.HardenWithDelay(cmd, 0)
+	if cmd.WaitDelay != 0 {
+		t.Errorf("WaitDelay = %v; want 0 (unchanged)", cmd.WaitDelay)
+	}
+
+	cmd2 := exec.CommandContext(ctx, "/bin/sh", "-c", "true")
+	gslexec.HardenWithDelay(cmd2, 50*time.Millisecond)
+	if cmd2.WaitDelay != 50*time.Millisecond {
+		t.Errorf("WaitDelay = %v; want 50ms", cmd2.WaitDelay)
+	}
+}
+
+// TestKillGroup_NotStarted returns ErrProcessDone rather than panicking on a
+// command with no Process.
+func TestKillGroup_NotStarted(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "true")
+	if err := gslexec.KillGroup(cmd); !errors.Is(err, os.ErrProcessDone) {
+		t.Errorf("KillGroup(unstarted) = %v; want os.ErrProcessDone", err)
+	}
+	if err := gslexec.KillGroup(nil); !errors.Is(err, os.ErrProcessDone) {
+		t.Errorf("KillGroup(nil) = %v; want os.ErrProcessDone", err)
+	}
+}
+
+// TestKillGroup_KillsGrandchild is the mechanism test behind E18: the whole
+// process GROUP dies, not just the direct child.
+//
+// The grandchild sleeps 1s and then touches a marker. We kill the group ~100ms
+// in. If only the direct child (sh) were killed, the orphaned grandchild would
+// survive and create the marker.
+func TestKillGroup_KillsGrandchild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX process groups; Windows uses Job Objects (out of scope)")
+	}
+
+	marker := filepath.Join(t.TempDir(), "grandchild-survived")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c",
+		"( sleep 1; touch "+marker+" ) & sleep 30")
+	gslexec.Harden(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	if err := gslexec.KillGroup(cmd); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("KillGroup: %v", err)
+	}
+	_ = cmd.Wait()
+
+	// Well past the grandchild's 1s sleep: prove it is dead, not merely slow.
+	time.Sleep(1500 * time.Millisecond)
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatalf("the grandchild outlived the group kill and wrote %s — only the "+
+			"direct child was killed (E18/F12)", marker)
+	}
+}

--- a/sdk/gsl/internal/exec/procgroup_unix.go
+++ b/sdk/gsl/internal/exec/procgroup_unix.go
@@ -1,0 +1,61 @@
+//go:build !windows
+
+package exec
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// setPgid puts the child in a NEW process group whose leader is the child
+// itself, so its pid doubles as the group id. Without this, the child shares
+// gsl's own process group and a negative-pid kill would signal gsl (and, under
+// `go test`, the test binary) — which is why the group id must be established
+// at fork time and cannot be retrofitted after Start.
+func setPgid(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// killGroup SIGKILLs the process group led by cmd's process.
+//
+// kill(-pid) addresses the GROUP; kill(pid) would address only the direct
+// child and leave the grandchildren holding the stdout pipe — the bug (E18).
+//
+// SIGKILL, not SIGTERM: these are read-only probes (`git status`, `gh pr view`,
+// `claude mcp list`) with no cleanup worth waiting for, and a process that
+// ignores SIGTERM is precisely the one whose deadline we are enforcing.
+func killGroup(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	pid := cmd.Process.Pid
+	if pid <= 0 {
+		return os.ErrProcessDone
+	}
+
+	err := syscall.Kill(-pid, syscall.SIGKILL)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, syscall.ESRCH):
+		// The whole group is already gone — the command finished on its own.
+		// os/exec keys on os.ErrProcessDone to preserve the real exit status.
+		return os.ErrProcessDone
+	default:
+		// No group to signal (e.g. Setpgid was not applied because the platform
+		// refused it). Fall back to the direct child so cancellation still does
+		// SOMETHING; WaitDelay remains the backstop for the leaked pipe.
+		if kerr := cmd.Process.Kill(); kerr != nil {
+			if errors.Is(kerr, os.ErrProcessDone) {
+				return os.ErrProcessDone
+			}
+			return kerr
+		}
+		return nil
+	}
+}

--- a/sdk/gsl/internal/exec/procgroup_windows.go
+++ b/sdk/gsl/internal/exec/procgroup_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package exec
+
+import (
+	"os"
+	"os/exec"
+)
+
+// setPgid is a NO-OP on Windows.
+//
+// Windows has no POSIX process groups and no Setpgid in SysProcAttr; the
+// equivalent containment primitive is a Job Object, which is a materially
+// different design (create the job, assign the process, terminate the job) and
+// is out of scope for this objective — gsl's supported hosts are WSL2, Linux,
+// and macOS. WaitDelay, which IS portable, still bounds the pipe wait here, so
+// the deadline guarantee (E18) holds on Windows even without group semantics.
+func setPgid(_ *exec.Cmd) {}
+
+// killGroup degrades to killing the direct child on Windows. See setPgid.
+func killGroup(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	return cmd.Process.Kill()
+}

--- a/sdk/gsl/internal/gh/exec.go
+++ b/sdk/gsl/internal/gh/exec.go
@@ -19,8 +19,7 @@ import (
 	"context"
 	"os/exec"
 
-	"github.com/sirupsen/logrus"
-	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
+	gslexec "github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/exec"
 )
 
 // Runner is the single entry point for gh invocations in gsl.
@@ -48,6 +47,11 @@ func NewSystemRunner() *SystemRunner {
 
 // Run invokes `<Path> <name> <args...>` with the given context.
 // Stdout and Stderr are merged into a single buffer.
+//
+// Containment (F12/E18): hardened via internal/exec — own process group,
+// group-wide kill on cancellation, WaitDelay bound on the I/O pipes. This seam
+// needs it most: `gh` forks git subprocesses of its own (remote -v, config,
+// remote get-url), any of which can outlive it holding the stdout pipe.
 func (r *SystemRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
 	bin := r.Path
 	if bin == "" {
@@ -61,13 +65,9 @@ func (r *SystemRunner) Run(ctx context.Context, name string, args ...string) ([]
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
+	gslexec.Harden(cmd)
 	if err := cmd.Run(); err != nil {
-		observe.Default().WithFields(logrus.Fields{
-			"event":   "gh.subprocess_error",
-			"command": bin,
-			"args":    full,
-			"error":   err.Error(),
-		}).Warn("gh subprocess failed")
+		gslexec.LogSubprocessError("gh", bin, full, err)
 		return buf.Bytes(), err
 	}
 	return buf.Bytes(), nil

--- a/sdk/gsl/internal/gh/exec_test.go
+++ b/sdk/gsl/internal/gh/exec_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/gh"
 )
@@ -129,4 +130,40 @@ func TestSystemRunnerEmptyPathDefaultsToGh(t *testing.T) {
 	if !strings.Contains(err.Error(), "gh") {
 		t.Errorf("error did not reference the gh fallback binary; got %v", err)
 	}
+}
+
+// ─── E18 / F12 — subprocess containment ──────────────────────────────────────
+
+const (
+	e18Deadline = 800 * time.Millisecond
+	e18Budget   = 1500 * time.Millisecond
+	// e18Script exits IMMEDIATELY but leaves a grandchild holding the inherited
+	// stdout pipe for 5s. SystemRunner sets cmd.Stdout to a *bytes.Buffer, so
+	// os/exec allocates an os.Pipe and Wait() blocks until every writer closes
+	// it. Without WaitDelay + a process-group kill the deadline is DEFEATED.
+	e18Script = "( sleep 5 ) & exit 0"
+)
+
+// TestRun_ReturnsWithinDeadline_WhenGrandchildHoldsPipe is E18 for the gh seam.
+func TestRun_ReturnsWithinDeadline_WhenGrandchildHoldsPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell semantics; not applicable on Windows")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), e18Deadline)
+	defer cancel()
+
+	r := &gh.SystemRunner{Path: "/bin/sh"}
+
+	start := time.Now()
+	_, _ = r.Run(ctx, "-c", e18Script)
+	elapsed := time.Since(start)
+
+	if elapsed > e18Budget {
+		t.Fatalf("gh.Run took %v with an %v deadline; want <= %v. "+
+			"An orphaned grandchild holding the stdout pipe defeats the deadline (E18/F12).",
+			elapsed.Round(time.Millisecond), e18Deadline, e18Budget)
+	}
+	t.Logf("gh.Run returned in %v (deadline %v, budget %v)",
+		elapsed.Round(time.Millisecond), e18Deadline, e18Budget)
 }

--- a/sdk/gsl/internal/gh/export_test.go
+++ b/sdk/gsl/internal/gh/export_test.go
@@ -1,0 +1,9 @@
+package gh
+
+// This file is compiled ONLY under `go test`, so it exposes internals to the
+// external gh_test package without widening the real API surface.
+
+// CacheFilePathForTest exposes cacheFilePath so tests can SEED the cache (and
+// locate an entry) without hardcoding the on-disk key format. Assertions about
+// cache CONTENT stay honest — only the path derivation is shared.
+func CacheFilePathForTest(branch string) string { return cacheFilePath(branch) }

--- a/sdk/gsl/internal/gh/pr.go
+++ b/sdk/gsl/internal/gh/pr.go
@@ -2,7 +2,10 @@ package gh
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,10 +23,25 @@ type prCache struct {
 	Number int       `json:"number"`
 	State  string    `json:"state"`
 	TS     time.Time `json:"ts"`
+	// TTLSeconds is this entry's OWN lifetime. It exists so a timeout-class
+	// failure can expire faster than a conclusive answer (E19 edge). Zero means
+	// "use cacheMaxAge" — which is what every cache file written before this
+	// field existed will unmarshal to, so old files keep working.
+	TTLSeconds int `json:"ttl_seconds,omitempty"`
 }
 
-// cacheMaxAge is the maximum age of a cache entry before it is considered stale.
+// cacheMaxAge is the default entry lifetime: a conclusive answer from gh,
+// positive ("PR #123 is OPEN") or negative ("this branch has no PR").
 const cacheMaxAge = 60 * time.Second
+
+// transientTTL is the lifetime of an INCONCLUSIVE entry — gh was still running
+// when the deadline fired, so we never learned anything.
+//
+// It is cached at all so that a hanging gh is not re-dialled on every single
+// render (each attempt costs the full 800 ms timeout on the hot path). It is
+// cached BRIEFLY because the answer is unknown, not "no": a network blip must
+// not blind the status line to a real PR for a full minute.
+const transientTTL = 5 * time.Second
 
 // prViewTimeout is the per-invocation timeout for `gh pr view`.
 const prViewTimeout = 800 * time.Millisecond
@@ -44,18 +62,72 @@ func sanitizeBranch(branch string) string {
 	).Replace(branch)
 }
 
-// cacheFilePath returns the path to the cache file for the given branch.
+// repoRoot walks up from dir looking for a .git entry and returns the first
+// directory that has one. It returns "" when dir is not inside a repository.
+//
+// This is a pure filesystem walk (a handful of stat calls) on purpose: it must
+// NOT fork a `git rev-parse`, or it would re-introduce on the hot render path
+// exactly the subprocess cost this workstream exists to remove.
+func repoRoot(dir string) string {
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// repoScope returns a short, stable discriminator for the repository that `gh`
+// will actually answer about.
+//
+// # Why the cache key cannot be the branch alone
+//
+// The cache lives in ONE global directory (~/.cache/gsl), but the key was just
+// "pr-<branch>.json" — no repository component. Every repo on the machine that
+// shares a branch name therefore shares a cache entry. Two ways that goes wrong:
+//
+//   - A repo with no PR on `main` caches a NEGATIVE entry under pr-main.json,
+//     which then suppresses the real PR of any OTHER repo whose `main` has one.
+//   - Conversely a positive entry leaks a PR number into an unrelated repo.
+//
+// The negative direction only became reachable when negative caching landed
+// (E19/F13) — before that the no-PR path wrote nothing — and negative results
+// are the COMMON case, so the poisoned key would be written constantly.
+//
+// The scope is derived from the PROCESS cwd, not the payload cwd, because the
+// gh Runner does not set cmd.Dir: `gh pr view` inherits gsl's own cwd and
+// resolves the repository from it. Keying on the process cwd's repo root is
+// therefore keying on precisely the repo whose answer we are storing.
+func repoScope() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "norepo"
+	}
+	root := repoRoot(wd)
+	if root == "" {
+		return "norepo"
+	}
+	sum := sha256.Sum256([]byte(root))
+	return hex.EncodeToString(sum[:4])
+}
+
+// cacheFilePath returns the path to the cache file for the given branch,
+// scoped to the repository gh will be asked about (see repoScope).
 func cacheFilePath(branch string) string {
 	base := os.Getenv("XDG_CACHE_HOME")
 	if base == "" {
 		base = filepath.Join(os.Getenv("HOME"), ".cache")
 	}
 	safe := sanitizeBranch(branch)
-	return filepath.Join(base, "gsl", "pr-"+safe+".json")
+	return filepath.Join(base, "gsl", "pr-"+safe+"-"+repoScope()+".json")
 }
 
 // readCache attempts to load a valid (non-stale) cache entry for branch.
-// Returns nil if the file is absent, unreadable, invalid, or older than cacheMaxAge.
+// Returns nil if the file is absent, unreadable, invalid, or past its TTL.
 func readCache(path string) *prCache {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -65,28 +137,48 @@ func readCache(path string) *prCache {
 	if err := json.Unmarshal(data, &c); err != nil {
 		return nil
 	}
-	if time.Since(c.TS) >= cacheMaxAge {
+	ttl := cacheMaxAge
+	if c.TTLSeconds > 0 {
+		ttl = time.Duration(c.TTLSeconds) * time.Second
+	}
+	if time.Since(c.TS) >= ttl {
 		return nil
 	}
 	return &c
 }
 
-// writeCache persists the PRInfo to the cache file at path.
-// Errors are silently ignored — a failed write is non-fatal.
-func writeCache(path string, info *PRInfo) {
+// writeCache persists the PRInfo to the cache file at path with an explicit TTL.
+// Errors are silently ignored — a failed write is non-fatal (we just re-probe).
+func writeCache(path string, info *PRInfo, ttl time.Duration) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return
 	}
 	c := prCache{
-		Number: info.Number,
-		State:  info.State,
-		TS:     time.Now(),
+		Number:     info.Number,
+		State:      info.State,
+		TS:         time.Now(),
+		TTLSeconds: int(ttl.Seconds()),
 	}
 	data, err := json.Marshal(c)
 	if err != nil {
 		return
 	}
 	_ = os.WriteFile(path, data, 0o644)
+}
+
+// cacheNegative remembers "there is no PR for this branch" for ttl.
+func cacheNegative(path string, ttl time.Duration) {
+	writeCache(path, &PRInfo{}, ttl)
+}
+
+// inconclusive reports whether the call failed because we RAN OUT OF TIME
+// rather than because gh gave us an answer. Those two get different TTLs:
+// an answer is good for a minute; a non-answer for five seconds.
+func inconclusive(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return true
+	}
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }
 
 // PR returns the PR number and state for the given branch.
@@ -96,14 +188,29 @@ func writeCache(path string, info *PRInfo) {
 // A non-nil error is returned only for internal logic failures that the caller
 // cannot work around by omitting output (currently none in this path).
 //
-// Cache: a file at ${XDG_CACHE_HOME:-$HOME/.cache}/gsl/pr-<branch>.json is
-// consulted first. If it exists and is < 60 s old the Runner is NOT called;
-// a cached entry whose Number is 0 represents a previously-observed "no PR"
-// result and yields (nil, nil) without invoking gh. Otherwise
-// `gh pr view <branch> --json number,state` is invoked with an 800 ms
-// timeout (the branch is passed explicitly so the query matches the cache
-// key rather than the process cwd's current branch); a fresh cache file is
-// written on every conclusive result, including the negative one.
+// # Caching (F13 / E19)
+//
+// A file at ${XDG_CACHE_HOME:-$HOME/.cache}/gsl/pr-<branch>.json is consulted
+// first. On a live entry the Runner is NOT called; an entry whose Number is 0
+// is a remembered "no PR" and yields (nil, nil) with no gh invocation.
+//
+// EVERY outcome is cached, and that is the point. The shipped code cached only
+// the `{"number":0}` shape — but that is not how gh reports "no PR". gh EXITS 1
+// and writes "no pull requests found for branch" to stderr, so the real no-PR
+// path took the `err != nil` branch and returned WITHOUT writing the cache.
+// Nothing was ever cached for a PR-less branch, so `gh pr view` — a ~760 ms
+// NETWORK call that forks three more git subprocesses of its own — re-ran on
+// EVERY render, forever. On `main`, which normally has no PR, that was the
+// single most expensive thing gsl did, on every assistant turn.
+//
+// TTLs differ by how much we learned:
+//   - a conclusive answer (a PR, or "no PR")      → cacheMaxAge  (60 s)
+//   - inconclusive (deadline fired, we know zip)  → transientTTL  (5 s)
+//
+// A nil Runner is a no-op returning (nil, nil): it used to nil-deref and panic,
+// and because render's Detect recovers from segment panics, the panic showed up
+// as nothing worse than a silently missing segment — a test could stay green on
+// a panicking path.
 func PR(ctx context.Context, runner Runner, branch string) (*PRInfo, error) {
 	path := cacheFilePath(branch)
 
@@ -117,6 +224,12 @@ func PR(ctx context.Context, runner Runner, branch string) (*PRInfo, error) {
 		return &PRInfo{Number: c.Number, State: c.State}, nil
 	}
 
+	// No runner (Deps{GH: nil}): nothing to ask, nothing learned. Do NOT cache
+	// — the on-disk cache is shared with processes that DO have a gh.
+	if runner == nil {
+		return nil, nil
+	}
+
 	// Apply a per-call timeout so we never block the status line for long.
 	tctx, cancel := context.WithTimeout(ctx, prViewTimeout)
 	defer cancel()
@@ -125,11 +238,20 @@ func PR(ctx context.Context, runner Runner, branch string) (*PRInfo, error) {
 	// requested branch (matching the cache key) rather than the cwd branch.
 	out, err := runner.Run(tctx, "pr", "view", branch, "--json", "number,state")
 	if err != nil {
-		// gh absent, no remote, no PR, timeout — all map to "omit".
+		// gh exited non-zero (the NORMAL "no PR for this branch" signal), gh is
+		// absent, or the deadline fired. All map to "omit" — but they are now
+		// all REMEMBERED, at a TTL that reflects how conclusive they were.
+		if inconclusive(tctx, err) {
+			cacheNegative(path, transientTTL)
+		} else {
+			cacheNegative(path, cacheMaxAge)
+		}
 		return nil, nil //nolint:nilerr
 	}
 
+	// gh exited 0 but said nothing. Conclusive enough: there is no PR.
 	if len(out) == 0 {
+		cacheNegative(path, cacheMaxAge)
 		return nil, nil
 	}
 
@@ -138,17 +260,20 @@ func PR(ctx context.Context, runner Runner, branch string) (*PRInfo, error) {
 		State  string `json:"state"`
 	}
 	if err := json.Unmarshal(out, &payload); err != nil {
+		// gh answered in a shape we don't understand. Don't re-dial it every
+		// render, but expire fast: a gh upgrade must not blind us for a minute.
+		cacheNegative(path, transientTTL)
 		return nil, nil //nolint:nilerr
 	}
 
 	// Number == 0 generally means no PR was found. Cache the negative result
 	// so PR-less repos don't pay the full gh invocation every render.
 	if payload.Number == 0 {
-		writeCache(path, &PRInfo{Number: 0, State: payload.State})
+		writeCache(path, &PRInfo{Number: 0, State: payload.State}, cacheMaxAge)
 		return nil, nil
 	}
 
 	info := &PRInfo{Number: payload.Number, State: payload.State}
-	writeCache(path, info)
+	writeCache(path, info, cacheMaxAge)
 	return info, nil
 }

--- a/sdk/gsl/internal/gh/pr_scope_test.go
+++ b/sdk/gsl/internal/gh/pr_scope_test.go
@@ -1,0 +1,125 @@
+package gh_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/gh"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/gh/fake"
+)
+
+// mkRepo creates a directory that repoRoot will recognise as a repository.
+// Only the presence of .git matters — the key derivation is a filesystem walk,
+// never a `git` subprocess (that would put a fork back on the hot render path).
+func mkRepo(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir repo %s: %v", name, err)
+	}
+	return dir
+}
+
+// TestPR_NegativeCacheIsScopedToRepo is the regression guard for a cross-repo
+// cache-poisoning bug.
+//
+// The PR cache lives in ONE global directory but was keyed on the branch name
+// alone. Negative caching (E19/F13) then made the common case — "this branch has
+// no PR" — write an entry under that shared key. Result: repo A having no PR on
+// a branch SUPPRESSED the real PR of repo B on a branch of the same name for the
+// full 60 s TTL.
+//
+// Reproduced end-to-end before the fix: repo A cached {"number":0} under
+// pr-shared-branch.json, and repo B's open PR #42 was then never even looked up
+// (gh was not invoked at all — the poisoned entry was served instead).
+//
+// Against the branch-only key this test fails on BOTH assertions below: the
+// runner is never called (CallCount 0) and the real PR comes back nil.
+func TestPR_NegativeCacheIsScopedToRepo(t *testing.T) {
+	setupCacheDir(t)
+
+	repoA := mkRepo(t, "repoA")
+	repoB := mkRepo(t, "repoB")
+	const branch = "shared-branch"
+
+	// ── repo A: no PR on `branch`. gh signals that by EXITING 1. ──
+	t.Chdir(repoA)
+	noPR := &fake.Runner{Default: fake.Response{
+		Stderr:   []byte("no pull requests found for branch \"" + branch + "\"\n"),
+		ExitCode: 1,
+		Err:      errors.New("exit status 1"),
+	}}
+	info, err := gh.PR(context.Background(), noPR, branch)
+	if err != nil {
+		t.Fatalf("repoA: unexpected error: %v", err)
+	}
+	if info != nil {
+		t.Fatalf("repoA: expected nil PRInfo (no PR), got %+v", info)
+	}
+	// Sanity: the negative WAS cached (that is the E19 behaviour we want kept).
+	if _, err := os.Stat(gh.CacheFilePathForTest(branch)); err != nil {
+		t.Fatalf("repoA: the negative result should still be cached (E19/F13): %v", err)
+	}
+
+	// ── repo B: SAME branch name, but here it really does have an open PR. ──
+	t.Chdir(repoB)
+	hasPR := &fake.Runner{Default: fake.Response{
+		Stdout: []byte(`{"number":42,"state":"OPEN"}`),
+	}}
+	info, err = gh.PR(context.Background(), hasPR, branch)
+	if err != nil {
+		t.Fatalf("repoB: unexpected error: %v", err)
+	}
+
+	if got := hasPR.CallCount(); got != 1 {
+		t.Errorf("repoB: CallCount() = %d; want 1 — gh was never asked, because "+
+			"repoA's NEGATIVE cache entry for the same branch name was served "+
+			"instead (the cache key must be scoped to the repository)", got)
+	}
+	if info == nil {
+		t.Fatalf("repoB: PR #42 came back nil — repoA's 'no PR' answer for an " +
+			"unrelated repository suppressed it (cross-repo cache poisoning)")
+	}
+	if info.Number != 42 || info.State != "OPEN" {
+		t.Errorf("repoB: got PR %+v; want {Number:42 State:OPEN}", info)
+	}
+}
+
+// TestPR_PositiveCacheDoesNotLeakAcrossRepos is the mirror image: repo A's real
+// PR number must not be FABRICATED into repo B, which has no PR at all. This
+// direction predates negative caching (the success path always wrote the cache),
+// so it is the older half of the same key bug.
+func TestPR_PositiveCacheDoesNotLeakAcrossRepos(t *testing.T) {
+	setupCacheDir(t)
+
+	repoA := mkRepo(t, "repoA")
+	repoB := mkRepo(t, "repoB")
+	const branch = "shared-branch"
+
+	t.Chdir(repoA)
+	hasPR := &fake.Runner{Default: fake.Response{
+		Stdout: []byte(`{"number":7,"state":"OPEN"}`),
+	}}
+	info, err := gh.PR(context.Background(), hasPR, branch)
+	if err != nil || info == nil || info.Number != 7 {
+		t.Fatalf("repoA: want PR #7, got %+v (err %v)", info, err)
+	}
+
+	t.Chdir(repoB)
+	noPR := &fake.Runner{Default: fake.Response{
+		Stderr:   []byte("no pull requests found\n"),
+		ExitCode: 1,
+		Err:      errors.New("exit status 1"),
+	}}
+	info, err = gh.PR(context.Background(), noPR, branch)
+	if err != nil {
+		t.Fatalf("repoB: unexpected error: %v", err)
+	}
+	if info != nil {
+		t.Fatalf("repoB: has NO PR, but got %+v — repo A's cached PR number "+
+			"leaked across the shared branch-only cache key", info)
+	}
+}

--- a/sdk/gsl/internal/gh/pr_test.go
+++ b/sdk/gsl/internal/gh/pr_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,14 +24,15 @@ func setupCacheDir(t *testing.T) string {
 }
 
 // writeFreshCache manually writes a cache entry that is < 60 s old.
-func writeFreshCache(t *testing.T, cacheDir, branch string, info gh.PRInfo) {
+//
+// The path comes from the production key function (via the test-only export) so
+// that seeding cannot silently drift from where PR() actually looks — a hardcoded
+// key here would make every cache-hit test vacuously pass the day the key
+// changes, which is precisely how a repo-scoped key could have shipped broken.
+func writeFreshCache(t *testing.T, _ string, branch string, info gh.PRInfo) {
 	t.Helper()
-	safe := branch
-	for _, ch := range []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|"} {
-		safe = replaceAll(safe, ch, "-")
-	}
-	dir := filepath.Join(cacheDir, "gsl")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	path := gh.CacheFilePathForTest(branch)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	type cacheEntry struct {
@@ -43,7 +45,6 @@ func writeFreshCache(t *testing.T, cacheDir, branch string, info gh.PRInfo) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	path := filepath.Join(dir, "pr-"+safe+".json")
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		t.Fatalf("write cache: %v", err)
 	}
@@ -318,8 +319,152 @@ func TestPRBranchSanitization(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 cache file, got %d entries", len(entries))
 	}
+	// The slashes must be flattened to dashes. The filename carries a trailing
+	// repo-scope discriminator (pr-<branch>-<scope>.json) so that two different
+	// repositories sharing a branch name cannot share a cache entry — see
+	// TestPR_NegativeCacheIsScopedToRepo — hence a prefix match, not equality.
 	name := entries[0].Name()
-	if name != "pr-feature-foo-bar.json" {
-		t.Errorf("cache filename = %q; want pr-feature-foo-bar.json", name)
+	const wantPrefix = "pr-feature-foo-bar-"
+	if !strings.HasPrefix(name, wantPrefix) || !strings.HasSuffix(name, ".json") {
+		t.Errorf("cache filename = %q; want %q<scope>.json", name, wantPrefix)
+	}
+	// The point of the sanitisation: no path separators and no traversal.
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		t.Errorf("cache filename %q must not contain a path separator or traversal", name)
+	}
+	// And it must be the file PR() actually reads back.
+	if got := filepath.Base(gh.CacheFilePathForTest("feature/foo/bar")); got != name {
+		t.Errorf("on-disk cache file %q is not the one PR() looks up (%q)", name, got)
+	}
+}
+
+// ─── E19 / F13 — negative caching ────────────────────────────────────────────
+
+// TestPR_NegativeCacheOnError is E19.
+//
+// The NORMAL case on `main` is that no PR exists for the branch, and gh signals
+// that by EXITING 1 — not by printing `{"number":0}`. gh.PR's error path
+// returned (nil, nil) without writing the cache, so nothing was ever cached and
+// `gh pr view` — a ~760ms NETWORK call that itself forks three more git
+// subprocesses — re-ran on EVERY render, forever, for any branch without a PR.
+//
+// The spy counts invocations: the runner must be called exactly ONCE across two
+// PR() calls inside the TTL.
+func TestPR_NegativeCacheOnError(t *testing.T) {
+	cacheDir := setupCacheDir(t)
+
+	spy := &fake.Runner{
+		// The real shape of "no PR for this branch": gh exits 1.
+		Default: fake.Response{
+			Stderr:   []byte("no pull requests found for branch \"main\"\n"),
+			ExitCode: 1,
+			Err:      errors.New("exit status 1"),
+		},
+	}
+
+	// First call — the runner runs, gh exits 1, and the NEGATIVE result must be
+	// persisted.
+	info1, err := gh.PR(context.Background(), spy, "main")
+	if err != nil {
+		t.Fatalf("first call: unexpected error: %v", err)
+	}
+	if info1 != nil {
+		t.Fatalf("first call: expected nil PRInfo (no PR), got %+v", info1)
+	}
+	if got := spy.CallCount(); got != 1 {
+		t.Fatalf("first call: CallCount() = %d; want 1", got)
+	}
+
+	// A cache entry MUST exist on disk after the error path.
+	entries, err := os.ReadDir(filepath.Join(cacheDir, "gsl"))
+	if err != nil {
+		t.Fatalf("no cache directory was created on the gh-error path: %v "+
+			"(the negative result was not cached — E19/F13)", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 cache file after the gh-error path, got %d: %v "+
+			"(the negative result was not cached — E19/F13)", len(entries), entries)
+	}
+
+	// Second call within the TTL — the runner must NOT be invoked again.
+	info2, err := gh.PR(context.Background(), spy, "main")
+	if err != nil {
+		t.Fatalf("second call: unexpected error: %v", err)
+	}
+	if info2 != nil {
+		t.Fatalf("second call: expected nil PRInfo (cached negative), got %+v", info2)
+	}
+	if got := spy.CallCount(); got != 1 {
+		t.Errorf("second call: CallCount() = %d; want still 1 — `gh pr view` (a ~760ms "+
+			"network call) re-ran on a cached negative result (E19/F13)", got)
+	}
+}
+
+// TestPR_NegativeCacheOnEmptyOutput asserts the OTHER silent-omit path — gh
+// exits 0 but prints nothing — is negatively cached too.
+func TestPR_NegativeCacheOnEmptyOutput(t *testing.T) {
+	setupCacheDir(t)
+
+	spy := &fake.Runner{Default: fake.Response{Stdout: nil, Err: nil}}
+
+	if _, err := gh.PR(context.Background(), spy, "main"); err != nil {
+		t.Fatalf("first call: unexpected error: %v", err)
+	}
+	if _, err := gh.PR(context.Background(), spy, "main"); err != nil {
+		t.Fatalf("second call: unexpected error: %v", err)
+	}
+	if got := spy.CallCount(); got != 1 {
+		t.Errorf("CallCount() = %d; want 1 — the empty-output result must be negatively cached (E19/F13)", got)
+	}
+}
+
+// TestPR_TimeoutUsesShorterTTL asserts the EDGE of E19: a timeout-class failure
+// is cached too (so we don't hammer a hanging gh every render), but with a much
+// shorter TTL than a clean "no PR" — a network blip must not blind us to a PR
+// for a full minute.
+func TestPR_TimeoutUsesShorterTTL(t *testing.T) {
+	setupCacheDir(t)
+
+	// An already-cancelled context reaches the runner as a context error.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	spy := &fake.Runner{}
+	if _, err := gh.PR(ctx, spy, "main"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(gh.CacheFilePathForTest("main"))
+	if err != nil {
+		t.Fatalf("timeout result was not cached at all: %v (E19 edge)", err)
+	}
+	var entry struct {
+		TTLSeconds int `json:"ttl_seconds"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("unmarshal cache entry: %v", err)
+	}
+	if entry.TTLSeconds <= 0 {
+		t.Fatalf("timeout cache entry has no explicit TTL (ttl_seconds=%d); a "+
+			"timeout must use a SHORTER TTL than a clean no-PR result (E19 edge)", entry.TTLSeconds)
+	}
+	if entry.TTLSeconds >= 60 {
+		t.Errorf("timeout TTL = %ds; want shorter than the 60s no-PR TTL (E19 edge)", entry.TTLSeconds)
+	}
+}
+
+// TestPR_NilRunner_NoPanic pins the degraded path: gh.PR must not panic when the
+// Runner is nil (Deps{GH: nil}). The panic was invisible because render's
+// recover() swallowed it and dropped the segment — a test could stay green on a
+// panicking path.
+func TestPR_NilRunner_NoPanic(t *testing.T) {
+	setupCacheDir(t)
+
+	info, err := gh.PR(context.Background(), nil, "main")
+	if err != nil {
+		t.Fatalf("nil runner: unexpected error: %v", err)
+	}
+	if info != nil {
+		t.Fatalf("nil runner: expected nil PRInfo, got %+v", info)
 	}
 }

--- a/sdk/gsl/internal/git/exec.go
+++ b/sdk/gsl/internal/git/exec.go
@@ -21,8 +21,7 @@ import (
 	"context"
 	"os/exec"
 
-	"github.com/sirupsen/logrus"
-	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
+	gslexec "github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/exec"
 )
 
 // Runner is the single entry point for git invocations in the gsl codebase.
@@ -80,6 +79,12 @@ func buildArgs(dir, subcommand string, extra ...string) []string {
 // Stdout and Stderr are merged into a single buffer. The buffer is returned
 // even when the command exits non-zero so that callers can surface git's
 // own error message verbatim.
+//
+// Containment (F12/E18): the command is hardened via internal/exec — its own
+// process group, a group-wide kill on cancellation, and a WaitDelay bound on
+// the I/O pipes. Without that, a grandchild inheriting the stdout pipe keeps
+// Wait() blocked long past ctx's deadline (measured: 5004 ms against an 800 ms
+// deadline).
 func (r *SystemRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
 	bin := r.Path
 	if bin == "" {
@@ -93,13 +98,9 @@ func (r *SystemRunner) Run(ctx context.Context, name string, args ...string) ([]
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
+	gslexec.Harden(cmd)
 	if err := cmd.Run(); err != nil {
-		observe.Default().WithFields(logrus.Fields{
-			"event":   "git.subprocess_error",
-			"command": bin,
-			"args":    full,
-			"error":   err.Error(),
-		}).Warn("git subprocess failed")
+		gslexec.LogSubprocessError("git", bin, full, err)
 		return buf.Bytes(), err
 	}
 	return buf.Bytes(), nil

--- a/sdk/gsl/internal/git/exec_test.go
+++ b/sdk/gsl/internal/git/exec_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/git"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
@@ -45,9 +47,16 @@ func TestSystemRunnerNonZeroExit(t *testing.T) {
 // TestSystemRunner_LogsOnFailure asserts the seam emits a structured
 // git.subprocess_error record when the underlying command fails. The gh/mcp
 // seams follow the same pattern; this covers the shared mechanism.
+//
+// The level is Debug (not Warn) because a non-zero exit here is the ROUTINE
+// case — see TestSystemRunner_ExpectedExit_LogsAtDebug for why that matters,
+// and TestSystemRunner_MissingBinary_LogsAtWarn for the failures that stay
+// loud. Hence GSL_LOG_LEVEL=debug: the record still exists, it is just no
+// longer shouted.
 func TestSystemRunner_LogsOnFailure(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "gsl.log")
 	t.Setenv("GSL_LOG_FILE", logPath)
+	t.Setenv("GSL_LOG_LEVEL", "debug")
 	observe.ResetDefaultForTest()
 	t.Cleanup(observe.ResetDefaultForTest)
 
@@ -63,5 +72,151 @@ func TestSystemRunner_LogsOnFailure(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"event":"git.subprocess_error"`) {
 		t.Fatalf("expected git.subprocess_error in log, got: %s", data)
+	}
+}
+
+// ─── E18 / F12 — subprocess containment ──────────────────────────────────────
+
+// deadlineBudget is the wall-clock ceiling for a Run whose child has exited but
+// whose GRANDCHILD still holds the stdout pipe open:
+//
+//	ctx deadline (800ms) + WaitDelay (200ms) + slack (500ms)
+//
+// The slack absorbs process spawn + scheduler jitter on a loaded CI box. It is
+// nowhere near the 5s the leaked grandchild sleeps for, so the assertion cannot
+// pass by accident.
+const (
+	e18Deadline = 800 * time.Millisecond
+	e18Budget   = 1500 * time.Millisecond
+	// e18Script exits IMMEDIATELY but backgrounds a grandchild that inherits
+	// (and holds open) the stdout pipe for 5s. Because SystemRunner points
+	// cmd.Stdout at a *bytes.Buffer, os/exec allocates an os.Pipe and Wait()
+	// blocks until EVERY writer closes it — the grandchild included. Without
+	// WaitDelay + a process-group kill, Wait blocks the full 5s and the
+	// context deadline is DEFEATED.
+	e18Script = "( sleep 5 ) & exit 0"
+)
+
+// TestRun_ReturnsWithinDeadline_WhenGrandchildHoldsPipe is E18 for the git seam.
+func TestRun_ReturnsWithinDeadline_WhenGrandchildHoldsPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell semantics; not applicable on Windows")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), e18Deadline)
+	defer cancel()
+
+	// Path is the shell, so name+args become `sh -c "<script>"`.
+	r := &git.SystemRunner{Path: "/bin/sh"}
+
+	start := time.Now()
+	_, _ = r.Run(ctx, "-c", e18Script)
+	elapsed := time.Since(start)
+
+	if elapsed > e18Budget {
+		t.Fatalf("git.Run took %v with an %v deadline; want <= %v. "+
+			"The orphaned grandchild is holding the stdout pipe and Wait() is "+
+			"blocking on it — the deadline is not being enforced (E18/F12).",
+			elapsed.Round(time.Millisecond), e18Deadline, e18Budget)
+	}
+	t.Logf("git.Run returned in %v (deadline %v, budget %v)",
+		elapsed.Round(time.Millisecond), e18Deadline, e18Budget)
+}
+
+// TestRun_KillsProcessGroup_OnContextCancel proves the kill targets the whole
+// process GROUP, not just the direct child.
+//
+// The child (sh) blocks for 30s, so ctx cancellation is what ends it. Its
+// backgrounded grandchild sleeps 1s and then touches a marker file. With only
+// the direct child killed (os/exec's default Cancel), the grandchild survives
+// its parent and creates the marker. With Setpgid + a negative-pid kill, the
+// grandchild dies with the group and the marker is NEVER created.
+func TestRun_KillsProcessGroup_OnContextCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX process groups; not applicable on Windows")
+	}
+
+	marker := filepath.Join(t.TempDir(), "grandchild-survived")
+	script := "( sleep 1; touch " + marker + " ) & sleep 30"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	r := &git.SystemRunner{Path: "/bin/sh"}
+	start := time.Now()
+	_, err := r.Run(ctx, "-c", script)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected an error from the cancelled command, got nil")
+	}
+	if elapsed > e18Budget {
+		t.Fatalf("Run took %v after a 300ms cancel; want <= %v", elapsed.Round(time.Millisecond), e18Budget)
+	}
+
+	// Give the (hopefully dead) grandchild well past its 1s sleep to prove it
+	// is gone rather than merely slow.
+	time.Sleep(1500 * time.Millisecond)
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatalf("grandchild survived context cancellation and wrote %s: "+
+			"only the direct child was killed. Cancel must kill the PROCESS GROUP (E18/F12).", marker)
+	}
+}
+
+// TestSystemRunner_ExpectedExit_LogsAtDebug pins the logging-hygiene rule: an
+// EXPECTED non-zero exit (not-a-repo, no-PR) is Debug, not Warn. Warn is
+// reserved for genuine operational failures (timeout, missing binary) so that
+// real records are not drowned by ~1.6k routine ones.
+func TestSystemRunner_ExpectedExit_LogsAtDebug(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "gsl.log")
+	t.Setenv("GSL_LOG_FILE", logPath)
+	t.Setenv("GSL_LOG_LEVEL", "debug")
+	observe.ResetDefaultForTest()
+	t.Cleanup(observe.ResetDefaultForTest)
+
+	r := git.NewSystemRunner()
+	if _, err := r.Run(context.Background(), "definitely-not-a-command"); err == nil {
+		t.Fatal("expected error from bogus git subcommand")
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `"event":"git.subprocess_error"`) {
+		t.Fatalf("expected git.subprocess_error in log, got: %s", got)
+	}
+	if !strings.Contains(got, `"level":"debug"`) {
+		t.Errorf("expected the expected-exit record at level=debug; got: %s", got)
+	}
+	if strings.Contains(got, `"level":"warning"`) {
+		t.Errorf("expected non-zero exit must NOT be logged at warn; got: %s", got)
+	}
+}
+
+// TestSystemRunner_MissingBinary_LogsAtWarn is the counterweight to the Debug
+// demotion: demoting the ROUTINE exits must not silence the REAL ones. A missing
+// binary is a genuine misconfiguration and must still be visible at the DEFAULT
+// log level (no GSL_LOG_LEVEL set — i.e. info), which Debug records are not.
+func TestSystemRunner_MissingBinary_LogsAtWarn(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "gsl.log")
+	t.Setenv("GSL_LOG_FILE", logPath)
+	// Deliberately NOT setting GSL_LOG_LEVEL: the default (info) must show this.
+	observe.ResetDefaultForTest()
+	t.Cleanup(observe.ResetDefaultForTest)
+
+	r := &git.SystemRunner{Path: "gsl-definitely-not-a-real-binary-xyz"}
+	if _, err := r.Run(context.Background(), "status"); err == nil {
+		t.Fatal("expected a lookup error for a missing binary")
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `"level":"warning"`) {
+		t.Errorf("a missing binary must still be logged at Warn (visible at the default "+
+			"level); got: %q", got)
 	}
 }

--- a/sdk/gsl/internal/mcp/exec.go
+++ b/sdk/gsl/internal/mcp/exec.go
@@ -19,8 +19,7 @@ import (
 	"context"
 	"os/exec"
 
-	"github.com/sirupsen/logrus"
-	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
+	gslexec "github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/exec"
 )
 
 // Runner is the single entry point for MCP subprocess invocations in gsl.
@@ -52,6 +51,11 @@ func NewSystemRunner() *SystemRunner {
 // given args and context. name is the full executable, not a subcommand
 // — unlike the git/gh seams which prepend a fixed binary. Stdout and
 // Stderr are merged into a single buffer.
+//
+// Containment (F12/E18): hardened via internal/exec — own process group,
+// group-wide kill on cancellation, WaitDelay bound on the I/O pipes. `claude
+// mcp list` DIALS EVERY SERVER, so it is the likeliest of the three seams to
+// leave a transport child holding the stdout pipe after its own deadline.
 func (r *SystemRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
 	bin := name
 	if r.Path != "" {
@@ -62,13 +66,9 @@ func (r *SystemRunner) Run(ctx context.Context, name string, args ...string) ([]
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
+	gslexec.Harden(cmd)
 	if err := cmd.Run(); err != nil {
-		observe.Default().WithFields(logrus.Fields{
-			"event":   "mcp.subprocess_error",
-			"command": bin,
-			"args":    args,
-			"error":   err.Error(),
-		}).Warn("mcp subprocess failed")
+		gslexec.LogSubprocessError("mcp", bin, args, err)
 		return buf.Bytes(), err
 	}
 	return buf.Bytes(), nil

--- a/sdk/gsl/internal/mcp/exec_test.go
+++ b/sdk/gsl/internal/mcp/exec_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/mcp"
 )
@@ -99,4 +100,44 @@ func execLookPath(name string) (string, error) {
 		}
 	}
 	return "", os.ErrNotExist
+}
+
+// ─── E18 / F12 — subprocess containment ──────────────────────────────────────
+
+const (
+	e18Deadline = 800 * time.Millisecond
+	e18Budget   = 1500 * time.Millisecond
+	// e18Script exits IMMEDIATELY but leaves a grandchild holding the inherited
+	// stdout pipe for 5s. SystemRunner sets cmd.Stdout to a *bytes.Buffer, so
+	// os/exec allocates an os.Pipe and Wait() blocks until every writer closes
+	// it. Without WaitDelay + a process-group kill the deadline is DEFEATED.
+	//
+	// This is the `claude mcp list` shape: the CLI dials every server and can
+	// leave transport children behind.
+	e18Script = "( sleep 5 ) & exit 0"
+)
+
+// TestRun_ReturnsWithinDeadline_WhenGrandchildHoldsPipe is E18 for the mcp seam.
+func TestRun_ReturnsWithinDeadline_WhenGrandchildHoldsPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell semantics; not applicable on Windows")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), e18Deadline)
+	defer cancel()
+
+	// The mcp seam treats `name` as the executable itself.
+	r := mcp.NewSystemRunner()
+
+	start := time.Now()
+	_, _ = r.Run(ctx, "/bin/sh", "-c", e18Script)
+	elapsed := time.Since(start)
+
+	if elapsed > e18Budget {
+		t.Fatalf("mcp.Run took %v with an %v deadline; want <= %v. "+
+			"An orphaned grandchild holding the stdout pipe defeats the deadline (E18/F12).",
+			elapsed.Round(time.Millisecond), e18Deadline, e18Budget)
+	}
+	t.Logf("mcp.Run returned in %v (deadline %v, budget %v)",
+		elapsed.Round(time.Millisecond), e18Deadline, e18Budget)
 }

--- a/sdk/gsl/internal/render/detect.go
+++ b/sdk/gsl/internal/render/detect.go
@@ -72,7 +72,7 @@ func Detect(ctx context.Context, cfg config.Config, st style.Style, segs []Segme
 						"event":   "segment.panic",
 						"segment": segmentTypeName(s),
 						"panic":   fmt.Sprintf("%v", r),
-					}).Warn("segment panicked during detect; dropping")
+					}).Error("segment panicked during detect; dropping")
 					items[idx] = item{ok: false}
 				}
 			}()

--- a/sdk/gsl/internal/render/gitinfo_test.go
+++ b/sdk/gsl/internal/render/gitinfo_test.go
@@ -1,0 +1,80 @@
+package render
+
+// gitinfo_test.go — WS3 / F12: the pre-threaded git.Info.
+//
+// cmd/statusline.go ran git.Status SERIALLY (to get the branch) and then
+// DirGitSegment ran git.Status AGAIN inside Detect: 4 git execs where 2 suffice,
+// with the serial pair draining the shared 1s budget before the concurrent
+// segments even start. Deps.GitInfo (the frozen interface) carries the already
+// computed status into the segment.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/git"
+	gitfake "github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/git/fake"
+)
+
+// dirgitOnlyConfig is a config with ONLY the dirgit segment enabled, so the
+// git-exec count attributable to that segment is unambiguous.
+func dirgitOnlyConfig() config.Config {
+	cfg := config.Default()
+	cfg.Segments = []config.Segment{{Type: "dirgit", Enabled: true}}
+	return cfg
+}
+
+// TestDetect_ReusesPreThreadedGitInfo is the subprocess-count assertion: with
+// Deps.GitInfo pre-computed, the dirgit segment must spawn ZERO further git
+// processes — and must still render the branch it was handed.
+func TestDetect_ReusesPreThreadedGitInfo(t *testing.T) {
+	spy := &gitfake.Runner{Script: gitStatusResponses("main")}
+
+	deps := Deps{
+		Cwd: "/tmp/myrepo",
+		Git: spy,
+		GitInfo: &git.Info{
+			Branch:    "feature/pre-threaded",
+			Staged:    1,
+			Untracked: 2,
+		},
+	}
+
+	cfg := dirgitOnlyConfig()
+	st := asciiStyle()
+	datas := Detect(context.Background(), cfg, st, BuildSegments(cfg, deps))
+
+	if got := spy.CallCount(); got != 0 {
+		t.Errorf("git.Runner.CallCount() = %d; want 0 — DirGitSegment re-ran git.Status "+
+			"even though Deps.GitInfo was pre-computed (2 redundant execs per render; WS3/F12)", got)
+	}
+
+	out := Format(datas, st, 0)
+	if !strings.Contains(out, "feature/pre-threaded") {
+		t.Errorf("rendered line = %q; want it to contain the pre-threaded branch "+
+			"'feature/pre-threaded' (the pre-computed Info must actually be USED)", out)
+	}
+}
+
+// TestDetect_DetectsGitInfoWhenNotPreThreaded is the other half of the contract:
+// a nil GitInfo means "not pre-computed; detect it yourself", which is what keeps
+// every existing caller (tests, internal/preview) working unchanged.
+func TestDetect_DetectsGitInfoWhenNotPreThreaded(t *testing.T) {
+	spy := &gitfake.Runner{Script: gitStatusResponses("main")}
+
+	deps := Deps{Cwd: "/tmp/myrepo", Git: spy, GitInfo: nil}
+
+	cfg := dirgitOnlyConfig()
+	st := asciiStyle()
+	datas := Detect(context.Background(), cfg, st, BuildSegments(cfg, deps))
+
+	// git.Status = `git status --porcelain=v2 --branch` + `git stash list` = 2 execs.
+	if got := spy.CallCount(); got != 2 {
+		t.Errorf("git.Runner.CallCount() = %d; want 2 (status + stash list) when GitInfo is nil", got)
+	}
+	if out := Format(datas, st, 0); !strings.Contains(out, "main") {
+		t.Errorf("rendered line = %q; want it to contain the detected branch 'main'", out)
+	}
+}

--- a/sdk/gsl/internal/render/panic_level_test.go
+++ b/sdk/gsl/internal/render/panic_level_test.go
@@ -1,0 +1,68 @@
+package render
+
+// panic_level_test.go — WS3 logging hygiene.
+//
+// A panicking segment is a BUG in gsl; it must be logged at Error. It was
+// logged at Warn, in the same band as the ~1.6k routine "expected non-zero
+// exit" records the seams emitted per session — which is exactly how a real
+// segment.panic goes unnoticed for months.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
+)
+
+// readPanicLog runs f with a temp log file and returns its contents.
+func readPanicLog(t *testing.T, f func()) string {
+	t.Helper()
+	logPath := filepath.Join(t.TempDir(), "gsl.log")
+	t.Setenv("GSL_LOG_FILE", logPath)
+	observe.ResetDefaultForTest()
+	t.Cleanup(observe.ResetDefaultForTest)
+
+	f()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	return string(data)
+}
+
+// TestRender_SegmentPanic_LogsAtError covers the Render path.
+func TestRender_SegmentPanic_LogsAtError(t *testing.T) {
+	got := readPanicLog(t, func() {
+		_ = Render(context.Background(), config.Default(), spaceStyle(), []Segment{&panicSegment{}})
+	})
+
+	if !strings.Contains(got, `"event":"segment.panic"`) {
+		t.Fatalf("expected segment.panic in log, got: %s", got)
+	}
+	if !strings.Contains(got, `"level":"error"`) {
+		t.Errorf("segment.panic must be logged at level=error (it is a gsl bug, not a routine "+
+			"degradation); got: %s", got)
+	}
+}
+
+// TestDetect_SegmentPanic_LogsAtError covers the Detect path — the one that
+// actually runs in production, and whose recover() silently swallowed the nil
+// Runner panic in gh.PR.
+func TestDetect_SegmentPanic_LogsAtError(t *testing.T) {
+	cfg := config.Default()
+	got := readPanicLog(t, func() {
+		_ = Detect(context.Background(), cfg, spaceStyle(), []Segment{&panicSegment{}})
+	})
+
+	if !strings.Contains(got, `"event":"segment.panic"`) {
+		t.Fatalf("expected segment.panic in log, got: %s", got)
+	}
+	if !strings.Contains(got, `"level":"error"`) {
+		t.Errorf("segment.panic during Detect must be logged at level=error; got: %s", got)
+	}
+}

--- a/sdk/gsl/internal/render/render.go
+++ b/sdk/gsl/internal/render/render.go
@@ -96,7 +96,11 @@ func BuildSegments(cfg config.Config, deps Deps) []Segment {
 		}
 		switch sc.Type {
 		case "dirgit":
-			segs = append(segs, NewDirGitSegment(deps.Cwd, deps.Git))
+			dg := NewDirGitSegment(deps.Cwd, deps.Git)
+			// Reuse the caller's pre-computed status instead of re-running
+			// git.Status inside Detect (WS3/F12). Nil ⇒ detect it ourselves.
+			dg.Info = deps.GitInfo
+			segs = append(segs, dg)
 		case "repo":
 			segs = append(segs, NewRepoSegment(deps.Git, deps.GH, deps.Branch, deps.RegistryPath, sc.Options))
 		case "ai":
@@ -161,7 +165,7 @@ func RenderAt(ctx context.Context, cfg config.Config, st style.Style, segs []Seg
 						"event":   "segment.panic",
 						"segment": segmentTypeName(s),
 						"panic":   fmt.Sprintf("%v", r),
-					}).Warn("segment panicked; dropping")
+					}).Error("segment panicked; dropping")
 					results[idx] = result{ok: false}
 				}
 			}()

--- a/sdk/gsl/internal/render/seg_dirgit.go
+++ b/sdk/gsl/internal/render/seg_dirgit.go
@@ -23,14 +23,40 @@ type DirGitSegment struct {
 	Cwd string
 	// Git is the injected git.Runner used for git.Status.
 	Git git.Runner
+	// Info is a PRE-COMPUTED git status (from Deps.GitInfo, threaded through
+	// BuildSegments). When non-nil the segment MUST NOT shell out: the caller
+	// already paid for those two execs. Nil means "not pre-computed; detect it
+	// yourself", which keeps every other caller (tests, internal/preview)
+	// working unchanged.
+	Info *git.Info
 	// home overrides $HOME for ~-abbreviation (tests). Empty → os.UserHomeDir.
 	home string
 }
 
 // NewDirGitSegment builds a DirGitSegment. cwd may be "" to fall back to
 // os.Getwd at render time.
+//
+// The signature is deliberately unchanged (out-of-package callers depend on it);
+// a pre-computed status is supplied by setting the Info field, which
+// BuildSegments does from Deps.GitInfo.
 func NewDirGitSegment(cwd string, gitRunner git.Runner) *DirGitSegment {
 	return &DirGitSegment{Cwd: cwd, Git: gitRunner}
+}
+
+// status returns the git status for dir, reusing the pre-computed Info when the
+// caller threaded one in and shelling out only otherwise.
+func (s *DirGitSegment) status(ctx context.Context, dir string) (git.Info, bool) {
+	if s.Info != nil {
+		return *s.Info, true
+	}
+	if s.Git == nil {
+		return git.Info{}, false
+	}
+	info, err := git.Status(ctx, s.Git, dir)
+	if err != nil {
+		return git.Info{}, false
+	}
+	return info, true
 }
 
 // Render implements Segment.
@@ -57,10 +83,8 @@ func (s *DirGitSegment) Render(ctx context.Context, st style.Style, _ int) (text
 	b.WriteString(s.abbrev(cwd))
 
 	// Git detail (best-effort; omit on any error / cancellation).
-	if s.Git != nil {
-		if info, err := git.Status(ctx, s.Git, cwd); err == nil {
-			s.appendGit(&b, st, info)
-		}
+	if info, ok := s.status(ctx, cwd); ok {
+		s.appendGit(&b, st, info)
 	}
 
 	return b.String(), "dirgit", true

--- a/sdk/gsl/internal/render/seg_dirgit_data.go
+++ b/sdk/gsl/internal/render/seg_dirgit_data.go
@@ -51,11 +51,13 @@ func (s *DirGitSegment) detect(ctx context.Context) (segmentData, bool) {
 
 	d := &dirGitData{cwd: cwd, home: home}
 
-	if s.Git != nil {
-		if info, err := git.Status(ctx, s.Git, cwd); err == nil {
-			d.gitInfo = &info
-			d.hasGit = true
-		}
+	// Reuse the pre-threaded status when the caller already computed it
+	// (Deps.GitInfo); shell out only when it is nil. This is the OTHER half of
+	// the 4-execs-where-2-suffice fix — cmd used to run git.Status serially for
+	// the branch and then this segment ran it AGAIN inside Detect.
+	if info, ok := s.status(ctx, cwd); ok {
+		d.gitInfo = &info
+		d.hasGit = true
 	}
 
 	return d, true

--- a/sdk/gsl/scripts/check-deps.sh
+++ b/sdk/gsl/scripts/check-deps.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 # Dependency + seam gate for the gsl module.
 #
-# Two checks:
+# Three checks:
 #   1. os/exec seam — no package under internal/ EXCEPT internal/git,
-#      internal/mcp, and internal/gh may import "os/exec". Every subprocess
-#      call must go through those three seams so the logic stays fakeable.
-#      cmd/ is the composition root (wiring) and is intentionally exempt.
-#   2. License gate — go-licenses check ./... must find no GPL/AGPL/LGPL
+#      internal/mcp, internal/gh, and internal/exec may import "os/exec". Every
+#      subprocess call must go through those three seams so the logic stays
+#      fakeable. cmd/ is the composition root (wiring) and is intentionally
+#      exempt.
+#   2. internal/exec sub-gate — internal/exec is exempted from (1) because it
+#      holds the shared subprocess-containment helper (Setpgid + process-group
+#      kill + WaitDelay) that the three seams apply to their *exec.Cmd. It
+#      CONFIGURES commands; it must never RUN one, or it would become a fourth,
+#      unfakeable seam through the back door. Enforced by banning command
+#      construction/execution there.
+#   3. License gate — go-licenses check ./... must find no GPL/AGPL/LGPL
 #      (restricted) or forbidden license anywhere in the dependency tree.
 #      Skipped with a warning when go-licenses is absent, UNLESS
 #      GSL_STRICT_CHECK=1 (set in CI), in which case its absence is a failure.
@@ -18,19 +25,45 @@ cd "$MODULE_DIR"
 
 fail=0
 
-echo "== seam check: os/exec confined to internal/git + internal/mcp + internal/gh =="
+echo "== seam check: os/exec confined to internal/git + internal/mcp + internal/gh (+ internal/exec helper) =="
 violations="$(grep -rln '"os/exec"' --include='*.go' internal \
   | grep -v '_test\.go$' \
   | grep -v '^internal/git/' \
   | grep -v '^internal/mcp/' \
-  | grep -v '^internal/gh/' || true)"
+  | grep -v '^internal/gh/' \
+  | grep -v '^internal/exec/' || true)"
 if [ -n "$violations" ]; then
   echo "FAIL: os/exec imported outside the git/mcp/gh seams:"
   echo "$violations" | sed 's/^/  - /'
   echo "  Route subprocess calls through git.Runner / mcp.Runner / gh.Runner instead."
   fail=1
 else
-  echo "OK: no os/exec outside internal/git + internal/mcp + internal/gh."
+  echo "OK: no os/exec outside internal/git + internal/mcp + internal/gh + internal/exec."
+fi
+
+echo "== sub-gate: internal/exec configures commands, never runs them =="
+if [ -d internal/exec ]; then
+  # It may take an *exec.Cmd and set fields on it. It may not CREATE or START
+  # one — that would make it a fourth seam that no test can fake.
+  #
+  # Match CALLS, not prose: require the open paren, and drop comment lines (the
+  # package doc necessarily *names* exec.CommandContext when documenting that
+  # callers must use it).
+  runners="$(grep -rnE 'exec\.Command(Context)?\(|\.Start\(\)|\.Run\(\)|\.Output\(\)|\.CombinedOutput\(\)' \
+    --include='*.go' internal/exec \
+    | grep -v '_test\.go:' \
+    | grep -vE ':[0-9]+:[[:space:]]*//' || true)"
+  if [ -n "$runners" ]; then
+    echo "FAIL: internal/exec constructs or executes a command:"
+    echo "$runners" | sed 's/^/  - /'
+    echo "  internal/exec may only CONFIGURE a *exec.Cmd (Setpgid / Cancel / WaitDelay)."
+    echo "  Subprocess execution belongs in the git/gh/mcp seams, behind their Runner interfaces."
+    fail=1
+  else
+    echo "OK: internal/exec only configures commands."
+  fi
+else
+  echo "SKIP: internal/exec not present."
 fi
 
 echo "== license check: no GPL/AGPL/LGPL/forbidden in the dependency tree =="


### PR DESCRIPTION
**WS3 / `latency` leaf.** Removes the network call from the render hot path and makes every subprocess seam deadline-safe:

- `internal/gh/pr.go` — negative caching: `writeCache` on the **error** and **empty** paths too, so a failing `gh` (~760 ms) is not re-spawned every render (E19)
- `internal/exec/procgroup*.go` *(new)* — shared `Setpgid` + process-group kill helper (+ Windows no-op); wired into the git/gh/mcp runners with `cmd.WaitDelay`, so a grandchild holding the pipe can no longer wedge a render past its deadline (E18: was 5121 ms against an 800 ms deadline)
- `cmd/statusline.go` — deletes the serial `git.Status` call; `*git.Info` is threaded once through `Deps.GitInfo` (git subprocess count 4 → 2)
- `internal/exec/classify.go` — exit-status classification so expected non-zero exits log at Debug, not WARN
- `cmd/degraded_test.go` — E24 degraded-path coverage; `scripts/check-deps.sh` seam gate

**Gate (P3 done-when):** full `go test ./...` green ✅ incl. the grandchild-holds-pipe deadline tests and gh negative-cache tests — verified 2026-07-26 after restacking onto the rebased iface (#161).

<!-- gss:stack-begin -->
## Stack — gsl-ultra (#158)

- #159 — design (base: `main`) — MBO design/spec/plan docs
- #161 — iface (base: `main`) — frozen §3 interfaces (P0, blocking)
- #165 — width (base: `iface`) ∥ #166 — latency (base: `iface`) ∥ #167 — agy (base: `iface`)
- *(not started)* mcp → style → tui (plan §6.2)

Landing order: `iface` → (`width` ∥ `latency` ∥ `agy`) → `mcp` → `style` → `tui`. Review bottom-up; merge bottom-up.
<!-- gss:stack-end -->
