### PR TITLE
flow-overlay-hardening: fix

### DIFF
--- a/opt/Desktop/Apps/scripts/AGENTS.md
+++ b/opt/Desktop/Apps/scripts/AGENTS.md
@@ -36,7 +36,12 @@ essentials:
    **Non-elevated is enough to test trigger keys**; elevation only matters for
    dictating into admin windows and for the logon-task that survives reboot. **KBM
    and AHK must run at the same integrity** or PowerToys' injected F24 never reaches
-   AHK's keyboard hook.
+   AHK's keyboard hook. **A non-elevated `Stop-Process` cannot kill the elevated
+   logon-task instance** (silent failure — `Get-Process AutoHotkey*` showing an
+   empty `Path` means elevated): reload that one via `setup-autostart.ps1` (UAC).
+   `macos.ahk`'s named-mutex guard makes a second copy started next to it exit
+   instead of creating duplicate keyboard hooks (the old "stuck HUD that ignores
+   Esc" failure).
 3. **Observe:** add temporary `FileAppend(..., A_Temp "\flow-dbg.txt")` lines tagged
    `; DEBUG (temporary)`, then read the log from WSL at
    `$(wslpath "$(powershell.exe '$env:TEMP')")/flow-dbg.txt`. **Strip every DEBUG

--- a/opt/Desktop/Apps/scripts/macos.ahk
+++ b/opt/Desktop/Apps/scripts/macos.ahk
@@ -1,5 +1,34 @@
 #Requires AutoHotkey v2.0
 #SingleInstance Force
+
+; --- Cross-integrity single-instance guard --------------------------------------
+; #SingleInstance Force replaces a prior instance via a window message, which UIPI
+; BLOCKS across integrity levels — a non-elevated debug reload next to the elevated
+; logon-task instance leaves TWO live keyboard hooks: one instance shows a HUD
+; while the other wins the keypress ("stuck overlay that ignores Esc"). A named
+; mutex is visible across integrity within the session, so the second copy can
+; detect the first and bow out. ERROR_ALREADY_EXISTS (183) and ACCESS_DENIED (5,
+; possible when the holder is elevated) both mean "someone already owns it".
+; Retry briefly: during a legitimate same-integrity replace (Reload / Force),
+; the outgoing process can still hold the mutex for a moment — only a holder
+; that NEVER releases (a live instance at another integrity) should abort us.
+_flowInstanceMutex := 0
+loop 15 {
+    _flowInstanceMutex := DllCall("CreateMutex", "Ptr", 0, "Int", 0, "Str", "dotfiles-macos-ahk", "Ptr")
+    if (A_LastError = 0)
+        break
+    if (_flowInstanceMutex)
+        DllCall("CloseHandle", "Ptr", _flowInstanceMutex), _flowInstanceMutex := 0
+    Sleep 200
+}
+if (!_flowInstanceMutex) {
+    MsgBox "macos.ahk is already running (possibly at another integrity level)."
+        . "`n`nThis copy will exit. To reload the elevated instance, run"
+        . "`nsetup-autostart.ps1 (UAC prompt) instead of starting a second copy.",
+        "macos.ahk", "Iconi T10"
+    ExitApp
+}
+
 #Include flow-calib.ahk      ; overlay-offset calibration data layer (DEFAULT + ini load/save)
 #Include flow-triggers.ahk   ; extra-trigger-key data + policy layer (load/save/normalize/compose/validate/manifest)
 #Include lib\hotcorners.ahk  ; outer-corner-only hot-corner geometry layer (multi-monitor, hotplug-safe)
@@ -276,7 +305,17 @@ _FlowCalibStopDirty() {
 _FlowCalibDestroy() {
     global _flowCalibGui
     if (_flowCalibGui) {
-        try _flowCalibGui.Destroy()
+        ; A failed Destroy() would orphan the HUD forever once the reference is
+        ; dropped below — no code path could ever close it again ("stuck
+        ; overlay"). Fall back to killing the OS window by handle.
+        hwnd := 0
+        try hwnd := _flowCalibGui.Hwnd
+        try
+            _flowCalibGui.Destroy()
+        catch {
+            if (hwnd)
+                try WinKill("ahk_id " hwnd)
+        }
         _flowCalibGui := ""
     }
 }
@@ -365,7 +404,14 @@ _FlowManageShow() {
 _FlowManageDestroyGui() {
     global _flowTriggerGui
     if (_flowTriggerGui) {
-        try _flowTriggerGui.Destroy()
+        hwnd := 0
+        try hwnd := _flowTriggerGui.Hwnd
+        try
+            _flowTriggerGui.Destroy()
+        catch {
+            if (hwnd)                        ; orphan-proof: see _FlowCalibDestroy
+                try WinKill("ahk_id " hwnd)
+        }
         _flowTriggerGui := ""
     }
 }
@@ -525,7 +571,14 @@ _FlowHelpShow() {
 _FlowHelpDestroy() {
     global _flowHelpGui
     if (_flowHelpGui) {
-        try _flowHelpGui.Destroy()
+        hwnd := 0
+        try hwnd := _flowHelpGui.Hwnd
+        try
+            _flowHelpGui.Destroy()
+        catch {
+            if (hwnd)                        ; orphan-proof: see _FlowCalibDestroy
+                try WinKill("ahk_id " hwnd)
+        }
         _flowHelpGui := ""
     }
 }

--- a/src/wispr-flow-debug/SKILL.md
+++ b/src/wispr-flow-debug/SKILL.md
@@ -42,9 +42,27 @@ diff -q <(tr -d '\r' < "$DEPLOYED") opt/Desktop/Apps/scripts/macos.ahk && echo "
 AutoHotkey does **not** hot-reload a changed `.ahk` — you must restart it.
 
 ### 2. Reload AutoHotkey (non-elevated is enough for trigger testing)
+
+**First check for an ELEVATED instance** — the logon task starts one, and a
+non-elevated `Stop-Process` CANNOT kill it (the failure is silent). It also
+shrugs off `#SingleInstance Force` (UIPI blocks the replace message), so starting
+a second copy next to it used to yield duplicate keyboard hooks — one instance
+draws a HUD while the other wins the keypress, i.e. a stuck overlay that ignores
+Esc. (`macos.ahk` now guards this with a named mutex: the second copy detects the
+first across integrity levels and exits with a pointer to `setup-autostart.ps1`.)
+
+```bash
+"$PS" -NoProfile -Command 'Get-Process AutoHotkey* -EA SilentlyContinue | Select-Object Id,Path'
+```
+An **empty `Path`** means that instance is elevated → reload it via
+`setup-autostart.ps1` (self-elevates, one UAC click) instead of the snippet below.
+
 ```bash
 "$PS" -NoProfile -Command '
-$exe = "$env:LOCALAPPDATA\Programs\AutoHotkey\v2\AutoHotkey64.exe"
+$exe = @("$env:ProgramFiles\AutoHotkey\v2\AutoHotkey64.exe",
+         "$env:LOCALAPPDATA\Programs\AutoHotkey\v2\AutoHotkey64.exe") |
+    Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $exe) { "WARN: AutoHotkey64.exe not found (Program Files / LOCALAPPDATA)"; exit 1 }
 $script = Join-Path ([Environment]::GetFolderPath("Desktop")) "Apps\scripts\macos.ahk"
 Get-Process AutoHotkey* -EA SilentlyContinue | Stop-Process -Force -EA SilentlyContinue
 Start-Sleep -Milliseconds 400


### PR DESCRIPTION
macos.ahk mutex guard + hwnd-fallback destroys; wispr-flow-debug skill exe-path/elevation fixes

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **flow-overlay-hardening**.

- **(no PR yet) — edward-raigosa/fix (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
