### PR TITLE
feat(research-evaluation): rubric dimension (h) — borrowable features (build-vs-adopt)

### DIFF
--- a/ai/skills/research-evaluation/SKILL.md
+++ b/ai/skills/research-evaluation/SKILL.md
@@ -6,9 +6,11 @@ description: >-
   doc + tracking issue per target. Use when the user wants to "research X", "evaluate
   X before we adopt it", "look up X and tell me if it's useful", "start a research
   MBO for X", or gives a list of candidate tools to investigate — even a single
-  target. Runs the seven-dimension rubric: (a) value to us, (b) setup cost +
+  target. Runs the eight-dimension rubric: (a) value to us, (b) setup cost +
   licensing, (c) adversarial review, (d) security & safety, (e) stability,
-  (f) quality & support, (g) a docker-sandboxed hands-on demo (docker-or-skip).
+  (f) quality & support, (g) a docker-sandboxed hands-on demo (docker-or-skip),
+  (h) borrowable features (build-vs-adopt — could we build just the valuable
+  bits ourselves instead of adopting the whole tool?).
   Fans multiple targets out to parallel research agents; NOT_FOUND is a valid,
   recorded outcome for targets that can't be identified through searches.
 ---
@@ -18,7 +20,7 @@ description: >-
 Turn "should we use <tool>?" into a consistent, evidence-backed evaluation instead of
 an ad-hoc impression. Works for one target or a batch; generalizes to any repo.
 
-## The rubric (all seven, every target)
+## The rubric (all eight, every target)
 
 | Dim | Question |
 | :-- | :-- |
@@ -29,6 +31,7 @@ an ad-hoc impression. Works for one target or a batch; generalizes to any repo.
 | (e) **Stability** | Likelihood it destabilizes our workflow or running services; maturity, breaking-change history, blast radius. |
 | (f) **Quality & support** | Maintenance signals **with the observation date**: stars, contributors/bus factor, release cadence, issue responsiveness, docs, last commit. |
 | (g) **Demo** | A workable sandboxed demo to validate first-hand: quickstart + real use case + success criteria. **Docker if possible; otherwise skip the demo entirely** — no unsandboxed demos. |
+| (h) **Borrowable features (build-vs-adopt)** | For each valuable capability the tool has that our stack lacks, could we implement *just that feature* in our existing setup more simply than adopting the whole tool? Table it: gap → value → build-it-ourselves sketch → worth it? Ground the sketches in what we already run. This can flip the verdict to **reject-but-build-the-feature** — often the simpler, safer conclusion. |
 
 ## Procedure
 
@@ -51,9 +54,11 @@ target) that must:
    variants; rule out name collisions explicitly. If no confident identification
    after honest searching → verdict **NOT_FOUND**, listing the searches tried and
    closest candidates — this is a valid terminal outcome, not a failure.
-2. Gather evidence for all seven dimensions. Ground (f) in the repo API (stars,
+2. Gather evidence for all eight dimensions. Ground (f) in the repo API (stars,
    contributors, last push, open issues) and **state the observation date**. Mine
-   the issue tracker for (c)/(d)/(e) — open bugs are the adversarial goldmine.
+   the issue tracker for (c)/(d)/(e) — open bugs are the adversarial goldmine. For
+   (h), diff the tool's capabilities against what we already run and ask which
+   valuable gaps are cheaply buildable in-house.
 3. Draft the (g) demo as concrete commands (compose file / docker run), sandboxed:
    throwaway dirs, localhost-only ports, never real credentials or OAuth tokens,
    full teardown. If docker genuinely can't work, write "no docker demo — skip".
@@ -67,9 +72,10 @@ what we already run (memory systems, orchestration, infra) — pass it in the pr
 
 Per FOUND target: condense the dossier into the research design doc
 (`designs/<slug>.md` from the research template) ending in a **Verdict**:
-`adopt / adopt selectively / park (gated on demo) / reject / reject-but-steal-the-pattern`
-— one paragraph, grounded in the sections. Per NOT_FOUND target: a stub doc
-recording the searches + candidates, state `not-found`.
+`adopt / adopt selectively / park (gated on demo) / reject / reject-but-steal-the-pattern
+/ reject-but-build-the-feature` — one paragraph, grounded in the sections (including the
+(h) build-vs-adopt call). Per NOT_FOUND target: a stub doc recording the searches +
+candidates, state `not-found`.
 
 ### 4 — Track
 
@@ -93,6 +99,8 @@ before its container run.
 - **Docker-or-skip** for demos — no "just try it on the host".
 - **Adversarial section is mandatory** — an evaluation with no case-against is
   marketing, not research.
+- **Always run the (h) build-vs-adopt check** — never conclude "adopt" without first
+  asking whether the valuable features could be built into our own stack more simply.
 - **Dated observations** — every quality/maintenance number carries the date.
 - **NOT_FOUND stops that target** — record it and move on; don't force a match
   onto a name-collision.

--- a/ai/skills/research-evaluation/evals/evals.json
+++ b/ai/skills/research-evaluation/evals/evals.json
@@ -24,6 +24,12 @@
       "prompt": "Can you check out that hermes agent harness on github and propose how we'd use it with our k8s project and standalone?",
       "expected_output": "Identifies the canonical repo, runs the full rubric, and includes a dedicated proposed-usage section covering both an integrated deployment against the user's cluster (least-privilege, sandboxed sidecar posture) and a standalone docker-compose path, ending with a verdict.",
       "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "For each tool we've researched, what features are we missing in our own setup, and should we just build them ourselves instead of adopting the tool?",
+      "expected_output": "Runs the (h) borrowable-features / build-vs-adopt dimension across the evaluations: for each valuable capability the tool has that the user's stack lacks, tables gap -> value to us -> build-it-ourselves sketch (grounded in existing hooks/.remember/MEMORY.md/gss/skills/skill-creator evals) -> worth it, and where the in-house build is simpler/safer flips the verdict to reject-but-build-the-feature rather than adopting.",
+      "files": []
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #200 (merged). Adds an eighth dimension to the `research-evaluation` rubric: for each valuable capability a tool has that our stack lacks, evaluate building *just that feature* into our existing setup (hooks, `.remember/`, MEMORY.md, gss, skills, `skill-creator` evals, the progressive-context DAG) instead of adopting the whole tool.

- New verdict option `reject-but-build-the-feature` — often the simpler, safer conclusion.
- Hard rule: never conclude "adopt" without first running the (h) build-vs-adopt check.
- Adds an eval case for the cross-sweep; JSON validated.

Mirrors the companion update to the playground research docs (sfc-gh-eraigosa/playground#244), where all six evaluations gained a Borrowable-features section and the docs/mbo research template + AGENTS.md gained dimension (h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vmghv5HXwpgnYfvjabhXwx