### PR TITLE
ci: merge_group triggers on all required-check workflows (merge queue prep)

### DIFF
--- a/.github/workflows/gff-ci.yml
+++ b/.github/workflows/gff-ci.yml
@@ -15,6 +15,11 @@ name: gff CI
 #   Total gate: ≥90% — a hard floor, never to be lowered.
 
 on:
+  # Merge-queue coverage: this workflow produces REQUIRED checks (binary-level
+  # e2e tests, unit tests + coverage gate), so it must report on the queue's
+  # ephemeral branches — merge_group takes no path filters by design.
+  merge_group:
+    branches: [ main ]
   push:
     branches: [ main ]
     paths:

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -10,6 +10,11 @@ name: Shell Lint
 # comment. See docker-image.yml for the full rationale.
 
 on:
+  # Merge-queue coverage: produces the REQUIRED "Shell Lint (shellcheck)"
+  # check, so it must report on the queue's ephemeral branches — merge_group
+  # takes no path filters by design.
+  merge_group:
+    branches: [ main ]
   push:
     branches: [ main ]
     paths:

--- a/.github/workflows/teams-eval.yml
+++ b/.github/workflows/teams-eval.yml
@@ -1,6 +1,11 @@
 name: AI Teams Eval
 
 on:
+  # Merge-queue coverage: produces the REQUIRED "Validate teams source +
+  # routing artifacts" check, so it must report on the queue's ephemeral
+  # branches — merge_group takes no path filters by design.
+  merge_group:
+    branches: [ main ]
   push:
     branches: [ main ]
     paths:


### PR DESCRIPTION
## Summary

Prep for enabling the merge queue on `main`: required status checks must report on the queue's ephemeral `merge_group` branches or every queue entry hangs until timeout. `docker-image.yml` has handled `merge_group` since the phase-6 CI work; this adds the trigger to the three remaining workflows that produce **required** checks:

- `gff-ci.yml` — `binary-level e2e tests`, `unit tests + coverage gate`
- `teams-eval.yml` — `Validate teams source + routing artifacts`
- `shell-lint.yml` — `Shell Lint (shellcheck)`

`merge_group` carries no path filters by design — the queue needs every required check to report on every entry. Side benefit: docs-only PRs are no longer stranded by path-filtered required checks, since the merge gate moves to the (unfiltered) queue run.

Rollout: merge this, then the ruleset gains the `merge_queue` rule (squash, ALLGREEN, 45-min check timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg1823QX3G1P7NpEtkGMPZ