### PR TITLE
ci: Mergify label hygiene — swap ready-for-merge for merged-by-mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -38,3 +38,14 @@ pull_request_rules:
     actions:
       queue:
         name: default
+
+  # Label hygiene: when Mergify performs the merge, swap the trigger label
+  # for an audit label so merged PRs are scannable at a glance.
+  - name: label swap after a Mergify merge
+    conditions:
+      - merged
+      - merged-by = mergify[bot]
+    actions:
+      label:
+        remove: [ready-for-merge]
+        add: [merged-by-mergify]


### PR DESCRIPTION
## Summary

When Mergify performs a merge, the `ready-for-merge` trigger label now comes off and `merged-by-mergify` (created) goes on — so queue-landed PRs are scannable at a glance and stale trigger labels don't linger on merged PRs. Mirrors the private companion repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg1823QX3G1P7NpEtkGMPZ
