### PR TITLE
ci: revive the dead type=gha build cache + build sdk binaries in the config layer

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -277,10 +277,48 @@ jobs:
         # docker-container driver is required for the type=gha layer cache below.
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      - name: Expose GitHub Actions runtime credentials (for the type=gha build cache)
+        # The `type=gha` cache backend authenticates with the per-job runtime
+        # credentials. GitHub mints those automatically, but only injects them
+        # into `docker/build-push-action` — NOT into a plain
+        # `run: docker buildx build` like our `make build`. Without this step the
+        # cache silently no-ops: buildx neither imports nor exports, prints no
+        # error, and the build still succeeds — which is exactly how #217 shipped
+        # a dead cache while CI stayed green. This action re-exports the runtime
+        # env into $GITHUB_ENV so the following steps can see it.
+        #
+        # NOTE: these credentials are EPHEMERAL — minted per job, expiring with
+        # the job. There is no secret to create, store, or rotate. Runbook + the
+        # rejected PAT-backed alternative: docs/ci-build-cache.md
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
+
+      - name: Assert the build cache backend is live (fail hard)
+        # A silently-disabled cache is a slow, invisible regression, so make its
+        # absence LOUD and FATAL here rather than letting the build "succeed"
+        # uncached. If this fails, the runtime step above did not run or GitHub
+        # renamed the variables — see docs/ci-build-cache.md.
+        run: |
+          missing=""
+          [ -n "${ACTIONS_RUNTIME_TOKEN:-}" ] || missing="$missing ACTIONS_RUNTIME_TOKEN"
+          [ -n "${ACTIONS_RESULTS_URL:-}" ] || missing="$missing ACTIONS_RESULTS_URL"
+          if [ -n "$missing" ]; then
+            echo "::error::BUILD CACHE BROKEN: missing runtime env:$missing — see docs/ci-build-cache.md"
+            exit 1
+          fi
+          echo "Build cache backend reachable (runtime credentials present)."
+
       - name: Build the Docker image
         # type=gha persists the two-phase Dockerfile's layers across runs: a PR
         # that doesn't touch opt/ or sdk/ or install.sh reuses the cached deps
         # layer and skips the expensive toolchain install.
+        #
+        # No `ignore-error=true` here on purpose: buildx defaults it to false, so
+        # once the credentials ARE present (guaranteed by the preflight above) a
+        # cache export failure is fatal via the exit code. Credentials-absent is
+        # the only mode that degrades silently, and the preflight covers it — so
+        # those two checks together are sufficient. Deliberately NOT grepping the
+        # progress output for "exporting cache": that text varies with
+        # --progress mode, TTY, and BuildKit version. See docs/ci-build-cache.md.
         run: make build BUILD_CACHE="--cache-from=type=gha --cache-to=type=gha,mode=max"
 
       - name: Run Integration Tests

--- a/docker/AGENTS.md
+++ b/docker/AGENTS.md
@@ -42,6 +42,25 @@ it into the cached deps layer so later edits stop taking effect per commit (a
 correctness bug). `--phase all` (a normal `./install.sh`) applies no overrides,
 so real machines are unaffected.
 
+> **A key in NEITHER list runs in BOTH phases** — the failure mode that shipped
+> in #217. The `install.sdk.*` keys were in neither, so every Go binary built
+> twice: once in the cached deps layer (where it got baked in and stamped
+> `Commit: none`, because that layer's partial `COPY` has no `.git`) and again in
+> config, where it silently degraded to `WARNING: 'go' not found` — `go` is on
+> `PATH` only in the layer where goenv ran, and `PATH` does not survive across
+> `RUN` layers. CI stayed green throughout, because the deps-layer binaries
+> existed and `gss version` worked.
+>
+> Two safeguards now exist: `ensure_go_on_path()` re-activates an
+> already-installed goenv in any phase (a no-op when `go` is already present), and
+> `install.sh` **exits non-zero** when a container phase (`deps`/`config`) still
+> has no `go`, instead of letting the sdk builds skip with a warning.
+
+**Go binaries belong in `--phase config`, never the base image.** They are
+repo-content builds: they need the full `COPY` (including `.git`, for the version
+stamp) and must rebuild per commit. Building them in the base image or the deps
+layer ships stale, mis-stamped binaries.
+
 **Changing `Dockerfile.base` in a PR? CI detects it automatically.** Because the
 base publishes from main only, the Build job checks the PR's changed files and
 **builds the base locally** (instead of pulling the stale published one) when a

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,22 @@ WORKDIR /home/$USERNAME
 COPY --chown=$USERNAME:$USERNAME opt git/dotfiles/opt
 COPY --chown=$USERNAME:$USERNAME sdk git/dotfiles/sdk
 COPY --chown=$USERNAME:$USERNAME install.sh Makefile git/dotfiles/
+
+# goenv derives GOPATH as $HOME/go/<version>, so $HOME/go must be writable by the
+# build user. BuildKit creates any MISSING PARENT of a mount target as root, and
+# the cache mount below targets $HOME/go/pkg/mod — so without this, `agent` cannot
+# mkdir $HOME/go/<version> and every `go build` dies with
+#   go: could not create module cache: mkdir /home/agent/go/<ver>: permission denied
+# Most sdk build.sh scripts treat that as non-fatal (warn and skip), so it stayed
+# invisible until the sdk builds actually began running in the config layer.
+RUN mkdir -p /home/$USERNAME/go && chown $USERNAME:$USERNAME /home/$USERNAME/go
+
+# Pin the Go caches to the exact mount targets. Left to itself, goenv's VERSIONED
+# GOPATH puts GOMODCACHE at $HOME/go/<version>/pkg/mod, which never matches the
+# mount at $HOME/go/pkg/mod — so the module-cache mount was caching nothing.
+ENV GOMODCACHE=/home/$USERNAME/go/pkg/mod
+ENV GOCACHE=/home/$USERNAME/.cache/go-build
+
 USER $USERNAME
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=1000,gid=1000 \
     --mount=type=cache,target=/home/${USERNAME}/go/pkg/mod,uid=1000,gid=1000 \

--- a/docs/ci-build-cache.md
+++ b/docs/ci-build-cache.md
@@ -1,0 +1,176 @@
+# CI build cache — operations runbook
+
+How the Docker layer cache in **Docker Image CI** (`.github/workflows/docker-image.yml`)
+is authenticated, how to verify it, and what to do when it breaks.
+
+**TL;DR — there is no secret to configure.** The cache authenticates with
+credentials GitHub mints automatically for every job. Nothing to create, store,
+rotate, or renew. If you came here looking for "where do I set
+`ACTIONS_RUNTIME_TOKEN`", the answer is: **you don't** — you expose it, and the
+workflow already does. Read [§1](#1-how-it-works) then
+[§4](#4-when-ci-fails-hard-on-the-cache).
+
+---
+
+## 1. How it works
+
+PR #217 split `docker/Dockerfile` into a cached **deps** layer and a per-commit
+**config** layer, and asked buildx to persist those layers between runs with
+`--cache-to=type=gha`. That backend needs two environment values:
+
+| Variable | Meaning | Where it comes from |
+|---|---|---|
+| `ACTIONS_RUNTIME_TOKEN` | Auth token for the Actions cache service | Minted **per job** by GitHub. Ephemeral — expires with the job. |
+| `ACTIONS_RESULTS_URL` | Endpoint of the **v2** cache service | Set by the runner. |
+
+> The older `ACTIONS_CACHE_URL` addressed the **v1** cache service, which GitHub
+> shut down on **2025-04-15**. Only the URL variable changed in that migration —
+> the token variable has always been `ACTIONS_RUNTIME_TOKEN`.
+
+**The catch that broke #217:** GitHub injects these into
+`docker/build-push-action` automatically, but **not** into a plain
+`run: docker buildx build` step — which is what `make build` is. Docker's own
+docs say so: *"If you invoke the `docker buildx` command manually from an inline
+step, then the variables must be manually exposed."*
+
+So the workflow exposes them explicitly:
+
+```yaml
+- name: Expose GitHub Actions runtime credentials (for the type=gha build cache)
+  uses: crazy-max/ghaction-github-runtime@<sha>  # v4.0.0
+```
+
+That action re-exports every `ACTIONS_*` variable the runner holds into
+`$GITHUB_ENV` (it is a wildcard, not a fixed list), after which `make build`
+inherits them.
+
+### Why this failure was invisible
+
+With the credentials **absent**, buildx does not error — it skips the backend
+entirely. Verified on the #217 post-merge run
+([31332375184](https://github.com/sfc-gh-eraigosa/dotfiles/actions/runs/31332375184)):
+zero `exporting cache` / `importing cache` stages, no warning, no 401, and the
+job still went **green** in 7m33s while rebuilding everything from scratch.
+
+That is the whole reason the preflight in §2 exists: a dead cache costs minutes
+per run and reports nothing.
+
+---
+
+## 2. The guardrails (why CI fails hard)
+
+Two checks, in order:
+
+1. **Preflight — `Assert the build cache backend is live`.** Runs *before* the
+   build and fails the job if `ACTIONS_RUNTIME_TOKEN` or `ACTIONS_RESULTS_URL`
+   is empty. This is the credentials-absent case — the only mode that degrades
+   silently.
+2. **Exit code.** buildx defaults `ignore-error=false` for `cache-to`, so once
+   the credentials are present, a cache *export* failure (bad token, service
+   outage, 401) already fails the step on its own. We deliberately do **not**
+   pass `ignore-error=true`.
+
+Together these cover both modes. We intentionally do **not** grep the build
+output for `exporting cache`: that string varies with `--progress` mode, TTY
+presence, and BuildKit version, so it is a false-failure generator.
+
+---
+
+## 3. Verify the cache is working
+
+**From a run's logs** — a warm build shows import and export stages:
+
+```
+importing cache manifest from gha:...
+=> CACHED [stage-0 6/10] RUN ... install.sh --phase deps
+exporting cache to GitHub Actions Cache
+```
+
+The `CACHED` on the `--phase deps` step is the signal that matters: a cold build
+runs that step for ~2 minutes, a warm one skips it.
+
+**List the stored entries:**
+
+```bash
+gh api repos/sfc-gh-eraigosa/dotfiles/actions/caches --jq '.actions_caches[] | "\(.key)\t\(.size_in_bytes)"'
+```
+
+**Reproduce locally** (no GHA cache; uses the local buildx cache instead):
+
+```bash
+make build                       # BUILD_CACHE is empty by default
+```
+
+---
+
+## 4. When CI fails hard on the cache
+
+### `BUILD CACHE BROKEN: missing runtime env: ACTIONS_RUNTIME_TOKEN`
+
+The preflight fired. In order of likelihood:
+
+1. **The expose step was removed or reordered.** It must sit *after*
+   `Set up Docker Buildx` and *before* the preflight. Restore it.
+2. **The pinned action failed to run** (e.g. a bad SHA after a Dependabot bump).
+   Check the step's own log.
+3. **GitHub renamed the variables again** (as in the v1→v2 migration). Confirm
+   against <https://docs.docker.com/build/cache/backends/gha/>, then update both
+   the preflight and the table in §1.
+
+There is **no secret to regenerate** — see §5 if you believe otherwise.
+
+### The build succeeds but is slow, and `--phase deps` never shows `CACHED`
+
+Expected in these cases, none of which are faults:
+
+- **First run on a new branch.** Nothing to import yet.
+- **The PR touches `opt/`, `sdk/`, `install.sh`, or `Makefile`.** These are the
+  deps layer's `COPY` inputs, so the layer correctly busts and re-validates.
+  This is by design (see `docker/AGENTS.md`).
+- **Cache evicted.** GitHub keeps **10 GB per repository**, evicting entries
+  untouched for **>7 days**, oldest-by-last-access first once over the cap.
+- **Branch scoping.** A run reads caches from its own branch, the default
+  branch, and (for PRs) its base branch — never from sibling or child branches.
+  A long-lived branch whose base has moved on will miss until it lands.
+
+---
+
+## 5. Why there is no Actions secret here
+
+A PAT-backed **registry** cache (`type=registry` against GHCR) was considered and
+**rejected**. It persists across branches and dodges the 10 GB cap, but it
+requires a personal access token stored as an Actions secret — which expires,
+silently disabling the cache until someone notices, and needs a documented
+rotation ritual plus an expiry probe in CI.
+
+The `type=gha` credentials are minted per job and cannot expire in storage
+because they are never stored. That removes the rotation problem outright rather
+than automating around it.
+
+**If a future change does introduce a PAT-backed cache**, it must ship with an
+expiry preflight that fails hard, e.g.:
+
+```yaml
+- name: Preflight — registry cache auth
+  run: |
+    code=$(curl -s -o /dev/null -w '%{http_code}' \
+      -H "Authorization: Bearer ${REGISTRY_PAT}" \
+      "https://ghcr.io/v2/${OWNER}/dotfiles-base/tags/list")
+    if [ "$code" = "401" ]; then
+      echo "::error::Cache PAT expired. Regenerate and run: gh secret set REGISTRY_PAT"
+      exit 1
+    fi
+```
+
+Do not add a cache credential without that gate.
+
+---
+
+## 6. Related
+
+- [`docker/AGENTS.md`](../docker/AGENTS.md) — the three-tier layering rule that
+  decides whether a step belongs in the base image, `--phase deps`, or
+  `--phase config`. **Read before adding any install step.**
+- [`.github/workflows/docker-image.yml`](../.github/workflows/docker-image.yml) —
+  the workflow itself.
+- Docker's backend reference — <https://docs.docker.com/build/cache/backends/gha/>

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ unset _ip_prev _ip_arg
 #   - CONFIG / SKILL / SYMLINK / any repo-content step -> _IP_CONFIG_FLAGS. Runs
 #     in the per-commit config layer; omitting it BAKES the step into the cached
 #     deps layer, so later edits to it stop taking effect per commit (a bug).
-_IP_CONFIG_FLAGS="INSTALL_SHELL_PROFILES INSTALL_SHELL_DEFAULT_ZSH INSTALL_AI_SKILLS INSTALL_AI_ANTIGRAVITY INSTALL_AI_CLAUDE INSTALL_TOOLS_GIT_ALIASES"
+_IP_CONFIG_FLAGS="INSTALL_SHELL_PROFILES INSTALL_SHELL_DEFAULT_ZSH INSTALL_AI_SKILLS INSTALL_AI_ANTIGRAVITY INSTALL_AI_CLAUDE INSTALL_TOOLS_GIT_ALIASES INSTALL_SDK_GSS INSTALL_SDK_TMUX_MGR INSTALL_SDK_WOL INSTALL_SDK_GSL INSTALL_SDK_GFF"
 _IP_DEPS_FLAGS="INSTALL_PKG_COMMON_CORE INSTALL_PKG_BREWFILE INSTALL_TOOLS_SOPS INSTALL_TOOLS_YQ INSTALL_TOOLS_K8S INSTALL_TOOLS_SNOWFLAKE INSTALL_TOOLS_DOCKER INSTALL_RUNTIME_GOENV INSTALL_RUNTIME_PYENV INSTALL_RUNTIME_RBENV INSTALL_RUNTIME_NVM"
 apply_install_phase() {
   case "$INSTALL_PHASE" in
@@ -417,6 +417,49 @@ if command -v goenv &> /dev/null; then
   fi
 fi
 else gff_skip_msg install.runtime.goenv; fi
+
+# --- Go PATH activation (phase-independent) --------------------------------
+# goenv INSTALLATION is a deps-phase step (repo-independent → cached layer), but
+# PATH is NOT inherited across Docker RUN layers. So in the `config` layer goenv
+# is present on disk while `go` is absent from PATH, and every later Go build —
+# the gff bootstrap just below and all sdk/*/build.sh — degrades to
+# "WARNING: 'go' not found" and skips. Post-#217 that was invisible: the sdk
+# builds also ran in the deps layer, so the image still shipped binaries, just
+# ones baked into the cached layer and stamped `Commit: none` (that layer's
+# partial COPY carries no .git). This re-activates an ALREADY-INSTALLED goenv;
+# it installs nothing and touches no network. It is a strict no-op whenever `go`
+# is already on PATH (the real-machine / `--phase all` case), so behavior there
+# is unchanged.
+ensure_go_on_path() {
+  if command -v go >/dev/null 2>&1; then
+    return 0
+  fi
+  [ -d "${HOME}/.goenv" ] && export PATH="${HOME}/.goenv/bin:${PATH}"
+  command -v goenv >/dev/null 2>&1 || return 0
+  # Same bash-safe init + PATH-clobber guard as the goenv section above; see
+  # docs/mbo/specs/shell-portability.md for why `- bash` is passed explicitly.
+  __goenv_path_safe="${PATH}"
+  eval "$(goenv init - bash)"
+  case ":${PATH}:" in
+    *":/usr/bin:"*) : ;;                          # system PATH survived
+    *) PATH="${PATH}:${__goenv_path_safe}" ;;     # init clobbered PATH; restore
+  esac
+  export PATH
+  unset __goenv_path_safe
+}
+ensure_go_on_path
+# FAIL HARD in a container build. On a real machine (`--phase all`) a missing Go
+# is tolerable — the sdk build scripts warn and skip, and the user may simply not
+# want Go. Inside the two-phase Docker build it is a BUG: the config layer would
+# silently ship whatever binaries the cached deps layer happened to bake in
+# (stamped `Commit: none`), which is exactly how #217 regressed unnoticed while
+# CI stayed green. Surface it as a build failure instead of a WARNING.
+if [ "$INSTALL_PHASE" != "all" ] && ! command -v go >/dev/null 2>&1; then
+  echo "ERROR: install.sh --phase ${INSTALL_PHASE}: no 'go' on PATH after goenv activation." >&2
+  echo "       The sdk/*/build.sh steps would silently skip and the image would ship" >&2
+  echo "       stale binaries. Check the goenv deps layer and ensure_go_on_path()." >&2
+  exit 1
+fi
 
 # build gff first so every later step can be feature-flag gated (fail-open:
 # if the build fails or gff is absent, all steps run — flags only ever skip).


### PR DESCRIPTION
Follow-up to #217.

## What

Three defects, each of which left CI **green** while silently disabling the thing it was supposed to do. The third was found *by* fixing the second.

### 1. The layer cache was completely inert

`--cache-to=type=gha` authenticates with the per-job Actions runtime credentials. GitHub injects those into `docker/build-push-action`, but **not** into a plain `run: docker buildx build` — which is exactly what `make build` is. Docker's docs: *"If you invoke the `docker buildx` command manually from an inline step, then the variables must be manually exposed."*

With them absent buildx does not error — it skips the backend. Verified on the #217 post-merge run [31332375184](https://github.com/sfc-gh-eraigosa/dotfiles/actions/runs/31332375184): **zero** `importing cache` / `exporting cache` stages, no warning, no 401, green in 7m33s having rebuilt everything.

**Fix:** expose the credentials via a SHA-pinned `crazy-max/ghaction-github-runtime`, plus a preflight that **fails hard** when they are missing.

### 2. The sdk Go builds ran in BOTH phases

The `install.sdk.*` keys were in *neither* `_IP_` list — and a key in neither list is overridden by neither phase, so it runs in both:

- **deps layer:** built the binaries and baked them into the cached layer, stamped `Commit: none` (that layer's partial `COPY` carries no `.git`).
- **config layer:** `WARNING: 'go' not found; skipping gss build` — `PATH` does not survive across `RUN` layers.

CI passed because the deps-layer binaries existed and `gss version` worked.

**Fix:** move the sdk keys to `_IP_CONFIG_FLAGS` so Go binaries build **once, in the per-commit config layer, off the full repo**. Add `ensure_go_on_path()` to re-activate an already-installed goenv in any phase.

### 3. `$HOME/go` was root-owned, so every Go build failed (found by fixing #2)

With the sdk builds finally running in the config layer, all of them failed:

```
go: could not create module cache: mkdir /home/agent/go/1.26.5: permission denied
```

goenv derives `GOPATH=$HOME/go/<version>`, but BuildKit creates any **missing parent of a mount target** as root — and #217's cache mount targets `$HOME/go/pkg/mod`. Only `gsl` surfaced it as a failure (strict seam-gate); `gff`, `gss`, `tmux-mgr` and `wol` warn and skip, which is why it stayed invisible.

**Fix:** `mkdir -p $HOME/go` + `chown` before the `USER` switch, and set `GOMODCACHE`/`GOCACHE` explicitly to the mount targets — goenv's versioned GOPATH put `GOMODCACHE` at `$HOME/go/<version>/pkg/mod`, which **never matched** the mount, so that mount was caching nothing either.

## Why

A silently-disabled cache is the worst failure mode available: it costs minutes on every run and reports nothing. Every change here converts "silently slow or wrong" into "loudly broken".

## Impact

- `--phase all` (a normal `./install.sh` on a real machine) is **unchanged**: `ensure_go_on_path()` is a strict no-op when `go` is already on `PATH`, and the new hard-fail is gated on `INSTALL_PHASE != all`.
- Missing `go` inside a container phase is now `exit 1` instead of a warning.
- Go binaries now carry a real commit stamp, and the module-cache mount is effective for the first time.
- A PR touching `opt/` / `sdk/` / `install.sh` / `Makefile` still correctly busts the deps layer — by design.

### On `ACTIONS_RUNTIME_TOKEN` — there is deliberately no secret to manage

These credentials are **minted per job and expire with the job**, so an "expired secret" state cannot exist; nothing to create, store, or rotate. [`docs/ci-build-cache.md`](docs/ci-build-cache.md) is the operations runbook: how it authenticates, how to verify it, what to do when the gate fires, and §5 records the PAT-backed registry-cache alternative as **rejected** — with the expiry-probe any future credentialed cache MUST ship so CI fails hard rather than degrading.

`docker/AGENTS.md` records the "key in neither list runs in both phases" trap.

## Testing

- `bash -n`, `shellcheck -S warning`, `actionlint`, YAML parse — clean
- `make lint-portability` — Tier 1 = 0, Tier 2 = 0
- `make lint-shell` (strict, zero backlog) — exit 0
- `rc_test.sh` — PASS=8 FAIL=0
- `docker buildx build --call=check` — clean (only the expected arm64-host/amd64-base platform warning)
- Phase-gating functional test across all three phases: `all` runs everything; `deps` skips the sdk builds; `config` runs them and skips the toolchain installs
- goenv activation test — resolves the pinned Go 1.26.3 with the system `PATH` guard intact

The first CI run on this PR ([31345231877](https://github.com/sfc-gh-eraigosa/dotfiles/actions/runs/31345231877)) confirmed both guardrails behaving correctly: the credential preflight **passed** (cache now authenticated) and the build **failed loudly** on defect 3 instead of silently skipping — which is the entire point. Commit 2 fixes that.

**Reviewer check:** confirm `importing cache` / `exporting cache` stages now appear, and that a second run reports `CACHED` on the `--phase deps` step. This dev host is `aarch64` and cannot build the amd64 image, so that verification only exists in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQYeP4hT1VUfeS4S2TKaSb