### PR TITLE
gss: run git non-interactively so it never hangs holding index.lock

### DIFF
--- a/sdk/gss/internal/git/exec.go
+++ b/sdk/gss/internal/git/exec.go
@@ -31,8 +31,38 @@ package git
 import (
 	"bytes"
 	"context"
+	"os"
 	"os/exec"
 )
+
+// nonInteractiveEnv is layered on top of the caller's environment for every
+// git invocation. gss git operations are automated — they run in hooks,
+// background jobs, and worktrees with no controlling terminal — so a git
+// subprocess must NEVER block on a human prompt. Without this, a git command
+// that wants an editor (a merge commit recreated during a rebase, an
+// autosquash, a commit that needs a message) or a credential/passphrase prompt
+// opens the user's interactive editor or a terminal prompt and blocks forever
+// with no TTY. Worse, while it blocks it holds `.git/index.lock`, which then
+// wedges every subsequent git operation in the repository until the hung
+// process is killed by hand (observed as `gss feature checkpoint` hanging on a
+// rebase and leaving a stale index.lock behind).
+//
+//   - GIT_EDITOR=true / GIT_SEQUENCE_EDITOR=true make git's editor a no-op
+//     that "succeeds" immediately, accepting the prepared default message
+//     instead of opening vi/nano. A rebase that would have opened an editor
+//     either completes with the default message or fails non-zero (which
+//     callers already handle, e.g. checkpoint's rebase --abort) — never hangs.
+//   - GIT_TERMINAL_PROMPT=0 makes git fail fast instead of prompting on the
+//     terminal for credentials.
+//
+// These are appended after the inherited environment so they win over any
+// value the caller happened to export (last occurrence wins; verified against
+// git's `var GIT_EDITOR`).
+var nonInteractiveEnv = []string{
+	"GIT_EDITOR=true",
+	"GIT_SEQUENCE_EDITOR=true",
+	"GIT_TERMINAL_PROMPT=0",
+}
 
 // Runner is the single entry point for git invocations in the gss
 // codebase. The interface signature is pinned by sdk/gss/docs/design.md
@@ -93,6 +123,9 @@ func (r *SystemRunner) Run(ctx context.Context, name string, args ...string) ([]
 	full = append(full, args...)
 
 	cmd := exec.CommandContext(ctx, bin, full...)
+	// Run git non-interactively so it can never block on an editor or a
+	// terminal prompt (and thus never wedge the repo holding index.lock).
+	cmd.Env = append(os.Environ(), nonInteractiveEnv...)
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf

--- a/sdk/gss/internal/git/exec_test.go
+++ b/sdk/gss/internal/git/exec_test.go
@@ -188,6 +188,84 @@ func TestSystemRunner_EmptyPathDefaultsToGit(t *testing.T) {
 	}
 }
 
+// TestSystemRunner_ForcesNoninteractiveEditor — the Runner must make git's
+// editor a no-op regardless of what the caller has exported, so an automated
+// git op can never open an interactive editor. `git var GIT_EDITOR` reports
+// the editor git would actually use; through the Runner it must be "true".
+func TestSystemRunner_ForcesNoninteractiveEditor(t *testing.T) {
+	skipIfNoGit(t)
+	// Simulate the real footgun: the ambient environment points GIT_EDITOR at
+	// an interactive editor. The Runner must override it.
+	t.Setenv("GIT_EDITOR", "vim")
+	r := git.NewSystemRunner()
+	out, err := r.Run(context.Background(), "var", "GIT_EDITOR")
+	if err != nil {
+		t.Fatalf("git var GIT_EDITOR: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "true" {
+		t.Errorf("effective GIT_EDITOR = %q; want \"true\" (Runner did not force a non-interactive editor)", got)
+	}
+}
+
+// TestSystemRunner_DoesNotInvokeHostileEditor is the regression proof for the
+// checkpoint-hang bug: a git operation that opens an editor must NOT invoke the
+// user's core.editor at all, so it can never block on it (the real editor that
+// stranded a checkpoint blocked forever, holding index.lock). The hostile
+// editor here records that it ran and exits non-zero; with the Runner's
+// GIT_EDITOR=true, `commit --amend` reuses the existing message and succeeds
+// without ever touching it. If the fix regresses, git invokes the hostile
+// editor: the amend fails (editor exited non-zero) and the sentinel appears —
+// either assertion fails this test. A bounded context is kept as a safety net
+// so a future blocking editor still fails fast rather than wedging the suite.
+func TestSystemRunner_DoesNotInvokeHostileEditor(t *testing.T) {
+	skipIfNoGit(t)
+	dir := initRepo(t)
+	r := git.NewSystemRunner()
+
+	// One real commit to amend.
+	if err := writeFile(filepath.Join(dir, "a.txt"), "hello\n"); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := r.Run(context.Background(), "-C", dir, "add", "a.txt"); err != nil {
+		t.Fatalf("add: %v\n%s", err, out)
+	}
+	if out, err := r.Run(context.Background(), "-C", dir, "commit", "-m", "init"); err != nil {
+		t.Fatalf("commit: %v\n%s", err, out)
+	}
+
+	// A hostile editor: if git ever invokes it, it records the fact and exits
+	// non-zero (a blocking editor is what stranded the real checkpoint; failing
+	// fast here keeps the test deterministic and orphan-free). The Runner must
+	// ensure it is never called.
+	sentinel := filepath.Join(dir, "editor-was-invoked")
+	editor := filepath.Join(dir, "hostile-editor.sh")
+	script := "#!/bin/sh\ntouch " + sentinel + "\nexit 1\n"
+	if err := os.WriteFile(editor, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Point BOTH the ambient env and git config at the hostile editor — this
+	// is how it reaches gss in the wild (inherited EDITOR / repo core.editor).
+	t.Setenv("GIT_EDITOR", editor)
+	t.Setenv("EDITOR", editor)
+	if out, err := r.Run(context.Background(), "-C", dir, "config", "core.editor", editor); err != nil {
+		t.Fatalf("config core.editor: %v\n%s", err, out)
+	}
+
+	// `commit --amend` (no -m/--no-edit) opens the editor.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	out, err := r.Run(ctx, "-C", dir, "commit", "--amend")
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatal("git hung on the editor — the Runner is not forcing a non-interactive editor (regression)")
+	}
+	if _, statErr := os.Stat(sentinel); statErr == nil {
+		t.Fatal("the hostile core.editor was invoked — GIT_EDITOR override is missing (regression)")
+	}
+	if err != nil {
+		t.Fatalf("amend should succeed with a non-interactive editor: %v\n%s", err, out)
+	}
+}
+
 // writeFile is a tiny helper so the test files don't pull in io/fs ceremony.
 // Implemented at the bottom to keep the table of tests above readable.
 func writeFile(path, content string) error {


### PR DESCRIPTION
## The bug (month-long footgun)
Every gss git call goes through `internal/git` `SystemRunner.Run`, which built the `*exec.Cmd` **without setting `cmd.Env`** — so git subprocesses inherited the caller's interactive `core.editor` / credential setup. When an automated git op wants an editor (a **merge commit recreated during a `feature checkpoint` rebase**, an autosquash, a commit needing a message) or a credential/passphrase prompt, git opens the user's editor or a terminal prompt and **blocks forever with no TTY**.

While blocked it **holds `.git/index.lock`**, which then wedges *every later git op in the repo* until the hung process is killed by hand. This showed up repeatedly as `gss feature checkpoint` hanging on a rebase and leaving a stale `index.lock` behind (found in the wild: a checkpoint launched in the background sat holding the lock for 30+ minutes, blocking all other git activity).

## Fix
`SystemRunner.Run` now layers a non-interactive environment over the caller's for **every** git invocation (one place → covers checkpoint, rebase, merged, restack, sync, everything):
```
GIT_EDITOR=true          # editor is a no-op that accepts the default message
GIT_SEQUENCE_EDITOR=true # rebase-todo editor no-op
GIT_TERMINAL_PROMPT=0    # fail fast instead of prompting for credentials
```
A rebase that would have opened an editor now either completes with the default message or fails non-zero — which callers already handle (e.g. checkpoint's `rebase --abort` → `ErrRebaseConflict`) — but **never hangs, and never strands the index.lock**.

## Testing
- `ForcesNoninteractiveEditor`: `git var GIT_EDITOR` == `"true"` through the Runner even when ambient `GIT_EDITOR=vim`.
- `DoesNotInvokeHostileEditor`: with a hostile `core.editor` (records that it ran, exits non-zero), `commit --amend` succeeds via the Runner and never touches it. **Verified this test fails fast without the fix** ("hostile core.editor was invoked").
- Full `go test ./...` green (23 pkgs), `go vet` clean.

## Impact / risk
Low. gss git operations are automated and should never want a human editor mid-run; forcing a no-op editor is the correct policy. Adjacent case not covered here: `commit.gpgsign=true` re-signing during rebase can still prompt via pinentry — a follow-up could add `-c commit.gpgsign=false` to internal commits. Flagging for review.
<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **gss-noninteractive-git**.

- **(no PR yet) — edward-raigosa/fix (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
