### PR TITLE
gsl-ultra: agy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -534,7 +534,15 @@ else gff_skip_msg install.sdk.wol; fi
 if gff_on install.sdk.gsl; then
   if [ -f "${BASE_DIR}/sdk/gsl/build.sh" ]; then
     echo "Installing gsl (Go status line)..."
-    bash "${BASE_DIR}/sdk/gsl/build.sh"
+    # This script has NO `set -e`, so an unchecked build.sh failure is silently
+    # SWALLOWED: install.sh would go on to print "Installation complete!" and exit
+    # 0 while gsl had not built at all. build.sh ends with the dependency + seam
+    # gate (sdk/gsl/scripts/check-deps.sh), so swallowing its exit status defeats
+    # the gate entirely — the exact hole this closes.
+    if ! bash "${BASE_DIR}/sdk/gsl/build.sh"; then
+        echo "ERROR: gsl build failed (see the build/seam-gate output above)." >&2
+        exit 1
+    fi
     if [ -f "${HOME}/opt/bin/gsl" ]; then
         echo "--------------------------------------------------"
         "${HOME}/opt/bin/gsl" version

--- a/opt/scripts/system/install_claude_skills.sh
+++ b/opt/scripts/system/install_claude_skills.sh
@@ -136,14 +136,28 @@ fi
 
 # --- statusline-command.sh (shim for gsl status line) ---
 # The settings.json template points statusLine.command at ~/.claude/statusline-command.sh.
-# This block symlinks the repo shim into place, backing up any existing plain file.
+# COPY the repo shim into that well-known $HOME path — do not symlink it.
+#
+# Per CLAUDE.md ("AI-tool config provisioning"), copy is the forward mechanism and
+# new repo-pointing symlinks must not be introduced. The old `ln -sf` was actively
+# dangerous here: running the installer from a `gss feature` worktree pointed
+# ~/.claude/statusline-command.sh at a TRANSIENT worktree path, so the user's global
+# status line broke the moment that worktree was cleaned up. install_antigravity_skills.sh
+# already copies this same shim (cp + chmod +x); this brings Claude to parity.
 if [ -f "$BASE_DIR/ai/claude/statusline-command.sh" ]; then
-    if [ -e "$CLAUDE_HOME/statusline-command.sh" ] && [ ! -L "$CLAUDE_HOME/statusline-command.sh" ]; then
+    if [ -L "$CLAUDE_HOME/statusline-command.sh" ]; then
+        # Legacy symlink (possibly into a stale checkout). Drop it so `install`
+        # writes a fresh regular file instead of following it back into the repo.
+        echo "  Replacing legacy statusline-command.sh symlink with a copy"
+        rm -f "$CLAUDE_HOME/statusline-command.sh"
+    elif [ -e "$CLAUDE_HOME/statusline-command.sh" ] &&
+        ! cmp -s "$BASE_DIR/ai/claude/statusline-command.sh" "$CLAUDE_HOME/statusline-command.sh"; then
+        # A different real file is present (hand-edited, or from an older revision).
+        # Back it up once; an identical copy is left alone so re-runs stay idempotent.
         echo "  Backing up existing statusline-command.sh -> statusline-command.sh.bak"
         mv "$CLAUDE_HOME/statusline-command.sh" "$CLAUDE_HOME/statusline-command.sh.bak"
     fi
-    ln -sf "$BASE_DIR/ai/claude/statusline-command.sh" "$CLAUDE_HOME/statusline-command.sh"
-    chmod +x "$BASE_DIR/ai/claude/statusline-command.sh"
+    install -m 0755 "$BASE_DIR/ai/claude/statusline-command.sh" "$CLAUDE_HOME/statusline-command.sh"
 fi
 
 echo "Claude Code configuration complete."

--- a/sdk/gsl/cmd/agy_toolctx_test.go
+++ b/sdk/gsl/cmd/agy_toolctx_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+// Regression tests for the agy render path.
+//
+// THE BUG: agy's settings.json points statusLine.command at a shim that `exec`s
+// `gsl render` with the payload on stdin — exactly like Claude Code. agy's
+// payload carries cwd + model + context_window, so deriveToolCtx's "payload is
+// populated ⇒ claude" rule matched EVERY agy render and returned "claude".
+// theme.Resolve therefore read ~/.claude/settings.json for Antigravity users and
+// the whole `case "antigravity"` branch — including the colorScheme support that
+// this leaf added — was DEAD CODE on the real agy path. The unit tests for it
+// were green because they called theme.Resolve("antigravity", …) directly, a
+// context production never produced.
+//
+// THE FIX: agy sends "product": "antigravity" in every payload (confirmed in the
+// live capture, internal/payload/testdata/agy_live.json). deriveToolCtx now keys
+// on that in-band discriminator first.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
+)
+
+// agyLivePayload returns the REAL captured agy payload (shared fixture, so this
+// test tracks the wire format rather than a hand-written idea of it).
+func agyLivePayload(t *testing.T) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "internal", "payload", "testdata", "agy_live.json"))
+	if err != nil {
+		t.Fatalf("reading the captured agy payload: %v", err)
+	}
+	return data
+}
+
+// TestDeriveToolCtx_AgyLivePayload — the real agy payload must resolve to the
+// antigravity context, NOT claude. Pre-fix this returned "claude".
+func TestDeriveToolCtx_AgyLivePayload(t *testing.T) {
+	p, err := payload.Parse(agyLivePayload(t))
+	if err != nil {
+		t.Fatalf("payload.Parse: %v", err)
+	}
+	if p.Product == nil {
+		t.Fatal("the captured payload has product:\"antigravity\" but Payload.Product is nil " +
+			"(field not decoded in Parse)")
+	}
+	noEnv := func(string) string { return "" }
+	if got := deriveToolCtx(p, noEnv); got != "antigravity" {
+		t.Errorf("deriveToolCtx(real agy payload) = %q, want \"antigravity\" "+
+			"(a populated agy payload was being misread as Claude, so the agy theme was never resolved)", got)
+	}
+}
+
+// TestDeriveToolCtx_ProductKey pins the discriminator's edges.
+func TestDeriveToolCtx_ProductKey(t *testing.T) {
+	noEnv := func(string) string { return "" }
+	cwd := "/tmp"
+
+	tests := []struct {
+		name    string
+		product *string
+		want    string
+	}{
+		{"product=antigravity wins over a claude-shaped payload", strptr("antigravity"), "antigravity"},
+		{"product is case-insensitive", strptr("Antigravity"), "antigravity"},
+		{"no product key -> claude (Claude Code sends none)", nil, "claude"},
+		{"unknown product -> claude heuristic", strptr("something-else"), "claude"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := payload.Payload{Cwd: &cwd, Model: &payload.Model{}, Product: tc.product}
+			if got := deriveToolCtx(p, noEnv); got != tc.want {
+				t.Errorf("deriveToolCtx = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func strptr(s string) *string { return &s }
+
+// renderWithHomes runs the real render path over the real captured agy payload
+// with a synthetic $HOME containing both settings files, and returns the raw
+// (ANSI-bearing) output.
+func renderWithHomes(t *testing.T, claudeTheme, agyColorScheme string) string {
+	t.Helper()
+
+	home := t.TempDir()
+	mustWriteJSON(t, filepath.Join(home, ".claude", "settings.json"),
+		map[string]any{"theme": claudeTheme})
+	mustWriteJSON(t, filepath.Join(home, ".gemini", "antigravity-cli", "settings.json"),
+		map[string]any{"colorScheme": agyColorScheme})
+
+	t.Setenv("HOME", home)
+	t.Setenv("COLUMNS", "200") // wide: no compaction
+
+	cfg := config.Default()
+	cfg.Style = "powerline" // a palette-driven style, so the theme is observable
+	cfgHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	if err := config.Save(config.DefaultPath(), cfg); err != nil {
+		t.Fatalf("setup: config.Save: %v", err)
+	}
+
+	p, err := payload.Parse(agyLivePayload(t))
+	if err != nil {
+		t.Fatalf("payload.Parse: %v", err)
+	}
+	return captureStdout(t, func() { _ = runStatusLine(renderCmd, p, "/tmp") })
+}
+
+// ansiCodes extracts just the SGR escape sequences from a rendered line. The
+// line also carries a live clock, so the raw strings always differ; the PALETTE
+// is what this test is about.
+func ansiCodes(s string) string {
+	return strings.Join(sgrRe.FindAllString(s, -1), "|")
+}
+
+var sgrRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func mustWriteJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestRunStatusLine_AgyThemeComesFromAntigravitySettings is the END-TO-END proof
+// that the colorScheme fix reaches a real agy render. Two assertions, one pair:
+//
+//   - flipping the AGY colorScheme (claude settings held constant) MUST change
+//     the rendered ANSI — the agy settings file is being read;
+//   - flipping the CLAUDE theme (agy colorScheme held constant) MUST NOT change
+//     it — the Claude settings file is NOT being read for an agy payload.
+//
+// Pre-fix both assertions failed (inverted): the agy payload resolved as
+// "claude", so ~/.claude/settings.json drove the palette and the agy colorScheme
+// was ignored entirely.
+func TestRunStatusLine_AgyThemeComesFromAntigravitySettings(t *testing.T) {
+	agyLight := ansiCodes(renderWithHomes(t, "dark", "light"))
+	agyDark := ansiCodes(renderWithHomes(t, "dark", "dark"))
+	if agyLight == "" || agyDark == "" {
+		t.Fatal("no ANSI codes in the render output")
+	}
+	if agyLight == agyDark {
+		t.Errorf("flipping the agy colorScheme did not change the palette (%s)\n"+
+			"the Antigravity settings file is not reaching the render path", agyLight)
+	}
+
+	claudeDark := ansiCodes(renderWithHomes(t, "dark", "light"))
+	claudeLight := ansiCodes(renderWithHomes(t, "light", "light"))
+	if claudeDark != claudeLight {
+		t.Errorf("flipping the CLAUDE theme changed the palette of an AGY render:\n"+
+			" claude=light -> %s\n claude=dark  -> %s\n"+
+			"gsl is resolving the Claude theme for an Antigravity payload", claudeLight, claudeDark)
+	}
+}

--- a/sdk/gsl/cmd/statusline.go
+++ b/sdk/gsl/cmd/statusline.go
@@ -24,28 +24,40 @@ import (
 // environment, for use with theme.Resolve.
 //
 // Rules (in priority order):
-//  1. If the Claude payload is populated (Cwd, Model, ContextWindow, or
+//  1. In-band `product` key: agy sends "product": "antigravity" in EVERY
+//     payload, so it is authoritative and is checked FIRST.
+//  2. If the payload is otherwise populated (Cwd, Model, ContextWindow, or
 //     RateLimits is non-nil), the caller is "claude".
-//  2. If any recognized Antigravity environment variable — or a legacy
+//  3. If any recognized Antigravity environment variable — or a legacy
 //     Gemini-era variable (Antigravity CLI deliberately reuses the ~/.gemini
 //     config tree, and Gemini CLI is EOL) — is set and non-empty, the caller
-//     is "antigravity".
-//  3. Otherwise "" (unknown / plain shell usage).
+//     is "antigravity". This still covers `gsl status` (no stdin payload).
+//  4. Otherwise "" (unknown / plain shell usage).
 //
 // env is the env-lookup function (os.Getenv in production; injected in tests).
 //
-// NOTE: The canonical Antigravity (agy) status-line environment variable is
-// unconfirmed at the time of writing. We check ANTIGRAVITY_CLI plus the
-// Gemini-era vars as a best-effort heuristic.
-// TODO(gsl): confirm canonical Antigravity status-line env var and update this list.
+// Why rule 1 exists (the bug it fixes): BOTH hosts run the same shim — agy's
+// settings.json points statusLine.command at a script that `exec`s `gsl render`
+// with the payload on stdin, exactly as Claude Code does — and agy's payload
+// carries cwd + model + context_window. So rule 2 matched EVERY agy render and
+// deriveToolCtx returned "claude", which made theme.Resolve read
+// ~/.claude/settings.json for Antigravity users. The entire "antigravity" branch
+// of theme.Resolve (including the colorScheme support) was dead code on the real
+// agy render path: an agy user with colorScheme "light" got their Claude theme —
+// or a dark line — no matter what their Antigravity settings said. The env-var
+// heuristic below never rescued it, because the payload check ran first.
 func deriveToolCtx(p payload.Payload, env func(string) string) string {
-	// Claude: the render subcommand populates the payload from stdin.
+	// 1. In-band product key — the only reliable discriminator, and the one agy
+	//    actually sends on every render.
+	if p.IsAntigravity() {
+		return "antigravity"
+	}
+	// 2. Claude: the render subcommand populates the payload from stdin.
 	if p.Cwd != nil || p.Model != nil || p.ContextWindow != nil || p.RateLimits != nil {
 		return "claude"
 	}
-	// Antigravity: best-effort heuristic — check known Antigravity env vars
-	// and the legacy Gemini-era vars it inherits.
-	// TODO(gsl): confirm canonical Antigravity status-line env var.
+	// 3. Antigravity with no payload (`gsl status`): fall back to env vars, incl.
+	//    the legacy Gemini-era vars it inherits.
 	for _, key := range []string{"ANTIGRAVITY_CLI", "ANTIGRAVITY_CLI_CONTEXT", "GEMINI_CLI", "GEMINI_API_KEY", "GEMINI_CLI_CONTEXT"} {
 		if env(key) != "" {
 			return "antigravity"

--- a/sdk/gsl/internal/payload/agy_test.go
+++ b/sdk/gsl/internal/payload/agy_test.go
@@ -1,0 +1,205 @@
+package payload_test
+
+import (
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
+)
+
+// readFixture is defined in payload_test.go (same package).
+
+// TestParse_AgyLive (E21) parses the CAPTURED real Antigravity payload.
+//
+// Provenance of testdata/agy_live.json — this is a real capture, not an
+// invention. It was taken on 2026-07-11 from agy v1.1.1 (a Go binary,
+// google3/third_party/jetski/cli) by temporarily replacing the statusLine
+// command configured in ~/.gemini/antigravity-cli/settings.json
+// ("bash ~/.gemini/config/statusline-command.sh") with a shim that tee'd
+// stdin to a file, then running `agy -p "..."`. 14 payloads were captured
+// across the session; this is the steady-state one. The ONLY edits are
+// privacy redactions: the "email" value, the session/conversation UUIDs, and
+// the $HOME path components. Every KEY, every value SHAPE, and all quota
+// numbers are byte-faithful to what agy actually sent.
+//
+// The capture disproved two assumptions baked into payload.go by PR #157:
+//   - each quota bucket carries reset_time + reset_in_seconds, which the
+//     hardcoded struct dropped on the floor;
+//   - agy never sends rate_limits at all, so the quota synthesis is the ONLY
+//     source of the AI segment's rate data.
+func TestParse_AgyLive(t *testing.T) {
+	p, err := payload.Parse(readFixture(t, "agy_live.json"))
+	if err != nil {
+		t.Fatalf("Parse(agy_live.json): unexpected error: %v", err)
+	}
+
+	// The four bucket keys agy actually sends.
+	wantBuckets := []string{"3p-5h", "3p-weekly", "gemini-5h", "gemini-weekly"}
+	for _, k := range wantBuckets {
+		if _, ok := p.Quota[k]; !ok {
+			t.Errorf("quota bucket %q missing from parsed payload (have %v)", k, p.Quota)
+		}
+	}
+	if got, want := len(p.Quota), len(wantBuckets); got != want {
+		t.Errorf("quota bucket count: got %d, want %d", got, want)
+	}
+
+	// reset_time is REAL and must survive. The pre-fix struct modelled only
+	// remaining_fraction, so this assertion is the red.
+	gw, ok := p.Quota["gemini-weekly"]
+	if !ok {
+		t.Fatal("gemini-weekly bucket missing")
+	}
+	if gw.ResetTime == nil {
+		t.Fatal("gemini-weekly.reset_time was dropped (nil); the capture has it")
+	}
+	if got, want := gw.ResetTime.String(), "2026-07-14T14:49:20Z"; got != want {
+		t.Errorf("gemini-weekly.reset_time: got %q, want %q", got, want)
+	}
+	if gw.ResetInSeconds == nil || *gw.ResetInSeconds != 227553 {
+		t.Errorf("gemini-weekly.reset_in_seconds: got %v, want 227553", gw.ResetInSeconds)
+	}
+
+	// agy sends NO rate_limits; the AI segment depends entirely on synthesis.
+	if p.RateLimits == nil {
+		t.Fatal("RateLimits not synthesized from quota")
+	}
+	if p.RateLimits.SevenDay == nil || p.RateLimits.SevenDay.UsedPercentage == nil {
+		t.Fatal("SevenDay not synthesized")
+	}
+	// gemini-weekly remaining_fraction 0.86283696 → used ≈ 13.716%
+	if got := *p.RateLimits.SevenDay.UsedPercentage; got < 13.7 || got > 13.73 {
+		t.Errorf("SevenDay.UsedPercentage: got %f, want ≈13.716", got)
+	}
+	// The synthesized window must carry the reset timestamp through.
+	if p.RateLimits.SevenDay.ResetsAt == nil {
+		t.Error("SevenDay.ResetsAt is nil; reset_time from the quota bucket was not threaded through")
+	} else if got, want := p.RateLimits.SevenDay.ResetsAt.String(), "2026-07-14T14:49:20Z"; got != want {
+		t.Errorf("SevenDay.ResetsAt: got %q, want %q", got, want)
+	}
+
+	if p.TerminalWidth == nil || *p.TerminalWidth != 80 {
+		t.Errorf("terminal_width: got %v, want 80", p.TerminalWidth)
+	}
+}
+
+// TestParse_AgyLiveAuthenticating parses the real early-session capture where
+// agy sends "model": null, "current_usage": null, no quota, and no plan_tier.
+// A null field must not poison the rest of the payload.
+func TestParse_AgyLiveAuthenticating(t *testing.T) {
+	p, err := payload.Parse(readFixture(t, "agy_live_authenticating.json"))
+	if err != nil {
+		t.Fatalf("Parse(agy_live_authenticating.json): unexpected error: %v", err)
+	}
+	if p.Model != nil {
+		t.Errorf("model was null in the capture; want nil, got %+v", p.Model)
+	}
+	if len(p.Quota) != 0 {
+		t.Errorf("quota absent in the capture; want empty, got %v", p.Quota)
+	}
+	// Fields that WERE present must still land.
+	if p.Cwd == nil || *p.Cwd != "/home/user/git/dotfiles" {
+		t.Errorf("cwd: got %v, want /home/user/git/dotfiles", p.Cwd)
+	}
+	if p.TerminalWidth == nil || *p.TerminalWidth != 80 {
+		t.Errorf("terminal_width: got %v, want 80", p.TerminalWidth)
+	}
+}
+
+// TestParse_QuotaBucketRename (E21 edge: "unknown bucket key → still rendered")
+// is the regression guard for the brittleness PR #157 shipped: the bucket keys
+// were HARDCODED, so an upstream rename would silently delete the quota display
+// rather than degrade. Buckets are now classified by suffix heuristic, so keys
+// this code has never seen still resolve to a window.
+func TestParse_QuotaBucketRename(t *testing.T) {
+	// Plausibly-renamed upstream keys — none of them are the four literals.
+	data := []byte(`{
+		"quota": {
+			"gemini-3-hourly":  {"remaining_fraction": 0.25},
+			"gemini-3-weekly":  {"remaining_fraction": 0.50}
+		}
+	}`)
+	p, err := payload.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if len(p.Quota) != 2 {
+		t.Errorf("renamed buckets dropped: got %d buckets, want 2 (%v)", len(p.Quota), p.Quota)
+	}
+
+	if p.RateLimits == nil {
+		t.Fatal("RateLimits nil: a bucket-key rename silently deleted the quota display")
+	}
+	if p.RateLimits.FiveHour == nil || p.RateLimits.FiveHour.UsedPercentage == nil {
+		t.Fatal("FiveHour not synthesized from the renamed *-hourly bucket")
+	}
+	if got, want := *p.RateLimits.FiveHour.UsedPercentage, 75.0; got < want-0.01 || got > want+0.01 {
+		t.Errorf("FiveHour.UsedPercentage: got %f, want %f", got, want)
+	}
+	if p.RateLimits.SevenDay == nil || p.RateLimits.SevenDay.UsedPercentage == nil {
+		t.Fatal("SevenDay not synthesized from the renamed *-weekly bucket")
+	}
+	if got, want := *p.RateLimits.SevenDay.UsedPercentage, 50.0; got < want-0.01 || got > want+0.01 {
+		t.Errorf("SevenDay.UsedPercentage: got %f, want %f", got, want)
+	}
+}
+
+// TestClassifyQuotaBucket pins the suffix heuristic (F15).
+func TestClassifyQuotaBucket(t *testing.T) {
+	cases := []struct {
+		key  string
+		want payload.QuotaKind
+	}{
+		// The four keys agy actually sends today.
+		{"3p-5h", payload.QuotaFiveHour},
+		{"gemini-5h", payload.QuotaFiveHour},
+		{"3p-weekly", payload.QuotaSevenDay},
+		{"gemini-weekly", payload.QuotaSevenDay},
+		// Suffix heuristic — keys we have never seen.
+		{"gemini-hourly", payload.QuotaFiveHour},
+		{"anything-hour", payload.QuotaFiveHour},
+		{"claude-7d", payload.QuotaSevenDay},
+		{"opus-week", payload.QuotaSevenDay},
+		{"UPPER-WEEKLY", payload.QuotaSevenDay},
+		// "week" must win over "hour" when both appear.
+		{"168-hour-weekly", payload.QuotaSevenDay},
+		// Genuinely unclassifiable.
+		{"monthly", payload.QuotaUnknown},
+		{"", payload.QuotaUnknown},
+	}
+	for _, tc := range cases {
+		if got := payload.ClassifyQuotaBucket(tc.key); got != tc.want {
+			t.Errorf("ClassifyQuotaBucket(%q) = %v, want %v", tc.key, got, tc.want)
+		}
+	}
+}
+
+// TestParse_QuotaSynthesisIsDeterministic guards the map iteration order.
+// Map ranging is randomized in Go; synthesis must not flap between the
+// "gemini" and "3p" buckets from render to render.
+func TestParse_QuotaSynthesisIsDeterministic(t *testing.T) {
+	data := readFixture(t, "agy_live.json")
+	var first float64
+	for i := range 50 {
+		p, err := payload.Parse(data)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		if p.RateLimits == nil || p.RateLimits.SevenDay == nil || p.RateLimits.SevenDay.UsedPercentage == nil {
+			t.Fatal("SevenDay not synthesized")
+		}
+		got := *p.RateLimits.SevenDay.UsedPercentage
+		if i == 0 {
+			first = got
+			continue
+		}
+		if got != first {
+			t.Fatalf("synthesis flapped across iterations: got %f, first %f "+
+				"(map iteration order leaked into the result)", got, first)
+		}
+	}
+	// gemini-weekly (0.86283696) must win over 3p-weekly (1.0) → ≈13.7, not 0.
+	if first < 13.7 || first > 13.73 {
+		t.Errorf("expected the gemini-* bucket to win (≈13.716%% used), got %f", first)
+	}
+}

--- a/sdk/gsl/internal/payload/field_coverage_test.go
+++ b/sdk/gsl/internal/payload/field_coverage_test.go
@@ -1,0 +1,103 @@
+package payload_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
+)
+
+// TestParse_EveryFieldIsDecoded guards the maintenance trap introduced by the
+// per-field tolerant decode: Parse no longer json.Unmarshal's into the Payload
+// struct, it calls decodeField once PER FIELD by name. A field added to the
+// struct but not to Parse therefore decodes to nil FOREVER — and every existing
+// test stays green while the segment that needs it silently goes blank. That is
+// the same "green test, dead code path" failure mode this whole objective exists
+// to kill.
+//
+// This test reflects over Payload's json tags, feeds Parse a payload that
+// populates every one of them, and fails if any field comes back zero. Adding a
+// field to Payload requires adding it here AND to Parse.
+func TestParse_EveryFieldIsDecoded(t *testing.T) {
+	// A valid JSON value for each json tag on Payload.
+	samples := map[string]string{
+		"cwd":            `"/home/user/repo"`,
+		"model":          `{"display_name":"X"}`,
+		"context_window": `{"used_percentage":1.0}`,
+		"rate_limits":    `{"five_hour":{"used_percentage":5.0}}`,
+		"terminal_width": `120`,
+		"quota":          `{"gemini-5h":{"remaining_fraction":0.5}}`,
+		"product":        `"antigravity"`,
+	}
+
+	typ := reflect.TypeOf(payload.Payload{})
+
+	// 1. Every json-tagged field must have a sample (forces this test to be
+	//    updated when the struct grows).
+	for i := range typ.NumField() {
+		tag := typ.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		if _, ok := samples[tag]; !ok {
+			t.Fatalf("Payload.%s has json tag %q with no sample in this test: add one, "+
+				"and make sure Parse calls decodeField for it", typ.Field(i).Name, tag)
+		}
+	}
+
+	// 2. Build the all-fields payload and parse it.
+	obj := make(map[string]json.RawMessage, len(samples))
+	for k, v := range samples {
+		obj[k] = json.RawMessage(v)
+	}
+	data, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	p, err := payload.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	// 3. No field may be zero — a zero field means Parse never decoded it.
+	v := reflect.ValueOf(p)
+	for i := range typ.NumField() {
+		f := typ.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		if v.Field(i).IsZero() {
+			t.Errorf("Payload.%s (json %q) was NOT decoded by Parse — the input carried %s. "+
+				"Parse is missing a decodeField call for this field.", f.Name, tag, samples[tag])
+		}
+	}
+}
+
+// TestParse_ProductFromLiveCapture — the discriminator cmd.deriveToolCtx relies
+// on must survive the real wire payload.
+func TestParse_ProductFromLiveCapture(t *testing.T) {
+	for _, name := range []string{"agy_live.json", "agy_live_authenticating.json"} {
+		p, err := payload.Parse(readFixture(t, name))
+		if err != nil {
+			t.Fatalf("Parse(%s): %v", name, err)
+		}
+		if p.Product == nil || *p.Product != "antigravity" {
+			t.Errorf("%s: product: got %v, want \"antigravity\" "+
+				"(this key is how gsl tells an agy render from a Claude render)", name, p.Product)
+		}
+		if !p.IsAntigravity() {
+			t.Errorf("%s: IsAntigravity() = false", name)
+		}
+	}
+
+	// A Claude payload has no product key and must not be mistaken for agy.
+	p, err := payload.Parse(readFixture(t, "full.json"))
+	if err != nil {
+		t.Fatalf("Parse(full.json): %v", err)
+	}
+	if p.IsAntigravity() {
+		t.Error("full.json (a Claude payload) was classified as Antigravity")
+	}
+}

--- a/sdk/gsl/internal/payload/fuzz_test.go
+++ b/sdk/gsl/internal/payload/fuzz_test.go
@@ -1,0 +1,85 @@
+package payload_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
+)
+
+// FuzzParse (E20) fuzzes the payload decoder.
+//
+// Parse is the prime fuzz target in gsl: it is the only place that consumes
+// untrusted bytes from another process's stdout, and ResetTime has a CUSTOM
+// UnmarshalJSON that hand-rolls number/string discrimination and does epoch
+// arithmetic (int64 conversion, a millisecond branch, time.Unix) — exactly the
+// shape that panics on a hostile input.
+//
+// The contract under fuzz:
+//   - Parse never panics, for any input.
+//   - Parse never returns both a non-nil error AND a populated Payload.
+//   - A Payload that comes back without an error is internally consistent
+//     (its ResetTime values can be stringified without blowing up).
+func FuzzParse(f *testing.F) {
+	// Seed with the real captures + every hand-written fixture.
+	for _, name := range []string{
+		"agy_live.json",
+		"agy_live_authenticating.json",
+		"full.json",
+		"five_hour_only.json",
+		"live_numeric_resets.json",
+		"null_used_pct.json",
+	} {
+		if data, err := os.ReadFile(filepath.Join("testdata", name)); err == nil {
+			f.Add(data)
+		}
+	}
+
+	// Seeds that target the custom ResetTime decoder and the per-field seam.
+	f.Add([]byte(``))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"quota":{"x-5h":{"remaining_fraction":1e308}}}`))
+	f.Add([]byte(`{"rate_limits":{"five_hour":{"resets_at":9223372036854775807}}}`))
+	f.Add([]byte(`{"rate_limits":{"five_hour":{"resets_at":-9223372036854775808}}}`))
+	f.Add([]byte(`{"rate_limits":{"five_hour":{"resets_at":1e308}}}`))
+	f.Add([]byte(`{"rate_limits":{"five_hour":{"resets_at":-1e308}}}`))
+	f.Add([]byte(`{"rate_limits":{"five_hour":{"resets_at":1783813000000}}}`))
+	f.Add([]byte(`{"rate_limits":{"five_hour":{"resets_at":"2026-07-14T14:49:20Z"}}}`))
+	f.Add([]byte(`{"rate_limits":{"five_hour":{"resets_at":""}}}`))
+	f.Add([]byte(`{"rate_limits":{"five_hour":{"resets_at":null}}}`))
+	f.Add([]byte(`{"rate_limits":{"five_hour":{"resets_at":NaN}}}`))
+	f.Add([]byte(`{"context_window":"not-an-object","model":{"display_name":"x"}}`))
+	f.Add([]byte(`{"terminal_width":-2147483648}`))
+	f.Add([]byte(`{"quota":{"":{"remaining_fraction":null}}}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		p, err := payload.Parse(data) // must not panic
+		if err != nil {
+			// On error the Payload must be the zero value — callers rely on
+			// not having to distinguish "partially populated" from "empty".
+			if p.Cwd != nil || p.Model != nil || p.ContextWindow != nil ||
+				p.RateLimits != nil || p.TerminalWidth != nil || p.Quota != nil {
+				t.Fatalf("Parse returned an error AND a populated payload: %+v", p)
+			}
+			return
+		}
+
+		// Touch every decoded value: stringifying a ResetTime must not panic
+		// regardless of what epoch arithmetic produced.
+		if p.RateLimits != nil {
+			for _, w := range []*payload.RateWindow{p.RateLimits.FiveHour, p.RateLimits.SevenDay} {
+				if w != nil && w.ResetsAt != nil {
+					_ = w.ResetsAt.String()
+					_ = w.ResetsAt.Time()
+				}
+			}
+		}
+		for k, w := range p.Quota {
+			_ = payload.ClassifyQuotaBucket(k)
+			if w.ResetTime != nil {
+				_ = w.ResetTime.String()
+			}
+		}
+	})
+}

--- a/sdk/gsl/internal/payload/payload.go
+++ b/sdk/gsl/internal/payload/payload.go
@@ -14,8 +14,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
 )
 
 // NewResetTime wraps a time.Time as a ResetTime. Convenience constructor
@@ -123,60 +126,219 @@ type Model struct {
 	DisplayName *string `json:"display_name"`
 }
 
-// QuotaWindow holds the quota data for one window in the Antigravity payload.
+// QuotaWindow holds the quota data for one bucket in the Antigravity payload.
+//
+// Shape confirmed against a real agy v1.1.1 capture (see
+// testdata/agy_live.json and the provenance note on TestParse_AgyLive):
+//
+//	"gemini-weekly": {
+//	  "remaining_fraction": 0.86283696,
+//	  "reset_time": "2026-07-14T14:49:20Z",
+//	  "reset_in_seconds": 227553
+//	}
+//
+// PR #157 modelled only remaining_fraction and dropped the other two.
 type QuotaWindow struct {
-	RemainingFraction *float64 `json:"remaining_fraction"`
+	RemainingFraction *float64   `json:"remaining_fraction"`
+	ResetTime         *ResetTime `json:"reset_time"`
+	ResetInSeconds    *float64   `json:"reset_in_seconds"`
 }
 
-// Quotas groups the quota windows in the Antigravity payload.
-type Quotas struct {
-	ThreePHour   *QuotaWindow `json:"3p-5h"`
-	ThreePWeekly *QuotaWindow `json:"3p-weekly"`
-	GeminiHour   *QuotaWindow `json:"gemini-5h"`
-	GeminiWeekly *QuotaWindow `json:"gemini-weekly"`
+// Quotas maps an Antigravity quota-bucket key to its window.
+//
+// It is deliberately a MAP and not a struct with four hardcoded keys. agy
+// v1.1.1 sends "3p-5h", "3p-weekly", "gemini-5h" and "gemini-weekly", but
+// those keys are agy's private naming, not a contract: they encode a model
+// vendor ("3p" = third-party, "gemini" = first-party) and a window length,
+// both of which move as Google ships models. With the previous hardcoded
+// struct an upstream rename would have decoded to all-nil and SILENTLY
+// deleted the quota display. Buckets are now classified by suffix heuristic
+// (ClassifyQuotaBucket), so an unrecognised key still resolves to a window
+// and the segment degrades gracefully instead of disappearing.
+type Quotas map[string]QuotaWindow
+
+// QuotaKind is the rolling window a quota bucket belongs to.
+type QuotaKind int
+
+const (
+	// QuotaUnknown means the bucket key matched no window heuristic.
+	QuotaUnknown QuotaKind = iota
+	// QuotaFiveHour is the short rolling window (agy: "*-5h").
+	QuotaFiveHour
+	// QuotaSevenDay is the long rolling window (agy: "*-weekly").
+	QuotaSevenDay
+)
+
+// ClassifyQuotaBucket maps a quota-bucket key to its rolling window using a
+// suffix heuristic (F15):
+//
+//	contains "week" or "7d"          → QuotaSevenDay
+//	contains "5h"   or "hour"        → QuotaFiveHour
+//	otherwise                        → QuotaUnknown
+//
+// The seven-day test runs FIRST so a hypothetical "168-hour-weekly" is
+// classified as the long window rather than the short one.
+func ClassifyQuotaBucket(key string) QuotaKind {
+	k := strings.ToLower(key)
+	if strings.Contains(k, "week") || strings.Contains(k, "7d") {
+		return QuotaSevenDay
+	}
+	if strings.Contains(k, "5h") || strings.Contains(k, "hour") {
+		return QuotaFiveHour
+	}
+	return QuotaUnknown
+}
+
+// pick returns the quota bucket to use for the given window.
+//
+// Map iteration order is randomised in Go, so selection must be deterministic
+// or the rendered percentage would flap between the "gemini" and "3p" buckets
+// from one render to the next. Candidate keys are sorted, and a first-party
+// ("gemini") bucket wins over any other — preserving the precedence PR #157
+// established with its explicit if/else chain.
+func (q Quotas) pick(kind QuotaKind) (QuotaWindow, bool) {
+	var keys []string
+	for k := range q {
+		if ClassifyQuotaBucket(k) == kind {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return QuotaWindow{}, false
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if strings.Contains(strings.ToLower(k), "gemini") {
+			return q[k], true
+		}
+	}
+	return q[keys[0]], true
+}
+
+// toRateWindow converts an agy quota bucket into the RateWindow shape the
+// renderer consumes. remaining_fraction (1.0 = untouched) inverts into a
+// used percentage; reset_time carries through to ResetsAt.
+func (w QuotaWindow) toRateWindow() *RateWindow {
+	if w.RemainingFraction == nil {
+		return nil
+	}
+	used := (1.0 - *w.RemainingFraction) * 100.0
+	rw := &RateWindow{UsedPercentage: &used}
+	if w.ResetTime != nil && !w.ResetTime.Time().IsZero() {
+		rt := *w.ResetTime
+		rw.ResetsAt = &rt
+	}
+	return rw
 }
 
 // Payload is the top-level structure parsed from Claude's stdin JSON.
 // All fields are pointers; an entirely empty/whitespace stdin yields a
 // zero-valued Payload (all nil) and no error.
+//
+// IMPORTANT: every field here must have a matching decodeField call in Parse.
+// A field added to the struct but not to Parse decodes to nil FOREVER, silently.
+// TestParse_EveryFieldIsDecoded (reflection over the json tags) is the guard.
 type Payload struct {
 	Cwd           *string        `json:"cwd"`
 	Model         *Model         `json:"model"`
 	ContextWindow *ContextWindow `json:"context_window"`
 	RateLimits    *RateLimits    `json:"rate_limits"`
 	TerminalWidth *int           `json:"terminal_width"`
-	Quota         *Quotas        `json:"quota"`
+	Quota         Quotas         `json:"quota"`
+
+	// Product is the host tool's self-identification. agy v1.1.1 sends
+	// "antigravity" in EVERY payload (confirmed in the live capture — see
+	// testdata/agy_live.json); Claude Code sends no such key.
+	//
+	// This is the only reliable in-band discriminator between the two hosts.
+	// Both CLIs invoke the SAME shim (`gsl render`, payload on stdin), and the
+	// payload shapes overlap almost completely, so without this key an agy
+	// render is indistinguishable from a Claude render and gets the Claude
+	// theme resolved against ~/.claude/settings.json. See cmd.deriveToolCtx.
+	Product *string `json:"product"`
 }
 
-// Parse decodes a Claude stdin JSON payload from the given byte slice.
+// IsAntigravity reports whether the payload came from the Antigravity CLI,
+// using the in-band `product` key agy sends on every render.
+func (p Payload) IsAntigravity() bool {
+	return p.Product != nil && strings.EqualFold(strings.TrimSpace(*p.Product), "antigravity")
+}
+
+// decodeField decodes one top-level field into dst, IN ISOLATION.
+//
+// This is the heart of the per-field tolerance contract (F14 / #31). A field
+// whose JSON type does not match its Go type is DROPPED — dst is left at its
+// zero value and the failure is logged at Debug — while every other field in
+// the payload still decodes. Absent and null fields are no-ops.
+//
+// Before this existed, Parse ran a single json.Unmarshal over the whole
+// Payload struct, so the first type mismatch aborted the entire decode: the
+// caller got a zero Payload and the AI segment vanished for the rest of the
+// session. That was #30 (a number-shaped resets_at) and, generalised, #31.
+func decodeField[T any](raw map[string]json.RawMessage, key string, dst *T) {
+	r, ok := raw[key]
+	if !ok {
+		return
+	}
+	trimmed := bytes.TrimSpace(r)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return
+	}
+	var v T
+	if err := json.Unmarshal(trimmed, &v); err != nil {
+		// Drop ONLY this field. The payload survives.
+		observe.Default().WithField("field", key).
+			WithError(err).
+			Debug("payload: dropping field with unexpected type")
+		return
+	}
+	*dst = v
+}
+
+// Parse decodes a Claude Code / Antigravity stdin JSON payload.
+//
 // Empty or whitespace-only input returns an empty Payload{} and a nil error.
-// Malformed JSON returns a non-nil error.
+// Input that is not a JSON object returns a non-nil error.
+//
+// Tolerance is per-FIELD, not per-byte: once the input is a valid JSON object,
+// each known field is decoded independently and a field with an unexpected
+// type is dropped on its own rather than discarding the whole payload (F14 /
+// #31). See decodeField.
 func Parse(data []byte) (Payload, error) {
 	if strings.TrimSpace(string(data)) == "" {
 		return Payload{}, nil
 	}
-	var p Payload
-	if err := json.Unmarshal(data, &p); err != nil {
+
+	// One shallow decode establishes that this IS a JSON object; field values
+	// stay raw so each can be decoded (and fail) independently.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
 		return Payload{}, fmt.Errorf("payload: parse: %w", err)
 	}
 
-	// Synthesize RateLimits from Quota if running under Antigravity
-	if p.RateLimits == nil && p.Quota != nil {
-		p.RateLimits = &RateLimits{}
-		if q := p.Quota.GeminiHour; q != nil && q.RemainingFraction != nil {
-			used := (1.0 - *q.RemainingFraction) * 100.0
-			p.RateLimits.FiveHour = &RateWindow{UsedPercentage: &used}
-		} else if q := p.Quota.ThreePHour; q != nil && q.RemainingFraction != nil {
-			used := (1.0 - *q.RemainingFraction) * 100.0
-			p.RateLimits.FiveHour = &RateWindow{UsedPercentage: &used}
-		}
+	var p Payload
+	decodeField(raw, "cwd", &p.Cwd)
+	decodeField(raw, "model", &p.Model)
+	decodeField(raw, "context_window", &p.ContextWindow)
+	decodeField(raw, "rate_limits", &p.RateLimits)
+	decodeField(raw, "terminal_width", &p.TerminalWidth)
+	decodeField(raw, "quota", &p.Quota)
+	decodeField(raw, "product", &p.Product)
 
-		if q := p.Quota.GeminiWeekly; q != nil && q.RemainingFraction != nil {
-			used := (1.0 - *q.RemainingFraction) * 100.0
-			p.RateLimits.SevenDay = &RateWindow{UsedPercentage: &used}
-		} else if q := p.Quota.ThreePWeekly; q != nil && q.RemainingFraction != nil {
-			used := (1.0 - *q.RemainingFraction) * 100.0
-			p.RateLimits.SevenDay = &RateWindow{UsedPercentage: &used}
+	// Antigravity sends `quota` and NO `rate_limits` at all (confirmed across
+	// 14 captured agy v1.1.1 payloads), so synthesis is the ONLY source of the
+	// AI segment's rate data under agy. Buckets are matched by heuristic, not
+	// by hardcoded key.
+	if p.RateLimits == nil && len(p.Quota) > 0 {
+		rl := &RateLimits{}
+		if w, ok := p.Quota.pick(QuotaFiveHour); ok {
+			rl.FiveHour = w.toRateWindow()
+		}
+		if w, ok := p.Quota.pick(QuotaSevenDay); ok {
+			rl.SevenDay = w.toRateWindow()
+		}
+		if rl.FiveHour != nil || rl.SevenDay != nil {
+			p.RateLimits = rl
 		}
 	}
 

--- a/sdk/gsl/internal/payload/testdata/agy_live.json
+++ b/sdk/gsl/internal/payload/testdata/agy_live.json
@@ -1,0 +1,62 @@
+{
+  "cwd": "/home/user/git/dotfiles",
+  "session_id": "00000000-0000-4000-8000-000000000000",
+  "conversation_id": "00000000-0000-4000-8000-000000000000",
+  "transcript_path": "/home/user/.gemini/antigravity/brain/00000000-0000-4000-8000-000000000000/.system_generated/logs/transcript.jsonl",
+  "model": {
+    "id": "Gemini 3.5 Flash (Medium)",
+    "display_name": "Gemini 3.5 Flash (Medium)"
+  },
+  "workspace": {
+    "current_dir": "/home/user/git/dotfiles",
+    "project_dir": "/home/user/git/dotfiles"
+  },
+  "version": "1.1.1",
+  "context_window": {
+    "total_input_tokens": 157,
+    "total_output_tokens": 819,
+    "context_window_size": 1048576,
+    "used_percentage": 0.014972686767578125,
+    "remaining_percentage": 99.98502731323242,
+    "current_usage": {
+      "input_tokens": 23571,
+      "output_tokens": 815,
+      "cache_creation_input_tokens": 0,
+      "cache_read_input_tokens": 0
+    }
+  },
+  "exceeds_200k_tokens": false,
+  "product": "antigravity",
+  "quota": {
+    "3p-5h": {
+      "remaining_fraction": 1,
+      "reset_time": "2026-07-12T04:36:42Z",
+      "reset_in_seconds": 17995
+    },
+    "3p-weekly": {
+      "remaining_fraction": 1,
+      "reset_time": "2026-07-18T23:36:42Z",
+      "reset_in_seconds": 604795
+    },
+    "gemini-5h": {
+      "remaining_fraction": 1,
+      "reset_time": "2026-07-12T04:36:42Z",
+      "reset_in_seconds": 17995
+    },
+    "gemini-weekly": {
+      "remaining_fraction": 0.86283696,
+      "reset_time": "2026-07-14T14:49:20Z",
+      "reset_in_seconds": 227553
+    }
+  },
+  "agent_state": "idle",
+  "vcs": {
+    "type": "git"
+  },
+  "sandbox": {
+    "enabled": false
+  },
+  "plan_tier": "Google AI Pro",
+  "email": "user@example.com",
+  "terminal_width": 80
+}

--- a/sdk/gsl/internal/payload/testdata/agy_live_authenticating.json
+++ b/sdk/gsl/internal/payload/testdata/agy_live_authenticating.json
@@ -1,0 +1,27 @@
+{
+  "cwd": "/home/user/git/dotfiles",
+  "session_id": "",
+  "conversation_id": "",
+  "transcript_path": "/home/user/.gemini/antigravity/brain/.system_generated/logs/transcript.jsonl",
+  "model": null,
+  "workspace": {
+    "current_dir": "/home/user/git/dotfiles",
+    "project_dir": "/home/user/git/dotfiles"
+  },
+  "version": "1.1.1",
+  "context_window": {
+    "total_input_tokens": 0,
+    "total_output_tokens": 0,
+    "context_window_size": 0,
+    "used_percentage": 0,
+    "remaining_percentage": 0,
+    "current_usage": null
+  },
+  "exceeds_200k_tokens": null,
+  "product": "antigravity",
+  "agent_state": "authenticating",
+  "sandbox": {
+    "enabled": false
+  },
+  "terminal_width": 80
+}

--- a/sdk/gsl/internal/payload/tolerant_test.go
+++ b/sdk/gsl/internal/payload/tolerant_test.go
@@ -1,0 +1,124 @@
+package payload_test
+
+import (
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
+)
+
+// TestParse_PerField (E20 / F14 / closes #31).
+//
+// Before this fix Parse did a single json.Unmarshal into the Payload struct,
+// so ONE field with an unexpected type made the decoder fail the WHOLE payload:
+// Parse returned a zero Payload and an error, the caller dropped everything,
+// and the AI segment vanished for the rest of the session. That is exactly the
+// class of bug tracked as #30 (a number-shaped resets_at killed the payload)
+// and generalized as #31.
+//
+// The contract now: a field whose type does not match is dropped INDIVIDUALLY;
+// every other field survives.
+func TestParse_PerField(t *testing.T) {
+	// context_window is a STRING where an object is expected. Everything else
+	// is well-formed and must survive.
+	data := []byte(`{
+		"cwd": "/home/user/repo",
+		"model": {"display_name": "Claude Opus 4.8 (1M context)"},
+		"context_window": "not-an-object",
+		"rate_limits": {
+			"five_hour": {"used_percentage": 42.0},
+			"seven_day": {"used_percentage": 7.5}
+		},
+		"terminal_width": 200
+	}`)
+
+	p, err := payload.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: one bad field must not fail the whole payload, got error: %v", err)
+	}
+
+	// The bad field — and ONLY the bad field — is dropped.
+	if p.ContextWindow != nil {
+		t.Errorf("context_window had a bad type; want nil, got %+v", p.ContextWindow)
+	}
+
+	// Everything else survives.
+	if p.Model == nil || p.Model.DisplayName == nil {
+		t.Fatal("model was discarded by an unrelated bad field (this is #31)")
+	}
+	if got, want := *p.Model.DisplayName, "Claude Opus 4.8 (1M context)"; got != want {
+		t.Errorf("model.display_name: got %q, want %q", got, want)
+	}
+	if p.RateLimits == nil || p.RateLimits.FiveHour == nil || p.RateLimits.FiveHour.UsedPercentage == nil {
+		t.Fatal("rate_limits was discarded by an unrelated bad field (this is #31)")
+	}
+	if got, want := *p.RateLimits.FiveHour.UsedPercentage, 42.0; got != want {
+		t.Errorf("rate_limits.five_hour.used_percentage: got %f, want %f", got, want)
+	}
+	if p.RateLimits.SevenDay == nil || p.RateLimits.SevenDay.UsedPercentage == nil {
+		t.Fatal("rate_limits.seven_day discarded")
+	}
+	if p.Cwd == nil || *p.Cwd != "/home/user/repo" {
+		t.Errorf("cwd: got %v, want /home/user/repo", p.Cwd)
+	}
+	if p.TerminalWidth == nil || *p.TerminalWidth != 200 {
+		t.Errorf("terminal_width: got %v, want 200", p.TerminalWidth)
+	}
+}
+
+// TestParse_PerField_BadNestedResetTime covers the #30 shape specifically: the
+// custom ResetTime.UnmarshalJSON rejects a bool. The five_hour window is lost,
+// but seven_day and the rest of the payload must survive.
+func TestParse_PerField_BadNestedResetTime(t *testing.T) {
+	data := []byte(`{
+		"model": {"display_name": "Sonnet"},
+		"rate_limits": {
+			"five_hour": {"used_percentage": 10.0, "resets_at": true},
+			"seven_day": {"used_percentage": 20.0}
+		}
+	}`)
+
+	p, err := payload.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if p.Model == nil || p.Model.DisplayName == nil || *p.Model.DisplayName != "Sonnet" {
+		t.Fatal("model discarded by a bad nested resets_at")
+	}
+	// rate_limits as a whole failed to decode (the bool resets_at is inside it),
+	// so it is dropped — but the payload survives and the model still renders.
+	// This is the degradation contract: lose the field, never the payload.
+}
+
+// TestParse_PerField_EveryFieldBad — a payload where every known field has the
+// wrong type must still Parse cleanly, yielding an empty Payload rather than an
+// error. Nothing to render is fine; a panic or a hard error is not.
+func TestParse_PerField_EveryFieldBad(t *testing.T) {
+	data := []byte(`{
+		"cwd": 12345,
+		"model": [1,2,3],
+		"context_window": "nope",
+		"rate_limits": false,
+		"terminal_width": {"x": 1},
+		"quota": "not-an-object"
+	}`)
+
+	p, err := payload.Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: all-bad fields must degrade, not error: %v", err)
+	}
+	if p.Cwd != nil || p.Model != nil || p.ContextWindow != nil ||
+		p.RateLimits != nil || p.TerminalWidth != nil || p.Quota != nil {
+		t.Errorf("expected an empty Payload, got %+v", p)
+	}
+}
+
+// TestParse_StillErrorsOnMalformedJSON — tolerance is per-FIELD, not per-byte.
+// Input that is not a JSON object at all is still an error (the existing
+// contract; callers rely on it to distinguish "no payload" from "broken pipe").
+func TestParse_StillErrorsOnMalformedJSON(t *testing.T) {
+	for _, in := range []string{`{`, `["not","an","object"]`, `nope`, `{"a":}`} {
+		if _, err := payload.Parse([]byte(in)); err == nil {
+			t.Errorf("Parse(%q): want error, got nil", in)
+		}
+	}
+}

--- a/sdk/gsl/internal/theme/colorscheme_test.go
+++ b/sdk/gsl/internal/theme/colorscheme_test.go
@@ -1,0 +1,148 @@
+package theme_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/theme"
+)
+
+// writeAgySettings writes a raw settings.json body to the Antigravity CLI path.
+func writeAgySettings(t *testing.T, home, body string) {
+	t.Helper()
+	dir := filepath.Join(home, ".gemini", "antigravity-cli")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// TestResolve_Antigravity_TopLevelColorScheme is the ground-truth test.
+//
+// gsl read "ui.theme", but agy does not write that key. The REAL
+// ~/.gemini/antigravity-cli/settings.json on a machine running agy v1.1.1 is:
+//
+//	{
+//	  "colorScheme": "light",
+//	  "enableTelemetry": false,
+//	  "trustedWorkspaces": ["..."],
+//	  "statusLine": { "type": "command", "command": "...", "enabled": true }
+//	}
+//
+// colorScheme is TOP-LEVEL. Because gsl looked for a "ui" object that never
+// exists, readAntigravityTheme returned "" for every real agy user and Resolve
+// fell through to the terminal palette — so a user on a LIGHT agy theme got a
+// DARK status line, permanently.
+func TestResolve_Antigravity_TopLevelColorScheme(t *testing.T) {
+	home := t.TempDir()
+	// Byte-faithful to the real file (paths/flags aside).
+	writeAgySettings(t, home, `{
+  "colorScheme": "light",
+  "enableTelemetry": false,
+  "trustedWorkspaces": ["/home/user/git/dotfiles"],
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.gemini/config/statusline-command.sh",
+    "enabled": true
+  }
+}`)
+	if got, want := theme.Resolve("antigravity", noEnv(), home), "light"; got != want {
+		t.Errorf("agy colorScheme=light: got %q, want %q "+
+			"(gsl is reading ui.theme, which agy never writes)", got, want)
+	}
+}
+
+// TestResolve_Antigravity_ColorSchemeKeywords runs the keyword bridge over the
+// top-level colorScheme key.
+func TestResolve_Antigravity_ColorSchemeKeywords(t *testing.T) {
+	cases := []struct{ scheme, want string }{
+		{"light", "light"},
+		{"Ayu Light", "light"},
+		{"dark", "dark"},
+		{"Tokyo Night", "dark"},
+		{"dark-daltonized", "dark-daltonism"},
+		{"colorblind", "dark-daltonism"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.scheme, func(t *testing.T) {
+			home := t.TempDir()
+			writeAgySettings(t, home, `{"colorScheme": "`+tc.scheme+`"}`)
+			if got := theme.Resolve("antigravity", noEnv(), home); got != tc.want {
+				t.Errorf("colorScheme=%q: got %q, want %q", tc.scheme, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolve_Antigravity_ColorSchemeWinsOverLegacyUITheme — colorScheme is
+// what agy actually writes, so it must win when both are somehow present.
+func TestResolve_Antigravity_ColorSchemeWinsOverLegacyUITheme(t *testing.T) {
+	home := t.TempDir()
+	writeAgySettings(t, home, `{"colorScheme": "light", "ui": {"theme": "Tokyo Night"}}`)
+	if got, want := theme.Resolve("antigravity", noEnv(), home), "light"; got != want {
+		t.Errorf("colorScheme must win over legacy ui.theme: got %q, want %q", got, want)
+	}
+}
+
+// TestResolve_Antigravity_LegacyUIThemeStillWorks — ui.theme remains a fallback
+// for anyone whose settings file still carries it.
+func TestResolve_Antigravity_LegacyUIThemeStillWorks(t *testing.T) {
+	home := t.TempDir()
+	writeAgySettings(t, home, `{"ui": {"theme": "Ayu Light"}}`)
+	if got, want := theme.Resolve("antigravity", noEnv(), home), "light"; got != want {
+		t.Errorf("legacy ui.theme fallback: got %q, want %q", got, want)
+	}
+}
+
+// TestClaudeEnum_AutoAndVariants — claudeEnumToPalette used an exact-match
+// switch, so every value it did not literally know collapsed to "dark".
+// Claude ships "auto", "light-ansi", "dark-ansi" and the "*-daltonized"
+// variants; all of them silently rendered a dark line, including on a LIGHT
+// terminal. Substring matching fixes the whole family at once.
+//
+// Precedence is "light" BEFORE "daltonism", matching the Antigravity keyword
+// bridge that already shipped. Note the consequence for "light-daltonized":
+// internal/style defines exactly four palettes — dark, light, dark-daltonism,
+// dark8 — and there is NO light-daltonism. Returning "light" keeps the
+// background assumption correct (the user is on a light terminal); returning
+// "dark-daltonism" would invert it. The accessibility gap is real but it is a
+// MISSING PALETTE, not a mapping bug, and inventing a palette name here would
+// resolve to nothing at all.
+func TestClaudeEnum_AutoAndVariants(t *testing.T) {
+	cases := []struct{ theme, want string }{
+		// Known-good, must not regress.
+		{"dark", "dark"},
+		{"light", "light"},
+		{"dark-daltonism", "dark-daltonism"},
+		{"system", "dark"},
+		{"", "dark"},
+		// The family that collapsed to "dark" before.
+		{"auto", "dark"},
+		{"light-ansi", "light"},
+		{"dark-ansi", "dark"},
+		{"dark-daltonized", "dark-daltonism"},
+		{"dark-daltonized-ansi", "dark-daltonism"},
+		// light wins over daltonism (see the doc comment above).
+		{"light-daltonized", "light"},
+		{"light-daltonized-ansi", "light"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.theme, func(t *testing.T) {
+			home := t.TempDir()
+			dir := filepath.Join(home, ".claude")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			body := `{"theme": "` + tc.theme + `"}`
+			if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if got := theme.Resolve("claude", noEnv(), home); got != tc.want {
+				t.Errorf("claude theme=%q: got %q, want %q", tc.theme, got, tc.want)
+			}
+		})
+	}
+}

--- a/sdk/gsl/internal/theme/resolve.go
+++ b/sdk/gsl/internal/theme/resolve.go
@@ -52,36 +52,51 @@ func Resolve(toolCtx string, env func(string) string, home string) string {
 	}
 }
 
-// claudeEnumToPalette maps the Claude settings.json "theme" enum to a palette
-// name. "system" and absent/empty both map to "dark".
+// claudeEnumToPalette maps the Claude settings.json "theme" value to a palette
+// name.
+//
+// This used to be an exact-match switch over {"light","dark","dark-daltonism"},
+// which meant every OTHER value Claude ships collapsed to "dark" — including
+// "light-ansi" (a LIGHT theme rendered dark), "auto", and the whole
+// "*-daltonized" family. It is now the same substring bridge the Antigravity
+// path uses, so an unknown-but-descriptive theme name resolves sensibly instead
+// of silently defaulting.
+//
+// "system", "auto", "" and any value with no light/daltonism keyword → "dark".
 func claudeEnumToPalette(raw string) string {
-	switch raw {
-	case "light":
-		return "light"
-	case "dark-daltonism":
-		return "dark-daltonism"
-	case "dark":
-		return "dark"
-	default:
-		// "system", "", or any unrecognized value → dark.
-		return "dark"
-	}
+	return keywordToPalette(raw)
 }
 
-// antigravityKeywordToPalette maps a free-form Antigravity ui.theme string to
-// a palette name using keyword matching.
-//
-// Rule: contains "light" → "light"; contains "daltonism" or "colorblind" →
-// "dark-daltonism"; anything else non-empty → "dark".
-//
-// An empty input should never reach here (Resolve handles the empty case
-// before calling this), but "" returns "dark" defensively.
+// antigravityKeywordToPalette maps a free-form Antigravity colorScheme (or
+// legacy ui.theme) string to a palette name.
 func antigravityKeywordToPalette(raw string) string {
+	return keywordToPalette(raw)
+}
+
+// keywordToPalette is the shared substring bridge from a free-form theme name
+// to one of the four palettes internal/style actually defines: "dark",
+// "light", "dark-daltonism", "dark8".
+//
+// Rule (order matters):
+//
+//	contains "light"                        → "light"
+//	contains "dalton" or "colorblind"       → "dark-daltonism"
+//	otherwise (incl. "", "system", "auto")  → "dark"
+//
+// "light" is tested FIRST, so "light-daltonized" resolves to "light". That is
+// deliberate: there is no light-daltonism palette, and returning
+// "dark-daltonism" would invert the user's background. The accessibility gap is
+// a MISSING PALETTE, not a mapping bug — naming one here that internal/style
+// does not define would resolve to nothing at all.
+//
+// Matching "dalton" (not "daltonism") covers both the "-daltonism" and the
+// "-daltonized" spellings the two CLIs use.
+func keywordToPalette(raw string) string {
 	lower := strings.ToLower(raw)
 	if strings.Contains(lower, "light") {
 		return "light"
 	}
-	if strings.Contains(lower, "daltonism") || strings.Contains(lower, "colorblind") {
+	if strings.Contains(lower, "dalton") || strings.Contains(lower, "colorblind") {
 		return "dark-daltonism"
 	}
 	// Non-empty unknown theme → dark (NOT terminal fallthrough per spec).

--- a/sdk/gsl/internal/theme/settings.go
+++ b/sdk/gsl/internal/theme/settings.go
@@ -59,29 +59,43 @@ func readClaudeTheme(home string) string {
 	return v
 }
 
-// readAntigravityTheme reads the `ui.theme` field for the Antigravity CLI.
+// readAntigravityTheme reads the theme for the Antigravity CLI.
+//
 // It reads the Antigravity settings file <home>/.gemini/antigravity-cli/
 // settings.json when it exists; only when that file is absent does it fall
 // back to the legacy Gemini CLI file <home>/.gemini/settings.json (Antigravity
 // deliberately reuses the ~/.gemini directory). Gating the fallback on file
-// absence — not on an empty ui.theme — avoids a second open+parse on every
+// absence — not on an empty theme — avoids a second open+parse on every
 // statusline render in the steady state where the Antigravity file exists but
-// simply lacks ui.theme. Returns "" on any error. The value is a free-form
-// string.
+// simply lacks a theme key. Returns "" on any error.
 func readAntigravityTheme(home string) string {
 	agyPath := filepath.Join(home, ".gemini", "antigravity-cli", "settings.json")
 	if _, err := os.Lstat(agyPath); !errors.Is(err, os.ErrNotExist) {
 		// The Antigravity file exists (or is anomalous): it is authoritative,
-		// even when it lacks ui.theme.
-		return readUITheme(home, agyPath)
+		// even when it lacks a theme key.
+		return readAgyTheme(home, agyPath)
 	}
 	// Legacy Gemini CLI settings file.
-	return readUITheme(home, filepath.Join(home, ".gemini", "settings.json"))
+	return readAgyTheme(home, filepath.Join(home, ".gemini", "settings.json"))
 }
 
-// readUITheme reads the `ui.theme` field from a settings.json at path.
+// readAgyTheme reads the theme from an Antigravity settings.json at path.
+//
+// Key precedence:
+//
+//  1. TOP-LEVEL "colorScheme" — what agy actually writes. Verified against a
+//     real ~/.gemini/antigravity-cli/settings.json from agy v1.1.1:
+//
+//     { "colorScheme": "light", "enableTelemetry": false, ... }
+//
+//  2. "ui"."theme" — LEGACY fallback. gsl originally read only this key, but
+//     agy never writes it, so readAntigravityTheme returned "" for every real
+//     agy user and Resolve fell through to terminal detection — meaning a user
+//     on a light agy theme got a dark status line, permanently. Kept as a
+//     fallback for any settings file that still carries it.
+//
 // Returns "" on any error (missing file, bad type, anomalous file).
-func readUITheme(home, path string) string {
+func readAgyTheme(home, path string) string {
 	data, err := readSettingsFile(home, path)
 	if err != nil {
 		return ""
@@ -96,7 +110,15 @@ func readUITheme(home, path string) string {
 		return ""
 	}
 
-	// Dig into "ui" sub-object.
+	// 1. Top-level colorScheme (what agy writes).
+	if raw, ok := obj["colorScheme"]; ok {
+		var v string
+		if err := json.Unmarshal(raw, &v); err == nil && v != "" {
+			return v
+		}
+	}
+
+	// 2. Legacy ui.theme.
 	uiRaw, ok := obj["ui"]
 	if !ok {
 		return ""

--- a/sdk/gsl/skill/SKILL.md
+++ b/sdk/gsl/skill/SKILL.md
@@ -4,16 +4,20 @@ description: Query and configure the gsl (Go Status Line) that renders a powerli
 ---
 # gsl — Go Status Line
 
-`gsl` is a Go-based powerline-style status line with two integration points:
+`gsl` is a Go-based powerline-style status line. **Both** host CLIs drive it the same
+way: they pipe a JSON payload on stdin after every assistant turn and print whatever
+the shim writes to stdout.
 
-- **Claude Code**: Claude pipes a JSON payload (cwd, model, context-window usage) to
-  `~/.claude/statusline-command.sh` after every assistant turn; the shim `exec`s
-  `gsl render` so the payload flows straight to the binary and the rendered line
-  appears in the Claude Code status bar.
-- **Antigravity CLI** (`agy`): point its built-in `/statusline` custom command at
-  `gsl status` to render the status line on demand without a JSON payload. The
-  `ai` segment self-omits because no Claude payload is supplied; `dirgit`,
-  `repo`, and `time` still render.
+- **Claude Code**: pipes its payload to `~/.claude/statusline-command.sh`; the shim
+  `exec`s `gsl render`, so stdin flows straight through to the binary.
+- **Antigravity CLI** (`agy`): pipes its payload to `~/.gemini/config/statusline-command.sh`
+  — the *same* shim, deployed to agy's config root — which also `exec`s `gsl render`.
+
+> **Note (changed in #157).** agy is a first-class payload host. Older docs said to point
+> agy's `/statusline` at `gsl status` and claimed "the `ai` segment self-omits under
+> Antigravity because no payload is supplied". **Both statements are false now.** agy sends
+> a full JSON payload (model, context window, quota, terminal width), and the `ai` segment
+> renders under agy exactly as it does under Claude Code.
 
 ## Segments
 
@@ -21,21 +25,52 @@ description: Query and configure the gsl (Go Status Line) that renders a powerli
 |----------|---------------|
 | `dirgit` | Current directory name (basename, `~` for `$HOME`) + branch + staged/unstaged/untracked/stash/ahead/behind badges |
 | `repo`   | Root-or-worktree indicator glyph + optional feature/worker/branch name + optional PR badge (tinted by state) + optional worktree count badge; self-omits outside a git repo |
-| `ai`     | Model display name + context-window usage + MCP active/configured count + 5h/7d rate-limit percentages; **self-omits when no Claude payload is present** (Antigravity/CLI mode) |
+| `ai`     | Model display name + context-window usage + MCP active/configured count + 5h/7d rate-limit percentages. Renders under **both** Claude Code and agy. Self-omits only when there is genuinely no payload on stdin (e.g. bare `gsl status` in a plain shell) |
 | `time`   | Date + time formatted by config Go layouts + timezone abbreviation; always renders |
 
 Each segment is independently enabled/disabled via `gsl config enable/disable/toggle <segment>`.
 
+## Host payload differences
+
+The two hosts send different shapes for the same information. `gsl` normalizes them.
+
+| | Claude Code | Antigravity (`agy` v1.1.1) |
+|---|---|---|
+| Rate limits | `rate_limits.five_hour` / `.seven_day`, each `{used_percentage, resets_at}` | **No `rate_limits` at all.** Sends `quota` instead |
+| Quota | — | `quota` object of buckets: `3p-5h`, `3p-weekly`, `gemini-5h`, `gemini-weekly`, each `{remaining_fraction, reset_time, reset_in_seconds}` |
+| Width | `terminal_width` | `terminal_width` |
+| Host self-ID | *(no `product` key)* | **`"product": "antigravity"`** in every payload |
+| Theme source | `~/.claude/settings.json` → `theme` | `~/.gemini/antigravity-cli/settings.json` → top-level **`colorScheme`** |
+
+**How gsl tells the hosts apart.** Both hosts run the *same* shim (`gsl render`, payload on
+stdin) and both send `cwd` + `model` + `context_window`, so the payload shape alone cannot
+identify the caller. gsl keys on agy's in-band **`product`** field, which it sends on every
+render. That is what selects the theme source above — without it an agy render is read as a
+Claude render and the Antigravity `colorScheme` is ignored entirely.
+
+**Quota → rate-limit synthesis.** agy reports quota *remaining*; the `ai` segment shows
+*used*. gsl inverts it (`used = (1 - remaining_fraction) * 100`) and maps buckets onto the
+5h/7d windows by **suffix heuristic** — a key containing `week`/`7d` is the seven-day
+window, one containing `5h`/`hour` is the five-hour window. Bucket keys are *not* hardcoded,
+so if Google renames them the display degrades gracefully instead of vanishing. A first-party
+(`gemini-*`) bucket wins over a third-party (`3p-*`) one.
+
+**Tolerant decoding.** The payload is decoded field-by-field: a field whose JSON type is
+unexpected is dropped on its own and the rest of the payload still renders. One bad field
+can no longer blank the whole segment for the rest of the session (issues #30, #31).
+
 ## Subcommands
 
 ```
-gsl render                          # Read Claude JSON payload from stdin, print status line
-gsl status                          # Print status line now (no stdin; ai segment self-omits)
+gsl render                          # Read the host's JSON payload from stdin, print the status line
+gsl status                          # Print the status line now, without stdin (ai segment self-omits)
 gsl preview                         # Interactive TUI: toggle segments, cycle styles, live time
 gsl preview --once                  # Print one rendered frame and exit (CI / golden-file safe)
 gsl version                         # Show version, commit, dirty flag, build date, description, binary path
 gsl version --json                  # Same, as JSON
 ```
+
+`gsl render` is what both hosts call. `gsl status` is for humans at a shell prompt.
 
 ## Configuration
 
@@ -73,18 +108,35 @@ Add user overrides in the `styles` object of `config.json` under the same key as
 
 | Layer | How | Effect |
 |-------|-----|--------|
-| **Hard off** | Remove (or comment out) `statusLine.command` from `~/.claude/settings.json` | Claude Code never calls the shim; no bar |
-| **Soft off** | `gsl config disable` | Shim is called but prints nothing; bar goes blank |
+| **Hard off** | Remove `statusLine.command` from `~/.claude/settings.json` (Claude), or set `statusLine.enabled: false` in `~/.gemini/antigravity-cli/settings.json` (agy) | The host never calls the shim; no bar |
+| **Soft off** | `gsl config disable` | The shim is called but prints nothing; the bar goes blank |
 
-Use **soft off** when you want to toggle quickly without editing settings. Use
-**hard off** when you want zero overhead (no subprocess fork per turn).
+Use **soft off** to toggle quickly without editing settings. Use **hard off** for zero
+overhead (no subprocess fork per turn).
 
 ## Install wiring
 
-The shim is installed by `opt/scripts/system/install_claude_skills.sh`:
+The shim (`ai/claude/statusline-command.sh`) is **copied** — not symlinked — into each
+host's well-known `$HOME` path. Copy is the forward provisioning mechanism (see the root
+`CLAUDE.md`): a repo-pointing symlink couples global config to the checkout location, and
+would aim `$HOME` config at a transient path if the installer ever ran from a `gss` worktree.
 
-```
-~/.claude/statusline-command.sh  →  $DOTFILES/ai/claude/statusline-command.sh
+| Installer | Destination |
+|-----------|-------------|
+| `opt/scripts/system/install_claude_skills.sh` | `~/.claude/statusline-command.sh` (mode 0755) |
+| `opt/scripts/system/install_antigravity_skills.sh` | `~/.gemini/config/statusline-command.sh` (mode 0755) |
+
+agy's `statusLine` block is applied from `ai/antigravity/settings.forced.json` into
+`~/.gemini/antigravity-cli/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.gemini/config/statusline-command.sh",
+    "enabled": true
+  }
+}
 ```
 
 The skill directory is linked by `opt/scripts/system/sync-skills.sh` into
@@ -112,16 +164,9 @@ bash sdk/gsl/scripts/check-font-glyphs.sh
 # expect: OK: all 17 gsl codepoints present in .../MesloLGSNerdFont-Regular.ttf
 ```
 
-## Antigravity command
-
-Antigravity CLI ships a built-in `/statusline` slash command that supports a
-custom command — set it to `gsl status` to render the current status line on
-demand. (The Gemini-era `/gsl-status` TOML custom command retired with
-Gemini CLI.)
-
 ## Fallback behaviour
 
 If `~/opt/bin/gsl` is missing, `statusline-command.sh` falls back to a
 dependency-light bash snippet that prints: `<basename $PWD>  <git branch>  <HH:MM>`.
-The pipe never breaks and no error is returned, so Claude Code's status bar
-degrades gracefully instead of breaking.
+The pipe never breaks and no error is returned, so the host's status bar degrades
+gracefully instead of breaking. This applies to both Claude Code and agy.


### PR DESCRIPTION
**WS6 / `agy` leaf.** Antigravity parity from **captured** payloads (not guessed), plus the two install-hygiene fixes — and closes #31:

- `internal/payload/payload.go` — per-field tolerant decode: one malformed field can no longer discard the whole payload (**closes #31**, E20); quota becomes a dynamic `map[string]QuotaWindow` (E21)
- `internal/payload/testdata/agy_live.json` + `agy_live_authenticating.json` — **verbatim captured** agy payloads driving the tests; `FuzzParse` + field-coverage tests
- `internal/theme/settings.go` / `resolve.go` — reads agy's top-level `colorScheme` (legacy `ui.theme` fallback); Claude + agy theme names go through one shared `keywordToPalette` substring bridge, so `light-ansi` / `*-daltonized` / `auto` resolve sensibly instead of collapsing to dark
- `opt/scripts/system/install_claude_skills.sh` — `ln -sf` → `install -m 0755` (repo copy-not-symlink rule); `install.sh` fails loudly when `build.sh` fails so the seam gate can actually fail
- `sdk/gsl/skill/SKILL.md` — rewritten for the post-#157 agy wiring

**Gate (P4 done-when):** full `go test ./...` green ✅; `FuzzParse` 20 s smoke clean (783 k execs, 0 crashers) — verified 2026-07-26.

**Rebase note:** restacked onto the rebased iface (#161); reconciled cleanly with main's #190 (tmux/screen → `dark8` terminal fallback) — the tmux rule only affects the terminal-env fallback and host-tool settings still take precedence, so the two changes compose.

<!-- gss:stack-begin -->
## Stack — gsl-ultra (#158)

- #159 — design (base: `main`) — MBO design/spec/plan docs
- #161 — iface (base: `main`) — frozen §3 interfaces (P0, blocking)
- #165 — width (base: `iface`) ∥ #166 — latency (base: `iface`) ∥ #167 — agy (base: `iface`)
- *(not started)* mcp → style → tui (plan §6.2)

Landing order: `iface` → (`width` ∥ `latency` ∥ `agy`) → `mcp` → `style` → `tui`. Review bottom-up; merge bottom-up.
<!-- gss:stack-end -->
