### PR TITLE
ci: Mergify merge queue config (label- and comment-driven)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,33 @@
+# Mergify merge queue — the queue GitHub reserves for org-owned repos,
+# provided by the Mergify app instead (installed on this personal-account
+# repo; free tier). Docs: https://docs.mergify.com/merge-queue/
+#
+# How to land a PR through the queue:
+#   - add the `ready-for-merge` label (it ALSO force-runs the heavy
+#     build-and-validate job on drafts — same label, one meaning: "land it"),
+#     then mark the PR ready for review; or
+#   - comment `@mergifyio queue` on the PR (works ad hoc, no label).
+#
+# Mergify updates the PR in place against the latest main (update_method:
+# merge — satisfies the ruleset's strict up-to-date requirement without
+# force-pushing the branch), waits for the ruleset's REQUIRED checks on the
+# updated code, then squash-merges. Queue entries are serialized, so two
+# green-but-conflicting PRs can never land stale.
+
+queue_rules:
+  - name: default
+    merge_method: squash
+    update_method: merge
+    # No extra merge_conditions: the branch ruleset's required status checks
+    # are enforced by GitHub and honored by Mergify automatically. Add
+    # conditions here only for gates that are NOT ruleset-required.
+    merge_conditions: []
+
+pull_request_rules:
+  - name: queue PRs labeled ready-for-merge
+    conditions:
+      - label = ready-for-merge
+      - -draft
+    actions:
+      queue:
+        name: default


### PR DESCRIPTION
## Summary

GitHub's native merge queue is unavailable on personal-account repos, so the just-installed **Mergify app** provides it. This config (`.github/mergify.yml`) wires the queue:

- **Enqueue** by adding the **`ready-for-merge`** label (the same label that already force-runs the heavy build-and-validate job on drafts — one label, one meaning: *land it*; drafts are excluded from queueing until marked ready) or ad hoc via a **`@mergifyio queue`** comment.
- **Behavior**: Mergify updates the PR in place against latest `main` (`update_method: merge` — satisfies the ruleset's strict up-to-date requirement without force-pushing your branch), waits for the ruleset's **required checks** on the updated code (honored automatically — `merge_conditions` intentionally empty), then **squash-merges**. Entries are serialized, so two green-but-conflicting PRs can never land stale.

The `merge_group` CI triggers from #206 stay in place — they're inert under Mergify and activate instantly if these repos ever move to an org for GitHub's native queue.

Suggested first customers once this merges: #204, #207, #208 — label them and watch the train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg1823QX3G1P7NpEtkGMPZ