### PR TITLE
feat(research-evaluation): tunable gff-weighted rubric + business vector + glossary

### DIFF
--- a/.github/gff/features.yaml
+++ b/.github/gff/features.yaml
@@ -144,3 +144,117 @@ sets:
       - path: install.windows.portproxy
         description: Gates the standalone refresh-wsl-portproxy.ps1 script on the Windows side.
         boolDefault: true
+
+  # research-rubric.* — tunable weights for the research-evaluation skill's rubric.
+  # Smart PUBLIC defaults live here; anyone tunes them on demand via the gff user
+  # layer (`gff set research-rubric.weight.security critical` / `gff tui`) or a repo
+  # override — dissenting weightings never require editing the skill. Weight tiers:
+  # none=0 low=1 medium=2 high=3 critical=4 (the selected option's intValue is the
+  # weight the skill multiplies each dimension score by). See the skill's
+  # references/tuning.md.
+  - area: research-rubric
+    features:
+      - path: research-rubric.weight.value
+        description: "Weight for dimension (a) Value — what the tool is worth to us / problems it solves."
+        choiceDefault:
+          mode: CHOICE_MODE_SINGLE
+          options:
+            - {id: none,     description: ignore this dimension, intValue: 0}
+            - {id: low,      description: minor factor,          intValue: 1}
+            - {id: medium,   description: normal factor,         intValue: 2}
+            - {id: high,     description: strong factor,         intValue: 3, selected: true}
+            - {id: critical, description: decisive factor,       intValue: 4}
+      - path: research-rubric.weight.setup-licensing
+        description: "Weight for dimension (b) Setup cost & licensing."
+        choiceDefault:
+          mode: CHOICE_MODE_SINGLE
+          options:
+            - {id: none,     description: ignore this dimension, intValue: 0}
+            - {id: low,      description: minor factor,          intValue: 1}
+            - {id: medium,   description: normal factor,         intValue: 2, selected: true}
+            - {id: high,     description: strong factor,         intValue: 3}
+            - {id: critical, description: decisive factor,       intValue: 4}
+      - path: research-rubric.weight.adversarial
+        description: "Weight for dimension (c) Adversarial review — the case against adopting."
+        choiceDefault:
+          mode: CHOICE_MODE_SINGLE
+          options:
+            - {id: none,     description: ignore this dimension, intValue: 0}
+            - {id: low,      description: minor factor,          intValue: 1}
+            - {id: medium,   description: normal factor,         intValue: 2}
+            - {id: high,     description: strong factor,         intValue: 3, selected: true}
+            - {id: critical, description: decisive factor,       intValue: 4}
+      - path: research-rubric.weight.security
+        description: "Weight for dimension (d) Security & safety."
+        choiceDefault:
+          mode: CHOICE_MODE_SINGLE
+          options:
+            - {id: none,     description: ignore this dimension, intValue: 0}
+            - {id: low,      description: minor factor,          intValue: 1}
+            - {id: medium,   description: normal factor,         intValue: 2}
+            - {id: high,     description: strong factor,         intValue: 3}
+            - {id: critical, description: decisive factor,       intValue: 4, selected: true}
+      - path: research-rubric.weight.stability
+        description: "Weight for dimension (e) Stability — blast radius / destabilization risk."
+        choiceDefault:
+          mode: CHOICE_MODE_SINGLE
+          options:
+            - {id: none,     description: ignore this dimension, intValue: 0}
+            - {id: low,      description: minor factor,          intValue: 1}
+            - {id: medium,   description: normal factor,         intValue: 2, selected: true}
+            - {id: high,     description: strong factor,         intValue: 3}
+            - {id: critical, description: decisive factor,       intValue: 4}
+      - path: research-rubric.weight.quality-support
+        description: "Weight for dimension (f) Quality & support — maintenance, bus factor, cadence."
+        choiceDefault:
+          mode: CHOICE_MODE_SINGLE
+          options:
+            - {id: none,     description: ignore this dimension, intValue: 0}
+            - {id: low,      description: minor factor,          intValue: 1}
+            - {id: medium,   description: normal factor,         intValue: 2, selected: true}
+            - {id: high,     description: strong factor,         intValue: 3}
+            - {id: critical, description: decisive factor,       intValue: 4}
+      - path: research-rubric.weight.demo
+        description: "Weight for dimension (g) Demo — first-hand docker-sandboxed validation."
+        choiceDefault:
+          mode: CHOICE_MODE_SINGLE
+          options:
+            - {id: none,     description: ignore this dimension, intValue: 0}
+            - {id: low,      description: minor factor,          intValue: 1, selected: true}
+            - {id: medium,   description: normal factor,         intValue: 2}
+            - {id: high,     description: strong factor,         intValue: 3}
+            - {id: critical, description: decisive factor,       intValue: 4}
+      - path: research-rubric.weight.borrowable
+        description: "Weight for dimension (h) Borrowable features — build-vs-adopt leverage."
+        choiceDefault:
+          mode: CHOICE_MODE_SINGLE
+          options:
+            - {id: none,     description: ignore this dimension, intValue: 0}
+            - {id: low,      description: minor factor,          intValue: 1}
+            - {id: medium,   description: normal factor,         intValue: 2}
+            - {id: high,     description: strong factor,         intValue: 3, selected: true}
+            - {id: critical, description: decisive factor,       intValue: 4}
+      - path: research-rubric.weight.business
+        description: "Weight for dimension (i) Business outcomes — the financial/ROI vector (modest default)."
+        choiceDefault:
+          mode: CHOICE_MODE_SINGLE
+          options:
+            - {id: none,     description: ignore this dimension, intValue: 0}
+            - {id: low,      description: minor factor,          intValue: 1}
+            - {id: medium,   description: normal factor,         intValue: 2, selected: true}
+            - {id: high,     description: strong factor,         intValue: 3}
+            - {id: critical, description: decisive factor,       intValue: 4}
+      - path: research-rubric.decision.mode
+        description: "Verdict-threshold posture applied to the weighted score."
+        choiceDefault:
+          mode: CHOICE_MODE_SINGLE
+          options:
+            - {id: strict,   description: high bar; reject unless strongly positive, stringValue: strict}
+            - {id: balanced, description: default posture,                          stringValue: balanced, selected: true}
+            - {id: lenient,  description: adopt-friendly; low bar,                  stringValue: lenient}
+      - path: research-rubric.require.adversarial
+        description: "Require a non-empty adversarial (case-against) section; a verdict without one is invalid."
+        boolDefault: true
+      - path: research-rubric.require.docker-demo
+        description: "Require the demo be docker-sandboxed or explicitly skipped — no unsandboxed demos."
+        boolDefault: true

--- a/ai/skills/research-evaluation/SKILL.md
+++ b/ai/skills/research-evaluation/SKILL.md
@@ -6,11 +6,12 @@ description: >-
   doc + tracking issue per target. Use when the user wants to "research X", "evaluate
   X before we adopt it", "look up X and tell me if it's useful", "start a research
   MBO for X", or gives a list of candidate tools to investigate — even a single
-  target. Runs the eight-dimension rubric: (a) value to us, (b) setup cost +
+  target. Runs the nine-dimension rubric: (a) value to us, (b) setup cost +
   licensing, (c) adversarial review, (d) security & safety, (e) stability,
   (f) quality & support, (g) a docker-sandboxed hands-on demo (docker-or-skip),
   (h) borrowable features (build-vs-adopt — could we build just the valuable
-  bits ourselves instead of adopting the whole tool?).
+  bits ourselves instead of adopting the whole tool?), (i) business outcomes
+  (the financial/ROI vector). Dimension weights are tunable gff feature flags.
   Fans multiple targets out to parallel research agents; NOT_FOUND is a valid,
   recorded outcome for targets that can't be identified through searches.
 ---
@@ -20,7 +21,7 @@ description: >-
 Turn "should we use <tool>?" into a consistent, evidence-backed evaluation instead of
 an ad-hoc impression. Works for one target or a batch; generalizes to any repo.
 
-## The rubric (all eight, every target)
+## The rubric (all nine, every target)
 
 | Dim | Question |
 | :-- | :-- |
@@ -32,6 +33,25 @@ an ad-hoc impression. Works for one target or a batch; generalizes to any repo.
 | (f) **Quality & support** | Maintenance signals **with the observation date**: stars, contributors/bus factor, release cadence, issue responsiveness, docs, last commit. |
 | (g) **Demo** | A workable sandboxed demo to validate first-hand: quickstart + real use case + success criteria. **Docker if possible; otherwise skip the demo entirely** — no unsandboxed demos. |
 | (h) **Borrowable features (build-vs-adopt)** | For each valuable capability the tool has that our stack lacks, could we implement *just that feature* in our existing setup more simply than adopting the whole tool? Table it: gap → value → build-it-ourselves sketch → worth it? Ground the sketches in what we already run. This can flip the verdict to **reject-but-build-the-feature** — often the simpler, safer conclusion. |
+| (i) **Business outcomes** | The financial/ROI vector: does this move us toward financially positive — efficiency gains, hard-time saved, cost that pays for itself, or a step toward a self-propelling revenue outlet? Tag qualitative tiers (low/med/high) for **time saved**, **cost savings**, and **revenue potential**; fold them in at this dimension's weight. Even small value counts — the point is to add a money vector to a decision that is otherwise all opinion. |
+
+### Weighting (tunable, not hard-coded)
+
+Each dimension carries a **weight** read at eval time from `gff` feature flags under
+`research-rubric.*` (tiers `none·low·medium·high·critical` = `0·1·2·3·4`; public defaults
+skew to **value + security + adversarial + borrowable**, with **business** modest). Read
+them with `gff get research-rubric.weight.<dim>` / `gff list`, and **state the active
+weighting in the output** so a reader sees the lens behind the verdict. Weightings are
+meant to be overridden per person/team via the gff user layer — see
+[`references/tuning.md`](./references/tuning.md). Two gate flags:
+`research-rubric.require.adversarial` and `research-rubric.require.docker-demo`.
+
+### Explaining terms (clickable, not wordier)
+
+Link jargon to [`references/glossary.md`](./references/glossary.md) on its **first use** in
+a doc — e.g. `[bus factor](./references/glossary.md#bus-factor)`. A link adds no prose;
+it just makes the output learnable. Glossary covers bus factor, blast radius, supply-chain
+surface, fail-open, prompt cache, CCR, prompt injection, SSRF, MCP, CalVer, CVE, SBOM.
 
 ## Procedure
 
@@ -54,11 +74,13 @@ target) that must:
    variants; rule out name collisions explicitly. If no confident identification
    after honest searching → verdict **NOT_FOUND**, listing the searches tried and
    closest candidates — this is a valid terminal outcome, not a failure.
-2. Gather evidence for all eight dimensions. Ground (f) in the repo API (stars,
+2. Gather evidence for all nine dimensions. Ground (f) in the repo API (stars,
    contributors, last push, open issues) and **state the observation date**. Mine
    the issue tracker for (c)/(d)/(e) — open bugs are the adversarial goldmine. For
    (h), diff the tool's capabilities against what we already run and ask which
-   valuable gaps are cheaply buildable in-house.
+   valuable gaps are cheaply buildable in-house. For (i), tag the ROI tiers. Read
+   the active `research-rubric.*` weights via `gff` and weight the dimensions
+   accordingly; link jargon to the glossary on first use.
 3. Draft the (g) demo as concrete commands (compose file / docker run), sandboxed:
    throwaway dirs, localhost-only ports, never real credentials or OAuth tokens,
    full teardown. If docker genuinely can't work, write "no docker demo — skip".

--- a/ai/skills/research-evaluation/references/glossary.md
+++ b/ai/skills/research-evaluation/references/glossary.md
@@ -1,0 +1,81 @@
+# Research-evaluation glossary
+
+Plain-language definitions for the jargon that shows up in research dossiers and the
+rubric. Link to an entry on a term's **first use** in a doc, e.g.
+`[bus factor](../references/glossary.md#bus-factor)` — a link, not extra prose, so the
+output stays short but stays learnable. (Playground design docs link to their own
+`docs/mbo/glossary.md` copy.)
+
+### Bus factor
+The number of people who would have to be "hit by a bus" (leave abruptly) before a
+project stalls. **Bus factor = 1** means one maintainer holds effectively all the
+knowledge and publishing rights — if they walk, the project (and your dependency on it)
+is stranded. Low bus factor is a supply-chain and stability risk.
+Learn more: <https://en.wikipedia.org/wiki/Bus_factor>
+
+### Blast radius
+How much breaks when one component fails or is compromised. A tool given broad
+credentials or sitting in the request path has a large blast radius; an isolated
+sidecar with least-privilege access has a small one.
+Learn more: <https://cloud.google.com/architecture/framework/reliability/manage-failure-modes>
+
+### Software supply-chain surface
+Everything you implicitly trust by installing something: its package registry account,
+transitive dependencies, install scripts, and build/publish pipeline. A larger surface
+(many deps, single-maintainer publishing) means more ways a compromise reaches you.
+Learn more: <https://en.wikipedia.org/wiki/Supply_chain_attack>
+
+### Fail-open (vs fail-closed)
+What a guard does when it can't decide. **Fail-open** = allow/continue on error (favours
+availability, weakens safety); **fail-closed** = block on error (favours safety). A
+security guardrail that "logs and continues" is fail-open.
+Learn more: <https://en.wikipedia.org/wiki/Fail-safe>
+
+### Prompt cache / cached reads
+Anthropic can cache a stable prompt prefix so repeated tokens are billed at ~10% of the
+normal input rate ("cached reads"). Anything that rewrites the prefix "busts" the cache
+and you pay full price again — which is why naive token-reduction math can overstate
+dollar savings.
+Learn more: <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+
+### CCR (compress · cache · retrieve)
+Headroom's pattern for *reversible* compression: shrink a payload, cache the original
+locally, and give the model a tool to fetch the full detail on demand. Failure mode: the
+model has to notice something's missing, so lossy compression can yield silent wrong
+answers rather than errors.
+Learn more: <https://headroom-docs.vercel.app/docs>
+
+### Prompt injection
+An attack where untrusted content (a web page, tool output, a file) carries instructions
+the model then follows. Persisted memory/observation stores make it worse: injected text
+can be re-injected into future sessions.
+Learn more: <https://owasp.org/www-project-top-10-for-large-language-model-applications/>
+
+### SSRF (server-side request forgery)
+Tricking a server into making requests to addresses it shouldn't reach (internal
+metadata endpoints, private IPs). Relevant when a proxy/agent allows arbitrary outbound
+URLs (`allow_private_urls`).
+Learn more: <https://owasp.org/www-community/attacks/Server_Side_Request_Forgery>
+
+### MCP (Model Context Protocol)
+An open protocol for exposing tools/data to LLM agents over a standard interface. MCP
+servers run as subprocesses with whatever privileges you grant — an unsigned MCP is a
+code-execution trust decision.
+Learn more: <https://modelcontextprotocol.io>
+
+### CalVer (calendar versioning)
+Version numbers derived from the date (e.g. `v2026.8.3`) rather than semantic meaning.
+Signals a fast, continuous release train — pin versions.
+Learn more: <https://calver.org>
+
+### CVE
+A Common Vulnerabilities and Exposures identifier — a public ID for a specific known
+security flaw (e.g. `CVE-2026-9277`). "An open CVE in a dependency" = a known,
+catalogued vulnerability not yet remediated.
+Learn more: <https://www.cve.org>
+
+### SBOM (software bill of materials)
+A machine-readable inventory of every component and dependency in a piece of software —
+the manifest you'd audit to answer "am I affected by X?". Absence of an SBOM/signing
+raises supply-chain uncertainty.
+Learn more: <https://www.cisa.gov/sbom>

--- a/ai/skills/research-evaluation/references/tuning.md
+++ b/ai/skills/research-evaluation/references/tuning.md
@@ -1,0 +1,57 @@
+# Tuning the rubric (gff weights)
+
+The rubric's per-dimension weights are **[gff](../../../sdk/gff/AGENTS.md) feature flags**,
+not hard-coded in the skill — so weightings are configurable on demand and *others can
+dissent without editing anything the skill ships*. One size does not fit all; your lived
+experience and priorities are meant to override these defaults.
+
+## The flags
+
+Nine weight flags + a decision mode + two requirement toggles, under `research-rubric.*`
+(defined in `.github/gff/features.yaml`; env-export form `RESEARCH_RUBRIC_*`):
+
+| Flag | Dimension | Public default |
+| :-- | :-- | :-- |
+| `research-rubric.weight.value` | (a) Value | high |
+| `research-rubric.weight.setup-licensing` | (b) Setup & licensing | medium |
+| `research-rubric.weight.adversarial` | (c) Adversarial | high |
+| `research-rubric.weight.security` | (d) Security & safety | critical |
+| `research-rubric.weight.stability` | (e) Stability | medium |
+| `research-rubric.weight.quality-support` | (f) Quality & support | medium |
+| `research-rubric.weight.demo` | (g) Demo | low |
+| `research-rubric.weight.borrowable` | (h) Borrowable (build-vs-adopt) | high |
+| `research-rubric.weight.business` | (i) Business outcomes | medium |
+| `research-rubric.decision.mode` | verdict posture | balanced |
+| `research-rubric.require.adversarial` | gate: case-against mandatory | true |
+| `research-rubric.require.docker-demo` | gate: docker-or-skip demos | true |
+
+Weight tiers are `none · low · medium · high · critical` → **0 · 1 · 2 · 3 · 4**. The
+skill multiplies each dimension's assessment by its tier value, so `none` drops a
+dimension entirely and `critical` makes it decisive.
+
+## Reading them (what the skill does)
+
+```bash
+gff get research-rubric.weight.security          # -> critical
+gff list --source com.github.sfc-gh-eraigosa.dotfiles   # all flags + winning layer
+```
+
+The skill reads the effective tiers at evaluation time and states the active weighting in
+its output, so a reader can see which lens produced the verdict.
+
+## Tuning on demand (the override layer)
+
+Overrides live in the gff **user layer** (`~/.config/gff/config.yaml`) — they win over the
+repo defaults and travel with you, no fork required:
+
+```bash
+gff set research-rubric.weight.business high      # I care more about ROI than the default
+gff set research-rubric.weight.demo none          # I don't gate on demos
+gff set research-rubric.decision.mode strict      # raise the adoption bar
+gff tui                                            # browse/toggle interactively w/ provenance
+gff unset research-rubric.weight.business          # restore the default
+```
+
+Share a weighting by committing a repo-layer override in your own project, or hand someone
+your `~/.config/gff/config.yaml` snippet. Dissenting rubrics are a feature: capture *why*
+alongside the override so the next person understands the lens, not just the numbers.


### PR DESCRIPTION
Follow-up to #200/#202 (merged). Makes the research-evaluation rubric **tunable** and adds two things you asked for.

**Weighted rubric via gff** — nine dimension weights under `research-rubric.*` (tiers none·low·medium·high·critical = 0·1·2·3·4), a `decision.mode`, and `require.{adversarial,docker-demo}` gates in `.github/gff/features.yaml`. Public smart defaults (value/security/adversarial/borrowable high; business modest) are overridable **on demand** through gff's user layer — `gff set research-rubric.weight.business high`, `gff tui` — so dissenting weightings never require editing the skill. Docs: `references/tuning.md`. (gff segments are kebab-only, so the prefix is `research-rubric.*`; env form `RESEARCH_RUBRIC_*`.)

**Dimension (i) Business outcomes** — a financial/ROI vector (qualitative low/med/high tiers for time-saved, cost-savings, revenue-potential) so decisions carry a money weight, not just opinion.

**Glossary + clickable terms** — `references/glossary.md`: plain-language definitions + external links for bus factor (incl. bus-factor=1), blast radius, supply-chain surface, fail-open, prompt cache, CCR, SSRF, MCP, CalVer, CVE, SBOM. The skill links jargon on first use — a link, no extra prose.

Companion playground changes ride on sfc-gh-eraigosa/playground#244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vmghv5HXwpgnYfvjabhXwx