### PR TITLE
ci: drop pull_request path filters on required-check workflows (unstick queue)

### DIFF
--- a/.github/workflows/gff-ci.yml
+++ b/.github/workflows/gff-ci.yml
@@ -26,12 +26,13 @@ on:
       - 'sdk/gff/**'
       - '.github/workflows/gff-ci.yml'
       - 'Makefile'
+  # No paths filter on pull_request: this workflow's checks are REQUIRED by
+  # the main ruleset, and the Mergify queue waits on required contexts — a
+  # path-skipped check never reports, so a PR not touching gff would sit in
+  # "waiting for queue conditions" forever. Both jobs are sub-minute; the
+  # push trigger above keeps its filter.
   pull_request:
     branches: [ main ]
-    paths:
-      - 'sdk/gff/**'
-      - '.github/workflows/gff-ci.yml'
-      - 'Makefile'
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/teams-eval.yml
+++ b/.github/workflows/teams-eval.yml
@@ -12,11 +12,12 @@ on:
       - 'ai/teams/**'
       - 'opt/scripts/system/install_ai_teams.sh'
       - '.github/workflows/teams-eval.yml'
+  # No paths filter on pull_request: the "Validate teams source + routing
+  # artifacts" check is REQUIRED by the main ruleset, and the Mergify queue
+  # waits on required contexts — a path-skipped check never reports, so a PR
+  # not touching ai/teams would sit in "waiting for queue conditions"
+  # forever. The job is ~40s; the push trigger above keeps its filter.
   pull_request:
-    paths:
-      - 'ai/teams/**'
-      - 'opt/scripts/system/install_ai_teams.sh'
-      - '.github/workflows/teams-eval.yml'
 
 # Cancel superseded runs on the same ref so only the latest commit is evaluated.
 concurrency:


### PR DESCRIPTION
## Summary

Root cause of the stuck `@mergifyio queue` commands on #204/#207/#208: **path-filtered required checks**. Mergify derives queue-entry conditions from the ruleset's required checks and waits for them on the PR's own CI (`pull_request` event — unlike GitHub's native queue it doesn't use the unfiltered `merge_group` event). A required check whose workflow is path-skipped never reports, so any PR not touching `sdk/gff` or `ai/teams` waits forever.

Fix: required-check workflows must always run on PRs — the `pull_request` `paths:` filters come off `gff-ci.yml` and `teams-eval.yml` (both jobs are sub-minute). `push` triggers keep their filters; `merge_group` unchanged.

**This PR itself queues cleanly** (it touches both workflow files, so every required context reports). After it merges, the stuck PRs just need their branches updated (Mergify's requeue or one Update-branch click) so their CI re-runs with the unfiltered workflows — then the queue drains on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg1823QX3G1P7NpEtkGMPZ