### PR TITLE
ci: force Mergify in-place queue checks (strict-ruleset compatibility)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,14 +14,21 @@
 # updated code, then squash-merges. Queue entries are serialized, so two
 # green-but-conflicting PRs can never land stale.
 
+# In-place checks only (no speculative draft-PR trains): required for
+# compatibility with the ruleset's strict "require branches to be up to date"
+# policy — Mergify flags the combination otherwise (see PR #204's warning).
+# Serialized in-place checking is our intended design anyway.
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
+    batch_size: 1
     merge_method: squash
     update_method: merge
-    # No extra merge_conditions: the branch ruleset's required status checks
-    # are enforced by GitHub and honored by Mergify automatically. Add
-    # conditions here only for gates that are NOT ruleset-required.
-    merge_conditions: []
+    # No queue/merge conditions: the branch ruleset's required status checks
+    # are enforced by GitHub and honored by Mergify automatically. Keeping
+    # both unset (identical) is also required for in-place mode.
 
 pull_request_rules:
   - name: queue PRs labeled ready-for-merge


### PR DESCRIPTION
## Summary

Mergify flagged on #204 that its speculative draft-PR queue checks are incompatible with the ruleset's strict "require branches to be up to date" policy (checks validated on a temporary draft leave the real PR branch out-of-date at merge time). This takes Mergify's **option 1** — force in-place checking, which was our intended design anyway:

- top-level `merge_queue: max_parallel_checks: 1`
- `batch_size: 1` on the queue rule
- queue/merge conditions identical (both unset; the ruleset's required checks govern)

The strict ruleset stays enabled, protecting any merge that bypasses the queue. After this merges, #204 gets requeued and should drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg1823QX3G1P7NpEtkGMPZ