### PR TITLE
plugins: update pass in sync-plugins — installs were pinned forever

### DIFF
--- a/ai/plugins.yaml
+++ b/ai/plugins.yaml
@@ -2,8 +2,9 @@
 # Human reference (summary + first-usage examples): docs/ai-plugins.md
 # Design: docs/mbo/plans/ai-plugin-manifest.md
 #
-# Ensure-only (additive): opt/scripts/system/sync-plugins.sh installs + enables
-# what's listed here; it never removes anything. Parsed with mikefarah `yq`.
+# Ensure-only (additive): opt/scripts/system/sync-plugins.sh installs, enables,
+# and updates-to-latest what is listed here; it never removes anything.
+# Parsed with mikefarah `yq`.
 #
 #   enabled: true   -> install AND enable for each platform block present
 #   enabled: false  -> parked: documented but not installed/enabled

--- a/docs/ai-plugins.md
+++ b/docs/ai-plugins.md
@@ -18,7 +18,7 @@ sync-plugins --dry-run
 sync-plugins
 ```
 
-The synchronization is **ensure-only**: it installs and enables what is listed but never removes existing extensions.
+The synchronization is **ensure-only**: it installs, enables, and **updates to latest** what is listed, but never removes existing extensions.
 
 ## 🤖 Supported Assistants
 

--- a/docs/claude-code-support.md
+++ b/docs/claude-code-support.md
@@ -10,7 +10,7 @@ for auditing new Claude Code releases.
 | Bound | Version | Why | Last verified |
 |---|---|---|---|
 | **Floor** | `v2.1.195` | Newest host that predates `/rc` (Remote Control, introduced v2.1.196, 2026-06-29) | 2026-08-08 |
-| **Latest verified** | `v2.1.224` | Primary WSL host (`claude --version`) | 2026-08-08 |
+| **Latest verified** | `v2.1.226` | Primary WSL host (`claude --version`; CLI auto-updater tracks the `latest` channel) | 2026-08-09 |
 
 When a floor host is upgraded, raise the floor here and delete any version guards the new
 floor makes unnecessary. When auditing a new release, update "Latest verified" + the log below.

--- a/opt/scripts/system/sync-plugins.sh
+++ b/opt/scripts/system/sync-plugins.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # sync-plugins.sh — ensure the AI-assistant plugins declared in ai/plugins.yaml
-# are installed and enabled. Ensure-only (additive): never removes anything.
-# Mirrors sync-skills.sh. Safe to re-run.
+# are installed, enabled, and UPDATED to latest. Ensure-only (additive): never
+# removes anything. Mirrors sync-skills.sh. Safe to re-run.
 #
 # Usage:
 #   sync-plugins.sh            install + enable per the manifest
@@ -136,11 +136,19 @@ sync_claude() {
         { [ -z "$src" ] || [ "$src" = "null" ]; } && continue
         run claude plugin marketplace add "$src"
     done < <(yq '.marketplaces[] | select(.claude != null) | .claude' "$MANIFEST")
-    # Install + enable each enabled plugin that has a claude.plugin.
+    # Refresh every marketplace catalog from its source BEFORE installing, so
+    # fresh installs resolve against current manifests. Without an explicit
+    # update pass, plugins stay PINNED at their first-installed version:
+    # `claude plugin install` is a no-op on an existing install, and the
+    # per-marketplace autoUpdate setting is unset by default.
+    run claude plugin marketplace update
+    # Install + enable + update each enabled plugin that has a claude.plugin.
     while IFS= read -r plugin; do
         { [ -z "$plugin" ] || [ "$plugin" = "null" ]; } && continue
         run claude plugin install "$plugin"
         enable_claude_plugin "$plugin"
+        # Converge to latest (no-op when current; a restart picks up changes).
+        run claude plugin update "$plugin"
     done < <(yq '.plugins[] | select(.enabled == true) | select(.claude.plugin != null) | .claude.plugin' "$MANIFEST")
 }
 


### PR DESCRIPTION
## Summary

Answer to "do we get the latest updates, or are they pinned?": **pinned, forever** — `claude plugin install` is a no-op on an already-installed plugin, and the per-marketplace `autoUpdate` setting is unset by default. Every plugin sat at its first-installed version.

### Fix
`sync-plugins.sh` now converges to latest on every run (i.e., every `install.sh`):
1. `claude plugin marketplace update` — refreshes all marketplace catalogs from source before installing, so fresh installs also resolve current manifests
2. `claude plugin update <plugin>` per enabled plugin — no-op when current; "restart to apply" when refreshed

Ensure-only semantics preserved: still installs/enables/updates, never removes. Header comment, `ai/plugins.yaml`, and `docs/ai-plugins.md` wording updated to match.

### Verification
- shellcheck clean; `--dry-run` shows the new pass
- Real run performed: refreshed four stale plugins (`github`, `code-review`, `skill-creator`, `pr-review-toolkit`); `superpowers` and `claude-md-management` already current

### Not affected
The `claude` CLI itself was never pinned — its built-in auto-updater tracks the latest channel (2.1.224 → 2.1.226 overnight, matching npm's latest) and `claude_install.sh` installs unpinned as backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg1823QX3G1P7NpEtkGMPZ