### PR TITLE
ci: rulesets-as-code — snapshot tooling + Mergify merge protections

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,6 +21,27 @@
 merge_queue:
   max_parallel_checks: 1
 
+# Branch-protection-as-code: the merge gate list lives HERE, reviewable in
+# PRs, and reports as the single "Mergify Merge Protections" check. Rollout:
+# (1) merge this, (2) verify the check reports on a PR, (3) add it to the
+# GitHub ruleset's required checks and slim the native list to just it
+# (then `make ruleset-snapshot` + commit). Until step 3 the GitHub ruleset's
+# native check list remains the enforcer and this is a parallel dry run.
+merge_protections:
+  - name: required CI green (managed as code)
+    description: Mirror of the main ruleset's required checks — edit via PR.
+    if:
+      - base = main
+    success_conditions:
+      - check-success = Build and Integration Test
+      - check-success = Lint (go + shell + markdown + actions)
+      - check-success = Validate teams source + routing artifacts
+      - check-success = binary-level e2e tests
+      - check-success = unit tests + coverage gate
+      - check-success = Run Shell Test Drivers
+      - check-success = Shell Lint (shellcheck)
+      - check-success = Run Unit Tests
+
 queue_rules:
   - name: default
     batch_size: 1

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,95 @@
+{
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "enforcement": "active",
+  "id": 20600414,
+  "name": "main",
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": false,
+        "required_reviewers": []
+      },
+      "type": "pull_request"
+    },
+    {
+      "parameters": {
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Build and Integration Test",
+            "integration_id": 15368
+          },
+          {
+            "context": "Lint (go + shell + markdown + actions)",
+            "integration_id": 15368
+          },
+          {
+            "context": "Validate teams source + routing artifacts",
+            "integration_id": 15368
+          },
+          {
+            "context": "binary-level e2e tests",
+            "integration_id": 15368
+          },
+          {
+            "context": "unit tests + coverage gate",
+            "integration_id": 15368
+          },
+          {
+            "context": "Run Shell Test Drivers",
+            "integration_id": 15368
+          },
+          {
+            "context": "Shell Lint (shellcheck)",
+            "integration_id": 15368
+          },
+          {
+            "context": "Run Unit Tests",
+            "integration_id": 15368
+          }
+        ],
+        "strict_required_status_checks_policy": true
+      },
+      "type": "required_status_checks"
+    },
+    {
+      "parameters": {
+        "review_draft_pull_requests": false,
+        "review_on_push": true
+      },
+      "type": "copilot_code_review"
+    }
+  ],
+  "source": "sfc-gh-eraigosa/dotfiles",
+  "source_type": "Repository",
+  "target": "branch"
+}

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ claude-test: ## Run Claude Code sanity check (CLI, links, hooks, 27-case hook te
 claude-hook-test: ## Run safety_guard hook test suite only
 	./ai/hooks/safety_guard_test.sh
 
+.PHONY: ruleset-snapshot
+ruleset-snapshot: ## Refresh .github/rulesets/*.json from the live GitHub rulesets (reviewable audit trail; run after any ruleset change)
+	./opt/scripts/git/ruleset_snapshot.sh
+
 .PHONY: git-doctor
 git-doctor: ## Check git identity (user.email/name) against the authenticated GitHub account (pass extra repos as args to the script directly)
 	./opt/scripts/git/git_identity_doctor.sh .

--- a/opt/scripts/git/ruleset_snapshot.sh
+++ b/opt/scripts/git/ruleset_snapshot.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# ruleset_snapshot.sh — export a repo's GitHub branch rulesets to
+# .github/rulesets/<name>.json so settings changes are reviewable in PRs.
+# Rulesets are repository SETTINGS (no file representation), so this snapshot
+# is the audit trail: re-run after any ruleset change and commit the diff.
+# The snapshot is documentation — GitHub does not read it back; the ruleset
+# UI/API remains the enforcement source.
+#
+# Usage: ruleset_snapshot.sh [owner/repo] [output-dir]
+#   Defaults: repo of the current directory's origin; <repo-root>/.github/rulesets
+#
+# Volatile fields (node_id, timestamps, links, current_user_can_bypass) are
+# stripped and keys sorted so diffs stay meaningful.
+
+set -eu
+
+command -v gh >/dev/null 2>&1 || { echo "ruleset_snapshot: gh is required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "ruleset_snapshot: jq is required" >&2; exit 1; }
+
+REPO="${1:-}"
+if [ -z "$REPO" ]; then
+  REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)" || {
+    echo "ruleset_snapshot: not in a repo and no owner/repo argument given" >&2; exit 1; }
+fi
+
+OUT_DIR="${2:-}"
+if [ -z "$OUT_DIR" ]; then
+  ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "ruleset_snapshot: not in a git repo; pass an output dir" >&2; exit 1; }
+  OUT_DIR="$ROOT/.github/rulesets"
+fi
+mkdir -p "$OUT_DIR"
+
+ids="$(gh api "repos/$REPO/rulesets" --jq '.[].id')"
+[ -n "$ids" ] || { echo "ruleset_snapshot: no rulesets on $REPO"; exit 0; }
+
+for id in $ids; do
+  raw="$(gh api "repos/$REPO/rulesets/$id")"
+  name="$(printf '%s' "$raw" | jq -r '.name' | tr -d '\n' | tr -c 'A-Za-z0-9._-' '-' )"
+  printf '%s' "$raw" | jq -S 'del(.node_id, .created_at, .updated_at, ._links, .current_user_can_bypass)' \
+    > "$OUT_DIR/$name.json"
+  echo "wrote $OUT_DIR/$name.json (ruleset $id)"
+done


### PR DESCRIPTION
## Summary

Two reviewability layers for branch protection, per today's discussion:

### 1. Ruleset snapshot (audit trail)
- **`.github/rulesets/main.json`** — committed export of the live GitHub ruleset. Rulesets are repository *settings* with no file representation, so this snapshot is how setting changes become PR-reviewable. Volatile fields stripped, keys sorted for stable diffs.
- **`make ruleset-snapshot`** → `opt/scripts/git/ruleset_snapshot.sh` (works for any repo: `ruleset_snapshot.sh owner/repo [outdir]`). Run after any ruleset change and commit the diff.
- Note: the snapshot is documentation — GitHub doesn't read it back; enforcement stays in the ruleset itself.

### 2. Merge protections as code (Mergify)
`merge_protections` in `.github/mergify.yml` now carries the merge-gate list — all eight required checks — reporting as the single **"Mergify Merge Protections"** check on every PR ([docs](https://docs.mergify.com/merge-protections/)).

**Staged rollout** (to avoid ever gating on a check that doesn't report):
1. Merge this — the protections run as a parallel dry run; native ruleset checks still enforce.
2. Verify "Mergify Merge Protections" reports on the next PR.
3. Slim the GitHub ruleset's required list to just the Mergify check + refresh the snapshot. From then on, gate changes are plain PRs to this file.

⚠️ One manual step only you can do: enable **Merge Protections** for both repos in the Mergify dashboard (Merge Protections → select repo → enable) if the check doesn't appear after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg1823QX3G1P7NpEtkGMPZ