### PR TITLE
fix(gff): WSLENV pass-through direction — /u never crosses WSL->Win32, use /w

### DIFF
--- a/opt/bin/install_windows.sh
+++ b/opt/bin/install_windows.sh
@@ -84,15 +84,18 @@ fi
 
 # ---------------------------------------------------------------------------
 # gff flag pass-through: append every exported GFF_INSTALL_WINDOWS_* name to
-# WSLENV (/u = WSL->Win32 direction) BEFORE any powershell.exe invocation, so
-# the PowerShell setup scripts' Test-GffOn gates see the same flags. Runs here
+# WSLENV (/w = include when invoking Win32 from WSL) BEFORE any powershell.exe
+# invocation, so the PowerShell setup scripts' Test-GffOn gates see the same
+# flags. NOTE: the flag was originally /u per the plan — refuted empirically
+# 2026-07-26 (P2-T5): /u means Win32->WSL only, so the vars never crossed;
+# /w is the WSL->Win32 direction (learn.microsoft.com WSLENV flags). Runs here
 # — after ps_exe resolution, ahead of every $ps_exe call — and de-duplicates,
 # so re-runs never grow WSLENV. Requires install.sh's `set -a` bootstrap
 # export; unset vars simply never appear (fail-open on the Windows side too).
 # ---------------------------------------------------------------------------
 _gff_wslenv="${WSLENV:-}"
 for _v in $(env | sed -n 's/^\(GFF_INSTALL_WINDOWS_[A-Z_]*\)=.*/\1/p'); do
-  case ":${_gff_wslenv}:" in *":${_v}/u:"*) : ;; *) _gff_wslenv="${_gff_wslenv:+${_gff_wslenv}:}${_v}/u" ;; esac
+  case ":${_gff_wslenv}:" in *":${_v}/w:"*) : ;; *) _gff_wslenv="${_gff_wslenv:+${_gff_wslenv}:}${_v}/w" ;; esac
 done
 export WSLENV="${_gff_wslenv}"
 


### PR DESCRIPTION
## What

One-line fix in `opt/bin/install_windows.sh`: the gff flag pass-through appended each `GFF_INSTALL_WINDOWS_*` name to `WSLENV` with the `/u` flag. Per the [WSLENV docs](https://learn.microsoft.com/en-us/windows/wsl/filesystems#wslenv-flags), `/u` includes a variable **only when invoking WSL from Win32** — the opposite of this hand-off's direction. Flipped to `/w` (include when invoking Win32 from WSL). Comment corrected to match.

## Why (found by the P2-T5 human evidence run, #180)

With the flag set to `false` and properly exported, the elevated batch still installed Wispr Flow. Isolated hop test on real WSL:

```
FOO=bar WSLENV=FOO   powershell.exe -Command 'Write-Host "[$env:FOO]"'   -> [bar]
FOO=bar WSLENV=FOO/u powershell.exe -Command 'Write-Host "[$env:FOO]"'   -> []
```

The plan §3.5 text specified `/u` (frozen-contract defect, escalated per IMPLEMENTATION.md §5.1 — owner approved this deviation 2026-07-26); P2-T4 implemented it faithfully and its live check was explicitly deferred to P2-T5, which is exactly where it surfaced. TRACKING §10 record lands on the gff closeout branch.

## Gates

- `bash -n opt/bin/install_windows.sh` clean
- `make lint-shell` rc=0 · `make lint-portability` rc=0 (Tier1=0, Tier2=0)
- Human verification on real WSL pending: `WSLENV=FOO/w` probe + full `install.sh` run expecting `SKIP (gff: install.windows.wispr-flow=false)` in the elevated log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uim2A5Y84PvxX4kcP5tZkF