### PR TITLE
ci: stop merge-queue main landings from cancelling Docker Image CI (fix red badge)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -46,11 +46,22 @@ on:
   merge_group:
 
 # Cancel superseded runs on the same ref: without this, a hung build (e.g. the
-# PR #182 tzdata-prompt hang) piles up one 6-hour run per push. main and the
-# merge queue never cancel (their runs validate distinct commits).
+# PR #182 tzdata-prompt hang) piles up one 6-hour run per push. PR runs cancel;
+# push (main) and merge_group runs must NOT — their runs validate distinct
+# commits and must all reach a conclusion (a cancelled run reddens the badge).
+#
+# The group therefore carries a per-run discriminator for non-PR events:
+#   - pull_request -> "pr", so the group is stable per PR ref and a new commit
+#     cancels the older in-flight run (the intended cost saving).
+#   - push / merge_group -> github.run_id, a UNIQUE value per run, so each run
+#     is alone in its group and can never be cancelled by a sibling.
+# This replaces `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`,
+# which did NOT protect push runs: once the merge queue went live, rapid
+# back-to-back main landings put two main runs in the same ref-keyed group and
+# the in-flight (slow Docker build) run was cancelled, failing the badge.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -38,10 +38,14 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Cancel in-flight runs of the same workflow if a new push arrives on the
-  # same branch/ref. This reduces runner usage when a developer pushes
-  # multiple commits in quick succession.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs to save runners, but never cancel push (main) or
+  # merge_group runs — those validate distinct commits and must each conclude
+  # (a cancelled run reddens the badge). The per-run discriminator keeps PR runs
+  # sharing a group (cancellable) while giving each push/merge_group run a unique
+  # group via github.run_id so it is alone and cannot be cancelled by a sibling.
+  # (A ref-only group + cancel-in-progress: true cancelled main runs once the
+  # merge queue started landing PRs back-to-back onto main.)
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem
The **Docker Image CI** badge on `main` shows **failing**. But main isn't broken — every job passes *except* **Build and Integration Test**, which shows **cancelled**. Reproduced on a fresh re-run of `main` HEAD: all fast jobs green, the ~10-min Docker build cancelled at ~80s with "The operation was canceled" (not the 15-min timeout → an external cancellation).

## Root cause
The concurrency group was keyed only by `(workflow, ref)`:
```
group: ${{ github.workflow }}-${{ github.ref }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```
So every push to `main` shared **one** group. The `cancel-in-progress` expression did **not** actually protect push runs. This was dormant until the **Mergify merge queue went live** — the queue now lands PRs back-to-back onto `main`, so each landing's run overlaps the previous still-building one. The slow Docker build is almost always in flight when the next landing pushes, so it gets cancelled → red badge.

`Shell Lint` has the identical config; it just rarely shows because it finishes in ~40s (usually done before the next landing).

## Fix
Add a per-run discriminator to the concurrency group:
- **pull_request →** `pr`: group stays stable per PR ref, so a new commit cancels the older in-flight run (the intended runner saving).
- **push / merge_group →** `github.run_id`: a **unique** value per run, so each run is alone in its group and can never be cancelled by a sibling.

Applied to both `docker-image.yml` and `shell-lint.yml`.

## Verification
- `yaml.safe_load` + `actionlint` clean on both files.
- After merge: back-to-back `main` landings each get a unique group → the Docker build run always reaches a conclusion → badge reflects the real build result.

## Notes / out of scope
- The build's `sanity_check.sh` sources `.zshrc`, which network-clones `zsh-completions` on startup — a *latent* fragility (a bad-network build day could fail/hang it) but **not** the cause of this badge failure. Left for a separate change to keep this PR focused on the concurrency root cause.
- `gff-ci.yml` / `teams-eval.yml` use the same ref-only pattern but are path-filtered and fast, so they're low-risk; can be brought in line in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2xi2Nj8DZtbRcD53zbLY3