### PR TITLE
bin/docker: stop leaking the PATH-scan list into the real docker's stdin

### DIFF
--- a/opt/bin/docker
+++ b/opt/bin/docker
@@ -32,15 +32,24 @@ fi
 # never run). Skip ourselves (any copy/symlink of this shim resolves to
 # the same physical file) and anything not actually executable (a
 # dangling /usr/bin/docker symlink fails -x).
+#
+# The candidates MUST be collected before exec'ing (mapfile, not
+# `while read ... done < <(...)`): a redirect-fed loop makes the pipe the
+# loop body's stdin, so the exec'd docker inherits the *unread rest of the
+# candidate list* as its stdin instead of ours. Anything piping data
+# through this shim gets that list as payload — kind ships kubeadm.conf
+# via `docker exec -i ... cp /dev/stdin` and got the leftover line
+# "/bin/docker" as its cluster config.
 self="$(cd -- "$(dirname "$0")" && pwd -P)/$(basename "$0")"
-while IFS= read -r cand; do
+mapfile -t cands < <(type -aP docker 2>/dev/null)
+for cand in "${cands[@]}"; do
     [ -n "${cand}" ] || continue
     [ "${cand}" = "${self}" ] && continue
     [ "$(cd -- "$(dirname "${cand}")" 2>/dev/null && pwd -P)/$(basename "${cand}")" = "${self}" ] && continue
     if [ -x "${cand}" ]; then
         exec "${cand}" "$@"
     fi
-done < <(type -aP docker 2>/dev/null)
+done
 
 # Windows docker.exe over interop. WIN_PROGRAM_FILES comes from the
 # install_windows.sh env cache when available; default to the standard


### PR DESCRIPTION
## What

Fixes a stdin-corruption bug in the `bin/docker` shim: the PATH-scan fallback exec'd the resolved docker CLI from *inside* `while read … done < <(type -aP docker)`. That redirect is the loop body's stdin, so the exec'd docker inherited the unread rest of the candidate list instead of the caller's stdin. Now the candidates are collected with `mapfile` first and walked in a plain `for` loop — the redirect ends before any `exec`, so the real docker keeps the caller's stdin.

## Why

Anything piping data *through* the shim received candidate paths as its payload. Concretely: kind delivers `kubeadm.conf` into its node via `docker exec -i … cp /dev/stdin`, and with `~/opt/bin` appearing early (and repeatedly) on PATH, the one line left unread at exec time was `/bin/docker` — so the cluster config arrived as those 12 bytes and `kubeadm init` failed with `could not interpret GroupVersionKind … cannot unmarshal string into Go value of type runtime.TypeMeta`, an error naming neither docker nor stdin. Cost a `kind create --retain` post-mortem to trace.

## Impact

- Piped docker invocations (`docker exec -i`, `docker run -i`, `docker login --password-stdin`, `docker build -` …) behave correctly through the shim on macOS / plain Linux / Raspberry Pi (the `type -aP` branch). The WSL Docker-Desktop and interop branches were unaffected (they exec before the loop).
- Resolution order and self-skip logic unchanged.

## Testing

On a Raspberry Pi 5 (rootless Docker, the `type -aP` branch):
- `printf 'stdin-roundtrip-ok' | docker exec -i <container> cp /dev/stdin /tmp/probe` previously wrote `/bin/docker`; with the fix the probe string round-trips intact.
- `kind create cluster` previously died at `kubeadm init`; with the fix the cluster comes up cleanly (verified via the playground repo's `make kind-up` / `make kind-load`, PR sfc-gh-eraigosa/playground#120 — whose `kind-preflight` now also probes for this class of wrapper bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUtJRp2yQ5KqtMAftj2VYh