### PR TITLE
k8s-tools: shellenv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,7 @@ while IFS= read -r file; do
 done < <(find "${BASE_DIR}/opt/profiles" -type f)
 
 # force a few
-for file in ".profile" ".zshenv" ".zshrc" ".bash_logout" ".bashrc"; do
+for file in ".profile" ".zprofile" ".zshenv" ".zshrc" ".bash_logout" ".bashrc"; do
   ln -sf "${BASE_DIR}/opt/profiles/${file}" "${HOME}/${file}"
 done 
 

--- a/opt/Desktop/Apps/scripts/install-claude-rc-autostart.ps1
+++ b/opt/Desktop/Apps/scripts/install-claude-rc-autostart.ps1
@@ -6,7 +6,7 @@
 
 .DESCRIPTION
   Creates ~\...\Startup\claude-remote.lnk pointing at
-  Windows Terminal -> wsl -d <Distro> -> bash -c -> claude-rc-boot.
+  Windows Terminal -> wsl -d <Distro> -> bash -lc -> claude-rc-boot.
   Also drops a copy of the shortcut on the Desktop so the session can be
   (re)started manually without digging into shell:startup.
   The launcher's absolute path inside WSL is resolved at install time (prefers
@@ -76,7 +76,10 @@ if (-not $launcher) {
 
 $prefixArg = if ($Prefix) { " " + $Prefix } else { '' }
 $inner  = "exec '$launcher'$prefixArg"
-$wtArgs = "wsl.exe -d $Distro -- bash -c `"$inner`""
+# -l (login) is load-bearing: it makes bash source ~/.profile, so the Claude
+# session (and everything it spawns) inherits the full dotfiles environment.
+# A plain `bash -c` here is how autostarted sessions ended up with a bare PATH.
+$wtArgs = "wsl.exe -d $Distro -- bash -lc `"$inner`""
 
 # Distinct icon (WSL penguin) so the shortcut doesn't blend in with plain
 # Windows Terminal launchers; skipped silently on hosts without System32\wsl.exe.

--- a/opt/profiles/.zprofile
+++ b/opt/profiles/.zprofile
@@ -1,0 +1,15 @@
+# shellcheck shell=sh
+# ~/.zprofile — zsh LOGIN shells read this; they never read ~/.profile
+# (that's a bash/sh file) and non-interactive login shells (`zsh -lc`,
+# SSH remote commands, GUI/automation launchers) never read ~/.zshrc
+# either. Without this file, any zsh login shell that isn't interactive
+# gets NO dotfiles environment at all — no ~/opt/bin, no scripts dirs,
+# no version managers — which is exactly how automation-launched
+# sessions ended up with a bare PATH.
+#
+# Delegate to ~/.profile (the canonical, POSIX-only env setup shared
+# with bash/dash) under sh emulation, so its POSIX semantics (word
+# splitting etc.) hold even though zsh is interpreting it. ~/.zshrc
+# still layers interactive-only setup (completion, prompt, aliases) on
+# top for interactive shells.
+[ -f "$HOME/.profile" ] && emulate sh -c '. "$HOME/.profile"'


### PR DESCRIPTION
Fix env loading for zsh login shells (.zprofile) and the claude-rc autostart (login bash)

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **k8s-tools**.

- #172 — edward-raigosa/install (base: `main`) ← parent of this PR
- **(no PR yet) — edward-raigosa/shellenv (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
