### PR TITLE
k8s-tools: credshim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ opt/bin/*
 # docker even in non-interactive shells (see opt/profiles/.bash_aliases).
 !opt/bin/docker
 !opt/bin/docker-compose
+!opt/bin/docker-credential-desktop.exe
 # Test drivers for the committed opt/bin tools (issue #46 phase 2)
 !opt/bin/pkg-install_test.sh
 !opt/bin/sshd-setup_test.sh

--- a/opt/bin/AGENTS.md
+++ b/opt/bin/AGENTS.md
@@ -13,6 +13,7 @@ These tools are built from source (typically in `src/`) and deposited here durin
 - `vault`: HashiCorp Vault binary.
 - `git-sizer`: Git repository analyzer.
 - `docker` / `docker-compose`: **Committed WSL shims, not binaries.** Real executables so non-interactive shells (make, scripts) resolve a working docker — the `.bash_aliases` docker.exe fallback is an alias and only exists interactively. Resolution order: Docker Desktop's WSL-integration Linux CLI → any other real docker on PATH → `docker.exe` over interop (with its credential helper dir appended to PATH). `docker-compose` delegates to `docker compose` (v2).
+- `docker-credential-desktop.exe`: **Committed WSL shim.** Docker Desktop's integration writes `credsStore: "desktop.exe"` into `~/.docker/config.json` on every init and symlinks `/usr/bin/docker-credential-desktop.exe` into the `/Docker/host/bin` mount — which never appears on some machines, so every build/pull dies with "error getting credentials". This wrapper (ahead of `/usr/bin` on PATH) forwards the credential-helper protocol to the real Windows helper over interop.
 
 ## Usage
 

--- a/opt/bin/docker-credential-desktop.exe
+++ b/opt/bin/docker-credential-desktop.exe
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# docker-credential-desktop.exe — WSL wrapper for Docker Desktop's WINDOWS
+# credential helper.
+#
+# Docker Desktop's WSL integration writes `credsStore: "desktop.exe"` into
+# ~/.docker/config.json on every init, and symlinks
+# /usr/bin/docker-credential-desktop.exe -> /Docker/host/bin/... — a mount
+# that never appears on this machine, leaving the symlink dangling. The
+# docker CLI then fails every build/pull with:
+#   error getting credentials - err: exec: "docker-credential-desktop.exe":
+#   executable file not found in $PATH
+# Emptying the config only lasts until the next integration init rewrites it.
+#
+# This wrapper lives in ~/opt/bin (ahead of /usr/bin on a dotfiles PATH), so
+# the CLI resolves it instead of the dangling symlink. It forwards the
+# credential-helper protocol (argv + stdio) to the real Windows helper over
+# interop, so saved registry credentials keep working.
+set -eu
+# shellcheck disable=SC1091
+[ -f "${HOME}/.cache/dotfiles/winenv.sh" ] && . "${HOME}/.cache/dotfiles/winenv.sh"
+exec "${WIN_PROGRAM_FILES:-/mnt/c/Program Files}/Docker/Docker/resources/bin/docker-credential-desktop.exe" "$@"


### PR DESCRIPTION
docker-credential-desktop.exe wrapper for the missing /Docker/host/bin mount

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **k8s-tools**.

- #174 — edward-raigosa/dockershim (base: `main`) ← parent of this PR
- **(no PR yet) — edward-raigosa/credshim (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
