### PR TITLE
feat(windows): unattended weekly security audit behind opt-in gff flag

### DIFF
--- a/.github/gff/features.yaml
+++ b/.github/gff/features.yaml
@@ -144,6 +144,9 @@ sets:
       - path: install.windows.portproxy
         description: Gates the standalone refresh-wsl-portproxy.ps1 script on the Windows side.
         boolDefault: true
+      - path: install.windows.security-audit
+        description: Opt-in (fail-closed) unattended weekly security audit - setup-security-audit.ps1 registers the ClaudeSecurityAuditCollector task and seeds the Claude analysis task. Enable with gff set install.windows.security-audit true.
+        boolDefault: false
 
   # research-rubric.* — tunable weights for the research-evaluation skill's rubric.
   # Smart PUBLIC defaults live here; anyone tunes them on demand via the gff user

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -19,4 +19,5 @@ Reference guides and the repo's objective-driven design system.
 - [`claude-code-support.md`](./claude-code-support.md) — supported Claude Code version range, cross-version compatibility rules, and the upgrade-audit runbook.
 - [`gitignore-allowlist.md`](./gitignore-allowlist.md) — the `*`-default `.gitignore` allowlist: opted-in paths, verification recipe, worked examples.
 - [`install-windows.md`](./install-windows.md) — `install.sh` Windows/WSL interactivity flow, `[y]/[s]` semantics, gff overrides.
+- [`security-audit.md`](./security-audit.md) — opt-in unattended weekly security audit: Windows collector task + Claude analysis task, gff-gated **fail-closed**.
 - [`mergify.md`](./mergify.md) — the merge model: Mergify queue, solo-maintainer rules and rationale, external-contributor review gate, AI-work traceability, break-glass.

--- a/docs/mbo/index.md
+++ b/docs/mbo/index.md
@@ -34,6 +34,7 @@ done` (also `parked`, `superseded`).
 | `gff` | [design](./designs/gff.md) | [spec](./specs/gff.md) | [plan](./plans/gff.md) | [#180](https://github.com/sfc-gh-eraigosa/dotfiles/issues/180) | [#181](https://github.com/sfc-gh-eraigosa/dotfiles/pull/181) · p1-engine [#182](https://github.com/sfc-gh-eraigosa/dotfiles/pull/182) · p2 [#184](https://github.com/sfc-gh-eraigosa/dotfiles/pull/184) · p3+p4 [#187](https://github.com/sfc-gh-eraigosa/dotfiles/pull/187) · vd-demo [#188](https://github.com/sfc-gh-eraigosa/dotfiles/pull/188) · WSLENV fix [#191](https://github.com/sfc-gh-eraigosa/dotfiles/pull/191) | done (all leaves merged; P2-T5 real-install evidence captured 2026-07-26; next-iteration backlog in plans/gff/IMPLEMENTATION.md §8.2) |
 | `fleet` | [design](./designs/fleet.md) | [spec](./specs/fleet.md) | [plan](./plans/fleet.md) + [trio](./plans/fleet/) | [#222](https://github.com/sfc-gh-eraigosa/dotfiles/issues/222) | [#223](https://github.com/sfc-gh-eraigosa/dotfiles/pull/223) | planning |
 | `gff-install-flow` | — | [spec](./specs/gff-install-flow.md) | [plan](./plans/gff-install-flow.md) | — | planning [#193](https://github.com/sfc-gh-eraigosa/dotfiles/pull/193) (merged) · build [#194](https://github.com/sfc-gh-eraigosa/dotfiles/pull/194) (ready) | in-review (all 6 tasks done; 4-run owner matrix green incl. the elevated-log wispr SKIP; awaiting merge) |
+| `security-audit` | — | [spec](./specs/security-audit.md) | [plan](./plans/security-audit.md) | — | (this PR) | building |
 
 ## Merged / historical (pre-MBO — tracking columns best-effort)
 

--- a/docs/mbo/plans/security-audit.md
+++ b/docs/mbo/plans/security-audit.md
@@ -1,0 +1,37 @@
+# Unattended Weekly Security Audit — plan
+
+**Status:** building · **Slug:** `security-audit` · **Spec:** [../specs/security-audit.md](../specs/security-audit.md)
+
+Small feature: spec → plan, built in a single PR (no execution trio).
+
+## Tasks
+
+| # | Task | Files |
+| :-- | :-- | :-- |
+| T1 | Opt-in fail-closed gates: `gff_opt_in` (POSIX) + `Test-GffOptIn` (PS) | `opt/lib/gff.sh`, `opt/Desktop/Apps/scripts/lib/gff.ps1` |
+| T2 | Flag `install.windows.security-audit` (`boolDefault: false`) | `.github/gff/features.yaml` |
+| T3 | Read-only collector (5 sections, stable formats, history, Drive fallback copy) | `opt/Desktop/Apps/scripts/security-audit-collect.ps1` |
+| T4 | Installer: user-level daily task, collector install, SKILL.md seed-if-absent, `-Status`/`-Uninstall`/`-At` | `opt/Desktop/Apps/scripts/setup-security-audit.ps1` |
+| T5 | Claude analysis prompt template (bootstrap-baseline mode, data-source fallback chain, no-computer-use rule) | `opt/Desktop/Apps/scripts/security-audit-skill.template.md` |
+| T6 | install.sh wiring at the deferred Windows phase: extract `export_gff_wslenv`, add `run_security_audit_setup` (gated, rc-captured, logged) | `opt/bin/install_windows.sh` |
+| T7 | Docs: user guide, scripts inventory, docs index, MBO registration | `docs/security-audit.md`, `opt/Desktop/Apps/scripts/AGENTS.md`, `docs/AGENTS.md`, `docs/mbo/*` |
+
+## Validation
+
+Run in the build sandbox (Linux — no Windows/PowerShell available):
+
+- `bash -n` + dash `sh -n` on every touched shell file — pass.
+- `opt/scripts/system/shell-portability-scan.sh --strict` (whole repo) — Tier 1: 0, Tier 2: 0.
+- `.github/gff/features.yaml` YAML parse + flag-shape check — pass.
+- markdownlint on added/changed markdown — run locally/CI (`make lint-markdown`);
+  shellcheck via `make lint-shell` in CI (neither tool was available in the sandbox).
+
+Requires a Windows host (the enabling machine, at flag-flip time):
+
+- `setup-security-audit.ps1` end-to-end: register → first report → seed → `-Status`.
+- One unattended Claude `weekly-security-audit` run reading the report (spec AC5).
+
+## Rollback
+
+`setup-security-audit.ps1 -Uninstall`, `gff unset install.windows.security-audit`
+(or `gff set … false`). Data/baseline folders are kept and documented.

--- a/docs/mbo/plans/security-audit.md
+++ b/docs/mbo/plans/security-audit.md
@@ -16,6 +16,9 @@ Small feature: spec → plan, built in a single PR (no execution trio).
 | T6 | install.sh wiring at the deferred Windows phase: extract `export_gff_wslenv`, add `run_security_audit_setup` (gated, rc-captured, logged) | `opt/bin/install_windows.sh` |
 | T7 | Docs: user guide, scripts inventory, docs index, MBO registration | `docs/security-audit.md`, `opt/Desktop/Apps/scripts/AGENTS.md`, `docs/AGENTS.md`, `docs/mbo/*` |
 | T8 | Tests for the fail-closed gate: `gff_opt_in` truth table + the `gff_on`/`gff_opt_in` inversion assertion, green under bash **and** dash | `opt/lib/gff_test.sh` |
+| T9 | **v2 collector expansion**: ~40 ATT&CK-mapped non-admin lenses (persistence/defense-evasion/network/process/accounts/posture/event-logs), STABLE-vs-VOLATILE fencing, version normalization, admin-gap markers, 4104 self-exclusion — designed via an adversarially-reviewed lens-catalog workflow and validated by a live read-only run on a real Win11 host | `opt/Desktop/Apps/scripts/security-audit-collect.ps1` |
+| T10 | Analysis prompt rewrite for the v2 sections: CRITICAL/WARN/INFO triage, STABLE/VOLATILE + event-set handling, known-benign rules, admin-gap handling | `opt/Desktop/Apps/scripts/security-audit-skill.template.md` |
+| T11 | Collector test driver: static contract checks (CI) + live read-only run assertion (WSL/Windows) | `opt/scripts/system/security-audit-collect_test.sh` |
 
 ## Validation
 
@@ -23,13 +26,19 @@ Run in the build sandbox (Linux — no Windows/PowerShell available):
 
 - `bash -n` + dash `sh -n` on every touched shell file — pass.
 - `bash opt/lib/gff_test.sh` **and** `sh opt/lib/gff_test.sh` — 20/20 pass.
+- `bash opt/scripts/system/security-audit-collect_test.sh` — 35/35 pass (static + live).
 - `opt/scripts/system/shell-portability-scan.sh --strict` (whole repo) — Tier 1: 0, Tier 2: 0.
 - `.github/gff/features.yaml` YAML parse + flag-shape check — pass; `gff export --shell`
   emits `GFF_INSTALL_WINDOWS_SECURITY_AUDIT=false` by default (fail-closed confirmed).
 - `make lint-shell` (shellcheck) and `make lint-markdown` (markdownlint-cli2) — pass.
 
-**Not verifiable in the Linux sandbox** (no PowerShell): the four `.ps1` files are
-review-verified only. Spec AC1–AC5 remain the Windows-host gate.
+**v2 collector validated on a real Windows 11 host** via WSL PowerShell interop: the
+collector was run read-only (`-StdOut`, no writes) against the live machine, iterated until
+every one of ~30 emitted sections is clean (no `COLLECTION ERROR`, no empty section, honest
+`ADMIN-REQUIRED` gaps only), and confirmed to surface real signals (a portproxy pivot, a
+service install, CodeIntegrity unsigned-load events) with false positives suppressed. The
+`setup-security-audit.ps1` end-to-end task registration (AC1–AC5) still requires a Windows
+host at flag-flip time; the collector output contract itself is now machine-verified.
 
 Requires a Windows host (the enabling machine, at flag-flip time):
 

--- a/docs/mbo/plans/security-audit.md
+++ b/docs/mbo/plans/security-audit.md
@@ -15,16 +15,21 @@ Small feature: spec → plan, built in a single PR (no execution trio).
 | T5 | Claude analysis prompt template (bootstrap-baseline mode, data-source fallback chain, no-computer-use rule) | `opt/Desktop/Apps/scripts/security-audit-skill.template.md` |
 | T6 | install.sh wiring at the deferred Windows phase: extract `export_gff_wslenv`, add `run_security_audit_setup` (gated, rc-captured, logged) | `opt/bin/install_windows.sh` |
 | T7 | Docs: user guide, scripts inventory, docs index, MBO registration | `docs/security-audit.md`, `opt/Desktop/Apps/scripts/AGENTS.md`, `docs/AGENTS.md`, `docs/mbo/*` |
+| T8 | Tests for the fail-closed gate: `gff_opt_in` truth table + the `gff_on`/`gff_opt_in` inversion assertion, green under bash **and** dash | `opt/lib/gff_test.sh` |
 
 ## Validation
 
 Run in the build sandbox (Linux — no Windows/PowerShell available):
 
 - `bash -n` + dash `sh -n` on every touched shell file — pass.
+- `bash opt/lib/gff_test.sh` **and** `sh opt/lib/gff_test.sh` — 20/20 pass.
 - `opt/scripts/system/shell-portability-scan.sh --strict` (whole repo) — Tier 1: 0, Tier 2: 0.
-- `.github/gff/features.yaml` YAML parse + flag-shape check — pass.
-- markdownlint on added/changed markdown — run locally/CI (`make lint-markdown`);
-  shellcheck via `make lint-shell` in CI (neither tool was available in the sandbox).
+- `.github/gff/features.yaml` YAML parse + flag-shape check — pass; `gff export --shell`
+  emits `GFF_INSTALL_WINDOWS_SECURITY_AUDIT=false` by default (fail-closed confirmed).
+- `make lint-shell` (shellcheck) and `make lint-markdown` (markdownlint-cli2) — pass.
+
+**Not verifiable in the Linux sandbox** (no PowerShell): the four `.ps1` files are
+review-verified only. Spec AC1–AC5 remain the Windows-host gate.
 
 Requires a Windows host (the enabling machine, at flag-flip time):
 

--- a/docs/mbo/specs/security-audit.md
+++ b/docs/mbo/specs/security-audit.md
@@ -14,16 +14,34 @@ Result: a "scheduled" audit that stalls until the user replies and pastes.
 
 - **R1 — no human in the loop**: a weekly audit run completes with zero
   approvals, zero pastes, zero computer-use calls.
-- **R2 — same lenses**: collection preserves the five audit sections and their
-  format so the existing baseline comparison carries over. Two deliberate
-  filter refinements (safe while the baseline is still in bootstrap mode, and
-  strictly additive — they only ever surface *more*): section 1 no longer
-  excludes `C:\Windows\Temp\` (user-writable, a standard persistence location),
-  and services with a null `PathName` stay visible.
-- **R2a — no silent blindness**: every section resolves to items, `(none)`, or
-  `!! COLLECTION ERROR: <msg>`. A lens that fails must be reported as
-  unverified; the analysis may not call the host clean while one is present.
-  (Previously a failed lens wrote an empty section that read as "clean".)
+- **R2 — comprehensive anomaly lenses (v2)**: collection covers ~40 read-only,
+  non-admin lenses across persistence (registry ASEPs, services, tasks, WMI
+  subscriptions), defense evasion (Defender health/exclusions/events, log
+  integrity), network exposure + C2 (firewall, listeners, portproxy, outbound,
+  hosts/DNS/proxy), process anomaly (user-writable paths, masquerade), accounts
+  & privilege, patch/integrity posture, and 7-day event-log signals (7045/7040/
+  4104/CodeIntegrity). Each lens is ATT&CK-mapped and grounded in what a non-admin
+  user can actually read (verified by live host probing). Section 1 does not
+  exclude `C:\Windows\Temp\`; null-`PathName` services stay visible.
+- **R2a — no silent blindness**: every section resolves to items, `(none)`,
+  `!! COLLECTION ERROR: <msg>`, or `## ADMIN-REQUIRED (<Type>)`. A lens that
+  fails is reported as unverified; a lens that needs elevation renders a
+  byte-stable admin-gap marker (exception TYPE only). The analysis may not call
+  the host clean while any COLLECTION ERROR is present. (Previously a failed
+  lens wrote an empty section that read as "clean".)
+- **R2b — false-positive discipline**: version strings normalized to `X.X`;
+  `[USER-WRITABLE-PATH]` alarms only on unsigned images; scheduled-task
+  suspicion keys on the executable not incidental args; Defender 5007 churn
+  collapses to a count; servicing start-type flaps `[CHURN]`-tagged; 4104
+  self-excludes the collector's own script; `[STABLE]` vs `[VOLATILE]` blocks
+  separate strict-diff from triage-only surfaces. Validated by a live read-only
+  run against a real Windows 11 host (non-admin).
+- **R2c — non-admin coverage honesty**: the Security event log, Defender
+  exclusion contents, and Secure Boot state are admin-only; the collector
+  surfaces each as an explicit `## ADMIN-REQUIRED` gap, never a misleading
+  `(none)`, and documents how to light them up (Event Log Readers / elevation).
+- **R2d — detection only**: the collector never changes configuration (spec
+  scope is anomaly reporting for a weekly review, not remediation).
 - **R3 — opt-in, fail-closed**: gated by `install.windows.security-audit`
   (`boolDefault: false`); absent gff/flag ⇒ the step must NOT run. This
   inverts the repo's fail-open `gff_on` convention deliberately.

--- a/docs/mbo/specs/security-audit.md
+++ b/docs/mbo/specs/security-audit.md
@@ -15,7 +15,15 @@ Result: a "scheduled" audit that stalls until the user replies and pastes.
 - **R1 — no human in the loop**: a weekly audit run completes with zero
   approvals, zero pastes, zero computer-use calls.
 - **R2 — same lenses**: collection preserves the five audit sections and their
-  exact filters/format so the existing baseline comparison carries over.
+  format so the existing baseline comparison carries over. Two deliberate
+  filter refinements (safe while the baseline is still in bootstrap mode, and
+  strictly additive — they only ever surface *more*): section 1 no longer
+  excludes `C:\Windows\Temp\` (user-writable, a standard persistence location),
+  and services with a null `PathName` stay visible.
+- **R2a — no silent blindness**: every section resolves to items, `(none)`, or
+  `!! COLLECTION ERROR: <msg>`. A lens that fails must be reported as
+  unverified; the analysis may not call the host clean while one is present.
+  (Previously a failed lens wrote an empty section that read as "clean".)
 - **R3 — opt-in, fail-closed**: gated by `install.windows.security-audit`
   (`boolDefault: false`); absent gff/flag ⇒ the step must NOT run. This
   inverts the repo's fail-open `gff_on` convention deliberately.
@@ -51,3 +59,9 @@ Result: a "scheduled" audit that stalls until the user replies and pastes.
 5. A Claude `weekly-security-audit` run completes unattended by reading
    `latest-audit.txt` (verified on wenlock's Vivobook after enabling).
 6. `make lint-shell` / portability scan / markdownlint pass on the diff.
+7. `opt/lib/gff_test.sh` covers the `gff_opt_in` truth table (unset / `true` /
+   `false` / `TRUE` / `1` / `'true '` / empty), the key mangling, the
+   gff-absent-from-PATH case, and an explicit assertion that `gff_on` and
+   `gff_opt_in` disagree on an unset var — the inversion IS the feature, and a
+   refactor that unified them would pass every other case. Green under **both**
+   `bash` and `dash` (the F9 cross-shell gate).

--- a/docs/mbo/specs/security-audit.md
+++ b/docs/mbo/specs/security-audit.md
@@ -1,0 +1,53 @@
+# Unattended Weekly Security Audit — spec
+
+**Status:** building · **Slug:** `security-audit` · **Owner:** edward-raigosa
+
+## Problem
+
+The `weekly-security-audit` Claude scheduled task needed a human twice per run:
+computer-use approvals cannot happen in unattended runs (observed 2026-08-16:
+grants stored on the task did not carry into the run), and terminals are
+click-tier, so Claude cannot type or paste into PowerShell even when granted.
+Result: a "scheduled" audit that stalls until the user replies and pastes.
+
+## Requirements
+
+- **R1 — no human in the loop**: a weekly audit run completes with zero
+  approvals, zero pastes, zero computer-use calls.
+- **R2 — same lenses**: collection preserves the five audit sections and their
+  exact filters/format so the existing baseline comparison carries over.
+- **R3 — opt-in, fail-closed**: gated by `install.windows.security-audit`
+  (`boolDefault: false`); absent gff/flag ⇒ the step must NOT run. This
+  inverts the repo's fail-open `gff_on` convention deliberately.
+- **R4 — no admin**: per-user scheduled task; read-only queries only.
+- **R5 — baseline is state, not config**: the Claude SKILL.md (holding the
+  evolving baseline) is seeded only when absent, never overwritten.
+- **R6 — resilient handoff**: analysis reads the task-folder copy first, the
+  canonical `%USERPROFILE%\Claude\SecurityAudit\latest-audit.txt` second, an
+  optional Google Drive copy third; a broken pipeline is reported, not worked
+  around.
+- **R7 — laptop reality**: collection uses `StartWhenAvailable` +
+  battery-friendly settings; analysis tolerates ≤3-day-old data, flags older.
+- **R8 — portability**: no hardcoded usernames/paths; `$env:USERPROFILE` on
+  the Windows side, `${HOME}`/`wslpath` on the WSL side.
+
+## Non-goals
+
+- Elevated lenses (autoruns-style kernel/driver enumeration) — out of scope.
+- Scheduling the Claude-side task from the installer — app-managed; the doc
+  ships the one-line instruction instead.
+- Fleet distribution (see `fleet` objective) — this is single-host.
+
+## Acceptance criteria
+
+1. `install.sh` with the flag unset/false → `SKIP (gff: … opt-in …)` line; no
+   task, no files.
+2. `gff set install.windows.security-audit true && ./install.sh` → task
+   `ClaudeSecurityAuditCollector` registered (daily, user-level), first
+   report written, SKILL.md seeded when absent.
+3. Re-running the installer never modifies an existing SKILL.md.
+4. `setup-security-audit.ps1 -Status` reports task state + report freshness;
+   `-Uninstall` removes task+collector but keeps data and baseline.
+5. A Claude `weekly-security-audit` run completes unattended by reading
+   `latest-audit.txt` (verified on wenlock's Vivobook after enabling).
+6. `make lint-shell` / portability scan / markdownlint pass on the diff.

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -80,6 +80,18 @@ setup-security-audit.ps1 -Uninstall   # removes task + collector; keeps data + b
   only write outside `%USERPROFILE%\Claude` is an optional copy of the report
   into a local Google Drive sync folder (`My Drive`) when one exists, giving the
   analysis run a fallback read path via the Drive connector.
+- **A broken lens is never silence.** Each section resolves to one of three
+  states — items, `(none)` (ran, found nothing), or
+  `!! COLLECTION ERROR: <msg>` (the lens itself failed). The analysis prompt is
+  required to report an errored section as *unverified* and is forbidden from
+  calling the machine clean while one is present. Without this an unavailable
+  `Get-MpComputerStatus` produced an empty DEFENDER section that read exactly
+  like "Defender is fine".
+- **Section 1 deliberately does not exclude `C:\Windows\Temp\`.** The
+  non-Microsoft heuristic skips services under `\Windows\`, but that directory
+  is user-writable by default and is a standard persistence location, so
+  excluding it would blind the audit's highest-value lens. Services with a null
+  `PathName` also stay visible rather than being filtered away.
 - The collector task itself shows up in audit section 2 — the analysis prompt
   expects it (`ClaudeSecurityAuditCollector`).
 - `StartWhenAvailable` + battery-friendly settings mean a laptop asleep at 09:00

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -1,0 +1,90 @@
+# security-audit — unattended weekly Windows security audit (opt-in)
+
+A Claude scheduled task that audits the Windows host weekly used to require a
+human in the loop twice: unattended runs cannot approve computer-use access, and
+terminals are only ever granted at "click" tier, so Claude can never type or
+paste into PowerShell anyway. This feature removes the human from the loop by
+**decoupling collection from analysis**:
+
+```text
+Windows Task Scheduler                          Claude scheduled task (weekly)
+ClaudeSecurityAuditCollector (daily 09:00)      weekly-security-audit
+  security-audit-collect.ps1  ──────────────►     reads latest-audit.txt from its
+  read-only queries, writes:                      own task folder (uploads), diffs
+  %USERPROFILE%\Claude\SecurityAudit\             against the baseline embedded in
+    latest-audit.txt + history\                   its SKILL.md, reports anomalies —
+  %USERPROFILE%\Claude\Scheduled\                 no computer use, no approvals,
+    weekly-security-audit\latest-audit.txt        no user interaction
+```
+
+**Opt-in and fail-closed**: gated by gff flag `install.windows.security-audit`
+(`boolDefault: false`). Unlike the fail-open `gff_on` gates, this step uses
+`gff_opt_in` / `Test-GffOptIn` — it runs **only** when the flag resolves to
+exactly `true`, so it can never install itself by accident on a machine where
+gff (or the flag export) is missing.
+
+## Pieces
+
+| File | Role |
+| :-- | :-- |
+| `opt/Desktop/Apps/scripts/setup-security-audit.ps1` | Installer: registers the collector task, seeds the Claude task prompt. `-Status` / `-Uninstall` / `-At HH:mm` |
+| `opt/Desktop/Apps/scripts/security-audit-collect.ps1` | Read-only collector (services, scheduled tasks, startup commands, AppData/Temp processes, Defender) |
+| `opt/Desktop/Apps/scripts/security-audit-skill.template.md` | Claude analysis-task prompt template (bootstrap-baseline mode) |
+| `opt/lib/gff.sh` (`gff_opt_in`) + `lib/gff.ps1` (`Test-GffOptIn`) | Fail-closed opt-in gates |
+| `opt/bin/install_windows.sh` (`run_security_audit_setup`) | install.sh wiring — runs at the deferred Windows phase, after the Desktop deploy |
+
+## Enable
+
+```sh
+gff set install.windows.security-audit true
+./install.sh          # the setup runs in the deferred Windows phase (after the deploy)
+```
+
+Or run it standalone from PowerShell (manual run = explicit intent, no flag
+needed; no admin either — it is a per-user scheduled task):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File $env:USERPROFILE\Desktop\Apps\scripts\setup-security-audit.ps1
+```
+
+Note the Desktop may be OneDrive-redirected; the deploy step handles that, and
+the installer copies the collector to `%USERPROFILE%\Claude\SecurityAudit` so
+the scheduled task never executes from a OneDrive-dehydratable path.
+
+## One-time Claude-side step
+
+The installer seeds the analysis prompt at
+`%USERPROFILE%\Claude\Scheduled\weekly-security-audit\SKILL.md` **only if it does
+not already exist** — the audit baseline lives inside that file and evolves with
+each accepted change, so the installer must never clobber it. Registering the
+schedule itself is app-managed: open Claude and say
+"schedule the weekly-security-audit task for Saturdays at 10:00" (any time after
+the daily 09:00 collection works).
+
+On the first analysis run the task is in **bootstrap-baseline mode**: it
+summarizes the report, asks you to confirm anything unrecognized, then embeds
+the accepted baseline into its own SKILL.md.
+
+## Operations
+
+```powershell
+setup-security-audit.ps1 -Status      # task state, last/next run, report freshness
+setup-security-audit.ps1 -At 07:30    # reinstall with a different collection time
+setup-security-audit.ps1 -Uninstall   # removes task + collector; keeps data + baseline
+```
+
+## Security posture & caveats
+
+- The collector is **read-only** (CIM/WMI, `Get-ScheduledTask`, `Get-Process`,
+  `Get-MpComputerStatus`); it needs no admin and makes no network calls. The
+  only write outside `%USERPROFILE%\Claude` is an optional copy of the report
+  into a local Google Drive sync folder (`My Drive`) when one exists, giving the
+  analysis run a fallback read path via the Drive connector.
+- The collector task itself shows up in audit section 2 — the analysis prompt
+  expects it (`ClaudeSecurityAuditCollector`).
+- `StartWhenAvailable` + battery-friendly settings mean a laptop asleep at 09:00
+  collects on wake; the analysis task tolerates data up to 3 days old before
+  flagging staleness.
+- Claude scheduled runs only fire while the Claude app is open; a missed
+  Saturday run executes on next launch and reads whatever the latest collection
+  was — the timestamp line keeps this honest.

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -28,10 +28,33 @@ gff (or the flag export) is missing.
 | File | Role |
 | :-- | :-- |
 | `opt/Desktop/Apps/scripts/setup-security-audit.ps1` | Installer: registers the collector task, seeds the Claude task prompt. `-Status` / `-Uninstall` / `-At HH:mm` |
-| `opt/Desktop/Apps/scripts/security-audit-collect.ps1` | Read-only collector (services, scheduled tasks, startup commands, AppData/Temp processes, Defender) |
-| `opt/Desktop/Apps/scripts/security-audit-skill.template.md` | Claude analysis-task prompt template (bootstrap-baseline mode) |
+| `opt/Desktop/Apps/scripts/security-audit-collect.ps1` | Read-only collector — ~40 anomaly lenses (below). Params `-StdOut` / `-BaseDir` / `-Days` for ad-hoc/test runs |
+| `opt/Desktop/Apps/scripts/security-audit-skill.template.md` | Claude analysis-task prompt: per-section triage (CRITICAL/WARN/INFO), STABLE-vs-VOLATILE handling, known-benign rules, bootstrap-baseline mode |
+| `opt/scripts/system/security-audit-collect_test.sh` | Test driver — static contract checks (CI) + live read-only run assertion (WSL/Windows) |
 | `opt/lib/gff.sh` (`gff_opt_in`) + `lib/gff.ps1` (`Test-GffOptIn`) | Fail-closed opt-in gates |
 | `opt/bin/install_windows.sh` (`run_security_audit_setup`) | install.sh wiring — runs at the deferred Windows phase, after the Desktop deploy |
+
+## What the collector checks (non-admin, read-only, ~40 lenses)
+
+Each lens is grounded in what a non-admin user can actually read on Windows 11 (verified by
+live probing), mapped to MITRE ATT&CK, and tuned against false positives. Sections resolve to
+`<data>` / `(none)` / `!! COLLECTION ERROR` / `## ADMIN-REQUIRED` — a blocked lens is never
+silently empty. High-churn surfaces split into a `[STABLE]` (strict-diff) and `[VOLATILE]`
+(triage-only) block.
+
+| Group | Lenses (section ids) |
+| :-- | :-- |
+| **Persistence — registry ASEPs** | Run/RunOnce all hives (A1), high-signal Policies\Run + RunOnceEx (A2), Winlogon Shell/Userinit/Notify (A3), IFEO debuggers + AppInit_DLLs (A4), logon-script + `COR_PROFILER` .NET-injection + win.ini + `$PROFILE` + Active Setup (A6), UAC-bypass/file-handler hijacks (A7), COM hijack — user-writable/scriptlet HKCU CLSID (A5) |
+| **Persistence — execution** | non-MS auto-start services + signature + path hygiene (B1), non-MS scheduled tasks + hidden/suspicious-action (B2), Startup-folder items (B3), WMI event-subscription persistence (B4) |
+| **Defense evasion — Defender** | core status: RTP/tamper/behavior/cloud/sig-age (C1), exclusions (C2 — contents admin-only, gap surfaced honestly), detection events 1116/1117 (C3), security-relevant config-change 5001/5007 incl. exclusion-change (C4) |
+| **Defense evasion — log integrity** | log-cleared 104/1102 (D1), channel health with `<absent>` markers (D2) |
+| **Network — exposure** | firewall profiles (E1), TCP listeners well-known-strict/dynamic-volatile + signature (E2), non-default SMB shares (E3), portproxy pivot rules (E4), remote-access service state — RDP/SSH/VNC/TeamViewer/AnyDesk (E5) |
+| **Network — anomaly / C2** | outbound to public IPs, process-strict/endpoint-volatile (F1), hosts-file entries (F2), DNS servers physical-strict/virtual-volatile (F3), proxy/AutoConfigURL (F4) |
+| **Process & binary** | processes from user-writable paths + signature + parent (G1), critical-name masquerade off System32 (G2) |
+| **Accounts & privilege** | local users + pw flags (H1), privileged-group membership (H2), built-in account state + autologon (H3), hidden users (H4) |
+| **Patch & integrity posture** | patch staleness + WU services + WSUS-redirect (I1), UAC/SmartScreen/Secure-Boot (I2), CodeIntegrity unsigned-load events (I3) |
+| **Event-log signals (7d)** | 7045 service-install w/ XML extraction (J1), 7040 start-type-change churn-tagged (J2), 4104 suspicious PowerShell self-excluded (J3) |
+| **Coverage gap** | consolidated Security-log visibility gap — 4720/4624/1102 need admin (K) |
 
 ## Enable
 
@@ -62,8 +85,19 @@ schedule itself is app-managed: open Claude and say
 the daily 09:00 collection works).
 
 On the first analysis run the task is in **bootstrap-baseline mode**: it
-summarizes the report, asks you to confirm anything unrecognized, then embeds
-the accepted baseline into its own SKILL.md.
+summarizes the report, explicitly lists the higher-risk items (unsigned
+autostarts, Administrators members, WMI consumers, portproxy rules, new ASEP
+entries) for you to confirm before they become baseline — a guard against
+baselining an already-compromised host — then embeds the accepted baseline into
+its own SKILL.md.
+
+> **Operational linchpin:** the diff-vs-baseline model depends on the unattended
+> analysis run being able to **self-edit its own `SKILL.md`** (via the
+> scheduled-task update tool) to persist accepted state. If that write path is
+> not available in the runtime, every run stays in bootstrap mode and re-summarizes
+> the full inventory weekly. Verify the first run actually rewrites the baseline
+> section; if it can't, treat the weekly output as a fresh full inventory rather
+> than a diff.
 
 ## Operations
 
@@ -75,25 +109,43 @@ setup-security-audit.ps1 -Uninstall   # removes task + collector; keeps data + b
 
 ## Security posture & caveats
 
-- The collector is **read-only** (CIM/WMI, `Get-ScheduledTask`, `Get-Process`,
-  `Get-MpComputerStatus`); it needs no admin and makes no network calls. The
-  only write outside `%USERPROFILE%\Claude` is an optional copy of the report
-  into a local Google Drive sync folder (`My Drive`) when one exists, giving the
-  analysis run a fallback read path via the Drive connector.
-- **A broken lens is never silence.** Each section resolves to one of three
-  states — items, `(none)` (ran, found nothing), or
-  `!! COLLECTION ERROR: <msg>` (the lens itself failed). The analysis prompt is
-  required to report an errored section as *unverified* and is forbidden from
-  calling the machine clean while one is present. Without this an unavailable
-  `Get-MpComputerStatus` produced an empty DEFENDER section that read exactly
-  like "Defender is fine".
+- The collector is **read-only** (CIM/WMI, registry reads, `Get-WinEvent`,
+  `Get-NetTCPConnection`, `Get-MpComputerStatus`, `Get-AuthenticodeSignature`);
+  it needs no admin and makes no network calls. **Detection only — it never
+  changes configuration.** The only write outside `%USERPROFILE%\Claude` is an
+  optional copy of the report into a local Google Drive sync folder (`My Drive`)
+  when one exists, giving the analysis run a fallback read path.
+- **A broken or blocked lens is never silence.** Each section resolves to
+  exactly one of four states — items, `(none)`, `!! COLLECTION ERROR: <msg>`
+  (the lens threw), or `## ADMIN-REQUIRED (<Type>)` (needs elevation we don't
+  have). The analysis prompt reports an errored section as *unverified* and may
+  not call the host clean while one is present. This is why an unavailable
+  `Get-MpComputerStatus` can never masquerade as "Defender is fine".
+- **Non-admin coverage limits (surfaced honestly, not hidden).** Three high-value
+  surfaces are unreadable without elevation and render an `## ADMIN-REQUIRED`
+  marker rather than a misleading `(none)`: the **Security event log** (4720
+  new-user, 4624/4625 logons, 1102 clear-audit), **Defender exclusion contents**
+  (`HideExclusionsFromLocalUsers=True` on this host — an attacker-added exclusion
+  is then detectable non-admin *only* via the C4 5007 config-change event echo),
+  and **Secure Boot state**. To light these up, add the collector account to
+  *Event Log Readers* or run it elevated.
+- **False-positive discipline is built in.** Version strings in paths/service
+  names are normalized to `X.X`; the `[USER-WRITABLE-PATH]` alarm fires only on
+  *unsigned* binaries (so Defender's own `ProgramData\...\Platform` services
+  don't false-flag); scheduled-task suspicion keys on the *executable*, not
+  incidental log-file arguments; Defender 5007 update-churn collapses to a count;
+  BITS/servicing start-type flaps are `[CHURN]`-tagged; and the PowerShell 4104
+  lens self-excludes the collector's own script (a keyword scan otherwise flags
+  its own source). `[STABLE]` blocks are strict-diffed; `[VOLATILE]` blocks
+  (ephemeral ports, per-run endpoints, virtual-adapter DNS) are triage-only.
 - **Section 1 deliberately does not exclude `C:\Windows\Temp\`.** The
   non-Microsoft heuristic skips services under `\Windows\`, but that directory
-  is user-writable by default and is a standard persistence location, so
-  excluding it would blind the audit's highest-value lens. Services with a null
-  `PathName` also stay visible rather than being filtered away.
-- The collector task itself shows up in audit section 2 — the analysis prompt
-  expects it (`ClaudeSecurityAuditCollector`).
+  is user-writable and a standard persistence location, so excluding it would
+  blind a high-value lens.
+- The collector task itself, and this host's own dotfiles artifacts (the
+  `macOS Hotkeys`/PowerToys tasks, the `refresh-wsl-portproxy` rule, the built-in
+  `SCM Event Log Filter` WMI subscription) show up in the report — the analysis
+  prompt lists them as expected baseline.
 - `StartWhenAvailable` + battery-friendly settings mean a laptop asleep at 09:00
   collects on wake; the analysis task tolerates data up to 3 days old before
   flagging staleness.

--- a/opt/Desktop/Apps/scripts/AGENTS.md
+++ b/opt/Desktop/Apps/scripts/AGENTS.md
@@ -28,7 +28,10 @@ keyboard shortcuts, Wispr Flow voice dictation, app/font setup, and PowerToys.
 - **`security-audit-collect.ps1`** — the read-only collector that task runs:
   snapshots services / scheduled tasks / startup commands / AppData processes /
   Defender into `latest-audit.txt` (+ a copy into the Claude task folder, dated
-  history, optional Google Drive fallback copy).
+  history, optional Google Drive fallback copy). Every section resolves to
+  items, `(none)`, or `!! COLLECTION ERROR: <msg>` — **never** an empty section,
+  which the analysis run would read as "clean". Keep that contract when editing
+  a lens: wrap it in `Add-Section`, don't hand-append to `$sections`.
 
 User-facing runbook: **`WISPR-FLOW.md`**. Overview: **`README.md`**.
 

--- a/opt/Desktop/Apps/scripts/AGENTS.md
+++ b/opt/Desktop/Apps/scripts/AGENTS.md
@@ -19,6 +19,16 @@ keyboard shortcuts, Wispr Flow voice dictation, app/font setup, and PowerToys.
 - **`setup-autostart.ps1`** — registers the elevated logon task for `macos.ahk` and,
   re-run standalone, **reloads** AutoHotkey after a re-deploy (self-elevates → UAC).
 - **`setup-apps.ps1`** — winget app install + Windows Terminal profiles/themes.
+- **`setup-security-audit.ps1`** — opt-in (gff `install.windows.security-audit`,
+  **fail-closed**) installer for the unattended weekly security audit: registers the
+  user-level `ClaudeSecurityAuditCollector` daily task, installs the collector to
+  `%USERPROFILE%\Claude\SecurityAudit`, and seeds the Claude analysis task prompt
+  (never overwrites an evolving baseline). `-Status` / `-Uninstall` / `-At HH:mm`.
+  See `docs/security-audit.md`.
+- **`security-audit-collect.ps1`** — the read-only collector that task runs:
+  snapshots services / scheduled tasks / startup commands / AppData processes /
+  Defender into `latest-audit.txt` (+ a copy into the Claude task folder, dated
+  history, optional Google Drive fallback copy).
 
 User-facing runbook: **`WISPR-FLOW.md`**. Overview: **`README.md`**.
 

--- a/opt/Desktop/Apps/scripts/AGENTS.md
+++ b/opt/Desktop/Apps/scripts/AGENTS.md
@@ -26,12 +26,19 @@ keyboard shortcuts, Wispr Flow voice dictation, app/font setup, and PowerToys.
   (never overwrites an evolving baseline). `-Status` / `-Uninstall` / `-At HH:mm`.
   See `docs/security-audit.md`.
 - **`security-audit-collect.ps1`** — the read-only collector that task runs:
-  snapshots services / scheduled tasks / startup commands / AppData processes /
-  Defender into `latest-audit.txt` (+ a copy into the Claude task folder, dated
-  history, optional Google Drive fallback copy). Every section resolves to
-  items, `(none)`, or `!! COLLECTION ERROR: <msg>` — **never** an empty section,
-  which the analysis run would read as "clean". Keep that contract when editing
-  a lens: wrap it in `Add-Section`, don't hand-append to `$sections`.
+  ~40 anomaly lenses (persistence ASEPs, Defender health, network exposure/C2,
+  process masquerade, accounts/privilege, patch posture, 7d event-log signals)
+  into `latest-audit.txt` (+ a copy into the Claude task folder, dated history,
+  optional Google Drive fallback copy). **Detection only — never changes config.**
+  Every section resolves to items, `(none)`, `!! COLLECTION ERROR`, or
+  `## ADMIN-REQUIRED` — **never** an empty section, which the analysis would read
+  as "clean". Keep that contract when editing a lens: wrap it in `Add-Section`
+  (never hand-append to `$sections`), use `Deny-Marker` for admin-gaps (type name
+  only, byte-stable), version-normalize churny paths via `Norm-Ver`, and split
+  high-churn surfaces into `[STABLE]`/`[VOLATILE]` blocks. Params `-StdOut` (emit
+  to stdout, no writes), `-BaseDir`, `-Days` support ad-hoc + test runs.
+  **Tested by `opt/scripts/system/security-audit-collect_test.sh`** — static
+  contract checks in CI + a live read-only run assertion on WSL/Windows.
 
 User-facing runbook: **`WISPR-FLOW.md`**. Overview: **`README.md`**.
 

--- a/opt/Desktop/Apps/scripts/lib/gff.ps1
+++ b/opt/Desktop/Apps/scripts/lib/gff.ps1
@@ -1,19 +1,35 @@
-# gff.ps1 — fail-open feature-flag gate for the Windows setup scripts.
-# Mirrors opt/lib/gff.sh: a key is ON unless its mangled env var is exactly
-# the literal string 'false'. Flags cross from WSL via WSLENV (/u), built by
-# opt/bin/install_windows.sh before each powershell.exe invocation.
+# gff.ps1 — feature-flag gates for the Windows setup scripts.
+# Mirrors opt/lib/gff.sh. Flags cross from WSL via WSLENV, built by
+# opt/bin/install_windows.sh (export_gff_wslenv) before each powershell.exe
+# invocation — with the /w flag: /u is Win32->WSL and was refuted empirically
+# (2026-07-26), see the note at that function.
+#
+# Two gates, opposite directions — pick by the flag's boolDefault:
+#   Test-GffOn     fail-OPEN  (boolDefault: true)  — ON unless exactly 'false'.
+#   Test-GffOptIn  fail-CLOSED (boolDefault: false) — OFF unless exactly 'true'.
+#
 # Usage:  . (Join-Path $PSScriptRoot 'lib\gff.ps1')
 #         if (Test-GffOn 'install.windows.wispr-flow') { ... }
+
+# ToUpperInvariant, never ToUpper: ToUpper is culture-sensitive, and under a
+# Turkish locale 'i' uppercases to 'İ' (U+0130) — the mangled name would then
+# never match the GFF_* variable WSLENV actually exported, silently ignoring
+# every flag containing an 'i' (i.e. all of install.*).
+function Get-GffVarName([string]$Key) {
+    return 'GFF_' + ($Key.ToUpperInvariant() -replace '[.-]', '_')
+}
+
 function Test-GffOn([string]$Key) {
-    $var = 'GFF_' + ($Key.ToUpper() -replace '[.-]', '_')
-    $val = [Environment]::GetEnvironmentVariable($var)
+    $val = [Environment]::GetEnvironmentVariable((Get-GffVarName $Key))
     return $val -ne 'false'   # fail-open: unset/anything-else => on
 }
 
-# Test-GffOptIn - FAIL-CLOSED mirror of opt/lib/gff.sh gff_opt_in for opt-in
+# FAIL-CLOSED mirror of opt/lib/gff.sh gff_opt_in, for opt-in
 # (boolDefault: false) steps: ON only when the env var is exactly 'true'.
+# No caller today — setup-security-audit.ps1 is deliberately ungated because a
+# manual PowerShell run IS the explicit intent (the gate lives at the install.sh
+# call site, opt/bin/install_windows.sh run_security_audit_setup). Kept here so
+# the PS gate library stays a faithful mirror of the POSIX one.
 function Test-GffOptIn([string]$Key) {
-    $var = 'GFF_' + ($Key.ToUpper() -replace '[.-]', '_')
-    return ([Environment]::GetEnvironmentVariable($var) -eq 'true')
+    return ([Environment]::GetEnvironmentVariable((Get-GffVarName $Key)) -eq 'true')
 }
-

--- a/opt/Desktop/Apps/scripts/lib/gff.ps1
+++ b/opt/Desktop/Apps/scripts/lib/gff.ps1
@@ -9,3 +9,11 @@ function Test-GffOn([string]$Key) {
     $val = [Environment]::GetEnvironmentVariable($var)
     return $val -ne 'false'   # fail-open: unset/anything-else => on
 }
+
+# Test-GffOptIn - FAIL-CLOSED mirror of opt/lib/gff.sh gff_opt_in for opt-in
+# (boolDefault: false) steps: ON only when the env var is exactly 'true'.
+function Test-GffOptIn([string]$Key) {
+    $var = 'GFF_' + ($Key.ToUpper() -replace '[.-]', '_')
+    return ([Environment]::GetEnvironmentVariable($var) -eq 'true')
+}
+

--- a/opt/Desktop/Apps/scripts/security-audit-collect.ps1
+++ b/opt/Desktop/Apps/scripts/security-audit-collect.ps1
@@ -1,55 +1,56 @@
 <#
 .SYNOPSIS
-  Read-only weekly security-audit collector. Snapshots the five audit lenses
-  and writes them to text files that the Claude "weekly-security-audit"
-  scheduled task analyzes unattended (no computer-use, no approvals).
+  Read-only weekly Windows security-audit collector (v2). Snapshots ~40 anomaly
+  lenses across persistence, defense-evasion, network, process, account and
+  posture surfaces, and writes stable, diff-friendly text that the Claude
+  "weekly-security-audit" task analyzes UNATTENDED (no computer-use, no admin,
+  no approvals). Detection only - it never changes configuration.
 
 .DESCRIPTION
-  Sections (keep formats/filters stable - the analysis baseline depends on them):
-    1. Non-Microsoft auto-start services
-    2. Non-Microsoft active scheduled tasks
-    3. Startup commands (Win32_StartupCommand lens)
-    4. Processes running from AppData\Roaming or AppData\Local\Temp
-    5. Microsoft Defender status
+  Every lens runs through Add-Section and resolves to exactly one visible state,
+  so the analysis run can never mistake a broken/blocked lens for a clean host:
+    <data>                     the lens ran and found items
+    (none)                     the lens ran and found nothing
+    !! COLLECTION ERROR: ..    the lens itself threw (report, do NOT read as clean)
+    ## ADMIN-REQUIRED (<Type>) the data needs elevation we do not have (honest gap)
+  Admin-gap markers are byte-stable (exception TYPE only, never the localized
+  .Message) so they diff cleanly week to week.
 
-  Every section resolves to exactly one of three states, so the analysis run can
-  never mistake a broken lens for a clean machine:
-    <data>                  - the lens ran and found items
-    (none)                  - the lens ran and found nothing
-    !! COLLECTION ERROR: .. - the lens itself failed (report it, do not read as clean)
+  High-churn surfaces are split into a [STABLE] block (version-normalized, the
+  strict-diff surface) and a [VOLATILE] block (ephemeral data shown for triage
+  but never alarmed on by absence/change alone).
 
-  Writes:
-    %USERPROFILE%\Claude\SecurityAudit\latest-audit.txt          (canonical)
-    %USERPROFILE%\Claude\Scheduled\weekly-security-audit\latest-audit.txt
-        (the Claude task folder - delivered to the analysis run as its uploads)
-    %USERPROFILE%\Claude\SecurityAudit\history\audit-YYYY-MM-DD.txt (keeps 20)
-    <Google Drive>\security-audit-latest.txt                      (fallback,
-        only when a local Drive sync folder exists)
-  Registered by setup-security-audit.ps1 as user-level task
-  'ClaudeSecurityAuditCollector' (daily, hidden). Runs fine standalone too.
-  Read-only WMI/CIM + Defender queries; no admin, no network calls.
+.PARAMETER BaseDir
+  Output root (default %USERPROFILE%\Claude\SecurityAudit). Tests pass a temp dir.
+.PARAMETER Days
+  Event-log look-back window in days (default 7).
+.PARAMETER StdOut
+  Emit the report to stdout and skip ALL file writes (for tests / ad-hoc runs).
 #>
+param(
+    [string]$BaseDir = (Join-Path $env:USERPROFILE 'Claude\SecurityAudit'),
+    [int]$Days = 7,
+    [switch]$StdOut,
+    # Test-only: append one deliberately-throwing lens so the driver can prove the
+    # throw -> '!! COLLECTION ERROR' contract, RC still 0, later sections render.
+    [switch]$FaultInject
+)
 
-# 'Stop' (not 'Continue') so a failing cmdlet raises a catchable terminating
-# error that Add-Section turns into a visible "!! COLLECTION ERROR" marker.
-# Under 'Continue' the error went to a stderr nobody reads and the section was
-# written EMPTY - indistinguishable from "nothing suspicious found".
+# 'Stop' so a failing cmdlet raises a catchable terminating error that
+# Add-Section turns into a visible marker. Under 'Continue' the error goes to a
+# stderr nobody reads and the section is written EMPTY - indistinguishable from
+# "nothing suspicious found".
 $ErrorActionPreference = 'Stop'
+$COLLECTOR_VERSION = '2'
+$SELF_PATH = $MyInvocation.MyCommand.Path
+$WINDOW    = (Get-Date).AddDays(-[Math]::Abs($Days))
 
-$base    = Join-Path $env:USERPROFILE 'Claude\SecurityAudit'
-$taskDir = Join-Path $env:USERPROFILE 'Claude\Scheduled\weekly-security-audit'
-$histDir = Join-Path $base 'history'
-New-Item -ItemType Directory -Force -Path $base, $histDir | Out-Null
+# ---- helpers ---------------------------------------------------------------
+$script:sections = @()
 
-$sections = @()
-
-# Add-Section - run one lens, and record its outcome unambiguously. A lens that
-# throws must never collapse into an empty section (see .DESCRIPTION).
+# Add-Section - run one lens; record its outcome unambiguously (see .DESCRIPTION).
 function Add-Section {
-    param(
-        [Parameter(Mandatory)][string]$Title,
-        [Parameter(Mandatory)][scriptblock]$Body
-    )
+    param([Parameter(Mandatory)][string]$Title,[Parameter(Mandatory)][scriptblock]$Body)
     $script:sections += "`r`n=== $Title ==="
     try {
         $out = (& $Body | Out-String -Width 400).TrimEnd()
@@ -60,75 +61,729 @@ function Add-Section {
     }
 }
 
-$sections += "AUDIT TIMESTAMP: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss zzz')"
-$sections += "COMPUTER: $env:COMPUTERNAME  USER: $env:USERNAME"
-
-# Path-based "non-Microsoft" heuristic: skip services under \Windows\, EXCEPT
-# \Windows\Temp\ - that directory is user-writable by default and is a classic
-# persistence location, so excluding it would blind the audit's most valuable
-# lens. Services with a null PathName fall through and stay visible on purpose.
-Add-Section '1. NON-MICROSOFT AUTO-START SERVICES' {
-    Get-CimInstance Win32_Service |
-        Where-Object {
-            $_.StartMode -eq 'Auto' -and
-            ($_.PathName -notmatch '\\Windows\\' -or $_.PathName -match '\\Windows\\Temp\\')
-        } |
-        Sort-Object DisplayName |
-        Format-Table -Auto State, DisplayName, PathName
+# Fixed-text admin-gap marker (byte-stable: type name only, no localized message).
+function Deny-Marker([string]$what,[System.Exception]$e) {
+    "## ADMIN-REQUIRED ($($e.GetType().Name)): $what"
 }
 
-Add-Section '2. NON-MICROSOFT ACTIVE SCHEDULED TASKS' {
-    Get-ScheduledTask |
-        Where-Object { $_.TaskPath -notmatch '^\\Microsoft' -and $_.State -ne 'Disabled' } |
-        Format-Table -Auto State, TaskPath, TaskName
+# Collapse version-ish path/name churn so updaters don't diff every week:
+#   \app-1.2.3\  1.2.3.4  \127.0.6533.100\  ->  X   (single canonical token)
+# IPv4 literals are PRESERVED: a hard-coded C2/exfil IP in a service or task
+# command must still diff, so a dotted run that is a valid 4-octet IPv4 (every
+# octet 0-255) is left intact; version strings (e.g. 148.0.7778.1018, octet
+# >255) are still collapsed.
+function Norm-Ver([string]$s) {
+    if ($null -eq $s) { return '' }
+    $ipv4 = '^(25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])){3}$'
+    $s = [regex]::Replace($s, '\d+(\.\d+){2,}', { param($m) if ($m.Value -match $ipv4) { $m.Value } else { 'X.X' } })
+    $s = $s -replace '(?<=[\\_\-])\d{2,}(\.\d+)*(?=[\\_\-]|$)', 'X'  # \12345\ build dirs
+    return $s
 }
 
-Add-Section '3. STARTUP COMMANDS' {
-    Get-CimInstance Win32_StartupCommand | Format-Table -Auto Name, Location
+# Cached Authenticode status by path (sig checks are ~ms each; dedupe them).
+$script:SIGCACHE = @{}
+function Sig-Status([string]$path) {
+    if (-not $path) { return 'NoPath' }
+    if ($script:SIGCACHE.ContainsKey($path)) { return $script:SIGCACHE[$path] }
+    $st = 'Unchecked'
+    try { if (Test-Path -LiteralPath $path) { $st = (Get-AuthenticodeSignature -LiteralPath $path).Status.ToString() } else { $st = 'PathMissing' } } catch { $st = 'SigError' }
+    $script:SIGCACHE[$path] = $st; return $st
 }
 
-# .Path throws on processes this user cannot open (protected/elevated). Read it
-# per-process inside try/catch so those become $null instead of failing the
-# whole lens - an access-denied on one PID must not hide every other match.
-Add-Section '4. PROCESSES FROM APPDATA/TEMP' {
-    Get-Process -ErrorAction SilentlyContinue |
-        ForEach-Object { try { $_.Path } catch { $null } } |
-        Where-Object { $_ -and $_ -match 'AppData\\(Roaming|Local\\Temp)' } |
-        Sort-Object -Unique
+# Pull the first quoted-or-bare .exe/.sys/.dll out of a service/command string.
+# The final fallback allows SPACES before the extension, so an UNQUOTED service
+# path with spaces (itself a red flag) still yields an image to sig-check rather
+# than $null - stopping just before a trailing " -flag" / " /flag" argument.
+function Image-Of([string]$cmd) {
+    if (-not $cmd) { return $null }
+    if ($cmd -match '^"([^"]+)"') { return $Matches[1] }
+    if ($cmd -match '^\s*([A-Za-z]:\\[^\s,]+?\.(?:exe|sys|dll|com|bat|cmd|ps1|scr))') { return $Matches[1] }
+    if ($cmd -match '([A-Za-z]:\\[^\s,]+?\.(?:exe|sys|dll|com|bat|cmd|ps1|scr))') { return $Matches[1] }
+    if ($cmd -match '^\s*([A-Za-z]:\\.+?\.(?:exe|sys|dll|com|bat|cmd|ps1|scr))(?:\s+[-/]|$)') { return $Matches[1] }
+    return $null
 }
 
-Add-Section '5. DEFENDER' {
-    Get-MpComputerStatus |
-        Format-List RealTimeProtectionEnabled, AntivirusEnabled, AntivirusSignatureLastUpdated, QuickScanEndTime
+# User-writable / suspicious image locations (case-insensitive regex fragments).
+# Broad on purpose: the whole per-user profile is writable (AppData\Local +
+# LocalLow, Documents, Desktop, %LOCALAPPDATA%\Programs - where a large share of
+# real per-user malware and infostealers land), so a substring match on
+# \users\<name>\ catches it; Program Files / WindowsApps sit outside the profile
+# and are excluded. (Alarm severity is still gated on signature elsewhere, so
+# broad coverage here does not by itself create noise.)
+$USERWRITABLE = 'appdata\\roaming','appdata\\local','appdata\\locallow',
+                '\\temp\\','\\downloads\\','\\users\\public\\','\\programdata\\',
+                '\\\$recycle','\\windows\\temp\\',
+                '\\users\\[^\\]+\\(documents|desktop|downloads|music|pictures|videos|favorites)\\'
+function Is-UserWritable([string]$p) {
+    if (-not $p) { return $false }
+    $l = $p.ToLower()
+    foreach ($u in $USERWRITABLE) { if ($l -match $u) { return $true } }
+    return $false
 }
 
-$report = $sections -join "`r`n"
-
-# The canonical copy is the one the pipeline is allowed to fail on: if it cannot
-# be written there is nothing to analyze, so surface a non-zero task result.
-$report | Set-Content -Path (Join-Path $base 'latest-audit.txt') -Encoding UTF8
-
-# Secondary copies are best-effort - a full disk, a locked file, or a missing
-# Drive folder must not discard the canonical report that already succeeded.
-try {
-    if (Test-Path $taskDir) {
-        $report | Set-Content -Path (Join-Path $taskDir 'latest-audit.txt') -Encoding UTF8
+# Probe-first event read: returns @{state='ok'|'denied'|'empty'|'error'; events=@(); err=} .
+# Going straight to -FilterHashtable on a DENIED log throws a generic
+# "No events were found" (NOT UnauthorizedAccessException) - so probe the log
+# with -MaxEvents 1 first to tell "denied" from "readable but quiet".
+# "No matching events" is a TERMINATING error with no distinct exception type;
+# key on the locale-INDEPENDENT FullyQualifiedErrorId, not the localized message
+# (the English 'No events were found' string breaks on non-English Windows and
+# would misreport a clean, readable log as a broken lens).
+function Test-NoEvents($errRec) {
+    return ($errRec.FullyQualifiedErrorId -match 'NoMatchingEventsFound')
+}
+function Read-Events([string]$log,[int[]]$ids,[int]$max=200) {
+    try { Get-WinEvent -LogName $log -MaxEvents 1 -ErrorAction Stop | Out-Null }
+    catch [System.UnauthorizedAccessException] { return @{ state='denied'; events=@(); err=$_.Exception } }
+    catch {
+        if (Test-NoEvents $_) { return @{ state='empty'; events=@() } }
+        return @{ state='error'; events=@(); err=$_.Exception }
     }
-} catch { Write-Warning "could not write the Claude task-folder copy: $($_.Exception.Message)" }
+    $filter = @{ LogName=$log; StartTime=$WINDOW }
+    if ($ids -and $ids.Count) { $filter['Id'] = $ids }
+    try {
+        $ev = @(Get-WinEvent -FilterHashtable $filter -MaxEvents $max -ErrorAction Stop)
+        return @{ state='ok'; events=$ev }
+    } catch {
+        if (Test-NoEvents $_) { return @{ state='empty'; events=@() } }
+        return @{ state='error'; events=@(); err=$_.Exception }
+    }
+}
 
-try {
-    $report | Set-Content -Path (Join-Path $histDir ("audit-{0}.txt" -f (Get-Date -Format 'yyyy-MM-dd'))) -Encoding UTF8
-    # Names are ISO-dated, so a descending lexical sort is newest-first: keep 20.
-    Get-ChildItem $histDir -Filter 'audit-*.txt' | Sort-Object Name -Descending |
-        Select-Object -Skip 20 | Remove-Item -Force
-} catch { Write-Warning "could not update the history folder: $($_.Exception.Message)" }
+# ---- header ----------------------------------------------------------------
+# Every header statement is guarded: an unhandled throw here would abort BEFORE
+# any report is written (no in-band signal, only a stale timestamp) - worse than
+# a COLLECTION ERROR. So nothing in the header may be allowed to terminate.
+$isAdmin = try { ([Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator) } catch { $false }
+$os = try { Get-CimInstance Win32_OperatingSystem } catch { $null }
+# UBR (the .NNN revision) is not in Win32_OperatingSystem.Version (that ends at
+# the build number); read it from the registry so BUILD shows build.revision,
+# not the build number twice.
+$ubr = try { (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -ErrorAction Stop).UBR } catch { $null }
+$sections += "AUDIT TIMESTAMP: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss zzz')"
+$sections += "COLLECTOR: v$COLLECTOR_VERSION  WINDOW: ${Days}d  ELEVATED: $isAdmin"
+$sections += "COMPUTER: $env:COMPUTERNAME  USER: $env:USERNAME"
+if ($os) { $sections += "OS: $($os.Caption)  BUILD: $($os.BuildNumber)$(if ($ubr) { ".$ubr" })" }
 
-# Optional Google Drive fallback copy (only when Drive for Desktop syncs locally).
-try {
-    foreach ($gd in @((Join-Path $env:USERPROFILE 'My Drive'), 'G:\My Drive')) {
-        if (Test-Path $gd) {
-            Copy-Item (Join-Path $base 'latest-audit.txt') (Join-Path $gd 'security-audit-latest.txt') -Force
-            break
+# ============================================================================
+# A. PERSISTENCE - registry autostart extensibility points (ASEPs)
+# ============================================================================
+Add-Section 'A1. RUN / RUNONCE KEYS (version-normalized)' {
+    $paths = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run',
+             'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce',
+             'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Run',
+             'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run',
+             'HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce'
+    foreach ($p in $paths) {
+        if (-not (Test-Path -LiteralPath $p)) { "$p :: <absent>"; continue }
+        $k = Get-Item -LiteralPath $p
+        $names = @($k.GetValueNames() | Sort-Object)
+        if (-not $names.Count) { "$p :: <empty>"; continue }
+        foreach ($n in $names) { '{0} :: {1} = {2}' -f ($p -replace '^HK.*?:','HK'), $n, (Norm-Ver ([string]$k.GetValue($n,$null,'DoNotExpandEnvironmentNames'))) }
+    }
+}
+
+Add-Section 'A2. HIGH-SIGNAL ASEPs (Policies\Run, RunOnceEx - should be empty)' {
+    $paths = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run',
+             'HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run',
+             'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnceEx',
+             'HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnceEx'
+    foreach ($p in $paths) {
+        if (-not (Test-Path -LiteralPath $p)) { "$p :: <absent>"; continue }
+        $k = Get-Item -LiteralPath $p
+        $names = @($k.GetValueNames() | Sort-Object)
+        $kids  = @(Get-ChildItem -LiteralPath $p -Recurse -ErrorAction SilentlyContinue)
+        if (-not $names.Count -and -not $kids.Count) { "$p :: <empty>"; continue }
+        foreach ($n in $names) { '{0} :: {1} = {2}' -f $p,$n,$k.GetValue($n,$null,'DoNotExpandEnvironmentNames') }
+        foreach ($c in ($kids | Sort-Object PSChildName)) { foreach ($n in @($c.GetValueNames()|Sort-Object)) { '{0}\{1} :: {2} = {3}' -f $p,$c.PSChildName,$n,$c.GetValue($n) } }
+    }
+}
+
+Add-Section 'A3. WINLOGON Shell/Userinit/Notify (HKLM + HKCU)' {
+    foreach ($p in 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon','HKCU:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon') {
+        if (-not (Test-Path -LiteralPath $p)) { "$p :: <absent>"; continue }
+        $k = Get-Item -LiteralPath $p
+        foreach ($v in 'Shell','Userinit','Taskman','VmApplet','System','GinaDLL','AppSetup') {
+            '{0} :: {1} = [{2}]' -f ($p -replace '^HK.*?:','HK'),$v,$k.GetValue($v,'<unset>','DoNotExpandEnvironmentNames')
         }
     }
-} catch { Write-Warning "could not write the Google Drive fallback copy: $($_.Exception.Message)" }
+}
+
+Add-Section 'A4. IFEO debuggers + AppInit_DLLs' {
+    # Reset a SCRIPT-scoped flag each run: the ForEach-Object body runs in a child
+    # scope, so a plain $found there never reaches this block - the read and the
+    # write must use the SAME script scope, or the "<none set>" footer prints even
+    # when a real Debugger/VerifierDlls hijack was found two lines above.
+    $script:ifeoFound = $false
+    foreach ($b in 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options','HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\Image File Execution Options') {
+        if (-not (Test-Path -LiteralPath $b)) { continue }
+        # Per-subkey try/catch: some IFEO subkeys are ACL'd to block non-admin
+        # reads (e.g. the Store/WindowsApps entries). One denied subkey must not
+        # fail the whole lens - skip it, keep scanning the rest.
+        Get-ChildItem -LiteralPath $b -ErrorAction SilentlyContinue | Sort-Object PSChildName | ForEach-Object {
+            try {
+                $d=$_.GetValue('Debugger'); $v=$_.GetValue('VerifierDlls')
+                if ($d -or $v) { $script:ifeoFound=$true; '{0} :: Debugger=[{1}] VerifierDlls=[{2}]' -f $_.PSChildName,$d,($v -join ';') }
+            } catch { }
+        }
+    }
+    $a = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Windows' -ErrorAction SilentlyContinue
+    "AppInit_DLLs=[$($a.AppInit_DLLs)] LoadAppInit_DLLs=$($a.LoadAppInit_DLLs)"
+    if (-not $script:ifeoFound) { "IFEO debuggers: <none set>" }
+}
+
+Add-Section 'A6. LOGON-SCRIPT / .NET-PROFILER / WIN.INI ASEPs (HKCU)' {
+    # High-value, non-admin-writable persistence Autoruns covers but naive audits
+    # miss. All of these should be empty/unset on a clean host.
+    $e = Get-ItemProperty 'HKCU:\Environment' -ErrorAction SilentlyContinue
+    "UserInitMprLogonScript = [$($e.UserInitMprLogonScript)]"                 # T1037.001 logon script
+    "COR_ENABLE_PROFILING   = [$($e.COR_ENABLE_PROFILING)]  COR_PROFILER=[$($e.COR_PROFILER)]  COR_PROFILER_PATH=[$($e.COR_PROFILER_PATH)]"  # T1574.012 profiler DLL
+    $w = Get-ItemProperty 'HKCU:\Software\Microsoft\Windows NT\CurrentVersion\Windows' -ErrorAction SilentlyContinue
+    "win.ini Load=[$($w.Load)]  Run=[$($w.Run)]"                              # T1546 win.ini-mapped ASEP
+    # PowerShell profile scripts run on every shell launch (non-admin persistence).
+    foreach ($pf in $PROFILE.CurrentUserAllHosts,$PROFILE.CurrentUserCurrentHost) {
+        if ($pf -and (Test-Path -LiteralPath $pf)) { "PS profile PRESENT: $pf" }
+    }
+    # Active Setup per-user StubPath (T1547.014).
+    $asRoot = 'HKCU:\Software\Microsoft\Active Setup\Installed Components'
+    if (Test-Path -LiteralPath $asRoot) {
+        Get-ChildItem -LiteralPath $asRoot -ErrorAction SilentlyContinue | ForEach-Object {
+            $sp = $_.GetValue('StubPath'); if ($sp) { "ActiveSetup StubPath: $($_.PSChildName) = $(Norm-Ver $sp)" }
+        }
+    }
+    "(HKCU Environment / win.ini / PS-profile / Active-Setup scan complete)"
+}
+
+Add-Section 'A7. UAC-BYPASS / FILE-HANDLER HIJACKS (HKCU Software\Classes)' {
+    # Per-user shell\open\command hijacks of protected ProgIDs are the classic
+    # fileless UAC-bypass primitives (fodhelper=ms-settings, eventvwr=mscfile) and
+    # default-handler hijacks. On a clean host every one of these is <unset>.
+    $any = $false
+    foreach ($progid in 'ms-settings','mscfile','exefile','Folder','.bat','.cmd','.exe','.ps1') {
+        $cmdKey = "HKCU:\Software\Classes\$progid\shell\open\command"
+        if (Test-Path -LiteralPath $cmdKey) {
+            $val = (Get-Item -LiteralPath $cmdKey).GetValue($null)
+            if ($val) { $any=$true; "[HANDLER-HIJACK] $progid\shell\open\command = $val" }
+        }
+        $delegKey = "HKCU:\Software\Classes\$progid\shell\open\command"  # DelegateExecute variant
+        $de = if (Test-Path -LiteralPath $delegKey) { (Get-Item -LiteralPath $delegKey).GetValue('DelegateExecute') } else { $null }
+        if ($de -ne $null -and $de -eq '') { $any=$true; "[UAC-BYPASS-SHAPE] $progid has empty DelegateExecute (fodhelper/eventvwr pattern)" }
+    }
+    if (-not $any) { '(no per-user handler hijacks - clean)' }
+}
+
+Add-Section 'A5. COM hijack - HKCU CLSID InprocServer32 (user-writable / scriptlet only)' {
+    $root = 'HKCU:\Software\Classes\CLSID'
+    if (-not (Test-Path -LiteralPath $root)) { "$root :: <absent>"; return }
+    $flagged = 0; $total = 0
+    Get-ChildItem -LiteralPath $root -ErrorAction SilentlyContinue | ForEach-Object {
+        foreach ($srv in 'InprocServer32','LocalServer32') {
+            $sp = Join-Path $_.PSPath $srv
+            if (Test-Path -LiteralPath $sp) {
+                $total++
+                $val = (Get-Item -LiteralPath $sp).GetValue($null)
+                if ($val -and ((Is-UserWritable $val) -or $val -match 'scrobj\.dll|\.sct|ScriptletURL')) {
+                    $flagged++; '{0} :: {1} = {2}' -f $_.PSChildName,$srv,(Norm-Ver $val)
+                }
+            }
+        }
+    }
+    "(scanned $total HKCU CLSID servers; $flagged flagged user-writable/scriptlet)"
+}
+
+# ============================================================================
+# B. PERSISTENCE - execution objects
+# ============================================================================
+Add-Section 'B1. NON-MICROSOFT AUTO-START SERVICES (signature + path hygiene)' {
+    # Anchor the \Windows\ exclusion to the REAL system root - an unanchored
+    # substring lets a service imaged under a user-created ...\Windows\ decoy
+    # folder in the profile evade the lens. \Windows\Temp\ stays visible.
+    $winRoot = [regex]::Escape($env:SystemRoot) + '\\'         # the true Windows dir
+    $winTemp = [regex]::Escape($env:SystemRoot) + '\\Temp\\'
+    Get-CimInstance Win32_Service | Where-Object {
+        $_.StartMode -eq 'Auto' -and ($_.PathName -notmatch $winRoot -or $_.PathName -match $winTemp)
+    } | Sort-Object Name | ForEach-Object {
+        $img = Image-Of $_.PathName
+        $sig = Sig-Status $img
+        $flag = ''
+        if ($sig -notin 'Valid','NoPath') { $flag += ' [SIG:' + $sig + ']' }
+        # Only ALARM on a user-writable path when the image is NOT validly signed:
+        # a Valid-signed binary in ProgramData (e.g. Defender's own MDCoreSvc /
+        # WinDefend under ProgramData\...\Platform) is benign - flagging it is noise.
+        if ((Is-UserWritable $img) -and $sig -ne 'Valid') { $flag += ' [USER-WRITABLE-PATH]' }
+        '{0,-34} sig={1,-12} {2}{3}' -f $_.Name, $sig, (Norm-Ver $img), $flag
+    }
+}
+
+Add-Section 'B2. NON-MICROSOFT SCHEDULED TASKS (enabled; hidden/suspicious flagged)' {
+    # '^\\Microsoft\\' (WITH the trailing folder separator) - '^\\Microsoft'
+    # without it also excludes an attacker-created \MicrosoftUpdater\ folder,
+    # since a non-admin can register tasks in new root folders. The real
+    # Microsoft subtree is \Microsoft\Windows\... and keeps the boundary.
+    Get-ScheduledTask | Where-Object { $_.TaskPath -notmatch '^\\Microsoft\\' -and $_.State -ne 'Disabled' } |
+      Sort-Object TaskPath,TaskName | ForEach-Object {
+        $hidden = if ($_.Settings.Hidden) { ' [HIDDEN]' } else { '' }
+        $susp = ''; $shown = ''
+        foreach ($act in $_.Actions) {
+            $exe  = [string]$act.Execute
+            $full = ($exe + ' ' + [string]$act.Arguments).Trim()
+            # User-writable check is on the EXECUTABLE only - an incidental log-file
+            # or data-path argument under ProgramData (e.g. Firefox --MOZ_LOG) is not
+            # a suspicious action. Script-host + download/proxy-exec LOLBins match on
+            # the full command.
+            if ((Is-UserWritable $exe) -or $full -match 'powershell|pwsh|wscript|cscript|mshta|rundll32|regsvr32|regasm|regsvcs|installutil|msbuild|certutil|bitsadmin|msiexec|curl\.exe|\.js\b|\.vbs\b|\.bat\b|\.cmd\b|\.ps1\b|\.scr\b') {
+                $susp=' [SUSPICIOUS-ACTION]'; $shown = "  <= " + (Norm-Ver $full); break
+            }
+        }
+        '{0}{1}{2}{3}' -f (Norm-Ver ($_.TaskPath + $_.TaskName)), $hidden, $susp, $shown
+    }
+}
+
+Add-Section 'B3. STARTUP FOLDER ITEMS + SHELL-FOLDER REDIRECT' {
+    foreach ($d in "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup","$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Startup") {
+        $tag = if ($d -match 'ProgramData') { 'ALL' } else { 'USER' }
+        if (-not (Test-Path -LiteralPath $d)) { "[$tag] <absent>"; continue }
+        $items = @(Get-ChildItem -LiteralPath $d -ErrorAction SilentlyContinue | Where-Object { $_.Name -ne 'desktop.ini' })
+        if (-not $items.Count) { "[$tag] <empty>"; continue }
+        $items | Sort-Object Name | ForEach-Object { "[$tag] $($_.Name)" }
+    }
+    # Shell-folder REDIRECT: repointing the Startup shell folder to an attacker
+    # directory evades the enumeration above and is non-admin (T1547.001).
+    $usf = Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders' -ErrorAction SilentlyContinue
+    $startup = $usf.Startup
+    if ($startup -and $startup -notmatch 'Microsoft\\Windows\\Start Menu\\Programs\\Startup') {
+        "[REDIRECT] User Shell Folders Startup = $startup"
+    } else {
+        "[REDIRECT] Startup shell folder = default"
+    }
+}
+
+Add-Section 'B4. WMI EVENT-SUBSCRIPTION PERSISTENCE' {
+    $f = @(Get-CimInstance -Namespace root\subscription -Class __EventFilter -ErrorAction SilentlyContinue)
+    $c = @(Get-CimInstance -Namespace root\subscription -Class __EventConsumer -ErrorAction SilentlyContinue)
+    $b = @(Get-CimInstance -Namespace root\subscription -Class __FilterToConsumerBinding -ErrorAction SilentlyContinue)
+    $f | Sort-Object Name | ForEach-Object { "FILTER   $($_.Name) :: $($_.Query)" }
+    $c | Sort-Object Name | ForEach-Object { "CONSUMER $($_.__CLASS)/$($_.Name) :: $($_.CommandLineTemplate)$($_.ScriptText)$($_.ExecutablePath)" }
+    "(filters=$($f.Count) consumers=$($c.Count) bindings=$($b.Count))"
+}
+
+# ============================================================================
+# C. DEFENSE EVASION - Microsoft Defender health
+# ============================================================================
+Add-Section 'C1. DEFENDER CORE STATUS' {
+    $s = Get-MpComputerStatus
+    "RealTimeProtection = $($s.RealTimeProtectionEnabled)"
+    "TamperProtection   = $($s.IsTamperProtected)"
+    "BehaviorMonitor    = $($s.BehaviorMonitorEnabled)"
+    "AntivirusEnabled   = $($s.AntivirusEnabled)"
+    "NIS/Network        = $($s.NISEnabled)"
+    "SignatureAge(days) = $($s.AntivirusSignatureAge)"
+    "LastQuickScanEnd   = $($s.QuickScanEndTime)"
+    $p = Get-MpPreference
+    "CloudMAPS(0off)    = $($p.MAPSReporting)"
+    "SubmitSamples      = $($p.SubmitSamplesConsent)"
+    "DisableRealtime    = $($p.DisableRealtimeMonitoring)"
+    "ASRrules(count)    = $(($p.AttackSurfaceReductionRules_Ids | Measure-Object).Count)"
+}
+
+Add-Section 'C2. DEFENDER EXCLUSIONS (contents admin-only on this host)' {
+    $p = Get-MpPreference
+    $hide = $p.HideExclusionsFromLocalUsers
+    foreach ($pair in @(@('Path',$p.ExclusionPath),@('Process',$p.ExclusionProcess),@('Extension',$p.ExclusionExtension))) {
+        $vals = @($pair[1])
+        if ($vals -match 'must be an administrator' -or $hide) {
+            "Exclusion$($pair[0]) = HIDDEN-BY-POLICY (contents UNKNOWN without elevation)"
+        } elseif (-not $vals.Count -or ($vals.Count -eq 1 -and -not $vals[0])) {
+            "Exclusion$($pair[0]) = (none)"
+        } else {
+            "Exclusion$($pair[0]) = " + ($vals -join ' | ')
+        }
+    }
+    "HideExclusionsFromLocalUsers = $hide  (attacker-added exclusions detectable non-admin only via C4 5007 events)"
+}
+
+Add-Section 'C3. DEFENDER DETECTION EVENTS (1116/1117)' {
+    $r = Read-Events 'Microsoft-Windows-Windows Defender/Operational' @(1116,1117) 50
+    switch ($r.state) {
+        'denied' { Deny-Marker 'Defender operational log' $r.err }
+        'empty'  { '(none in window)' }
+        'error'  { throw $r.err }
+        default  { if (-not $r.events.Count) { '(none in window)' } else { $r.events | ForEach-Object { '{0:yyyy-MM-dd HH:mm}  {1}' -f $_.TimeCreated, (($_.Message -split "`n")[0].Trim()) } } }
+    }
+}
+
+Add-Section 'C4. DEFENDER CONFIG-CHANGE EVENTS (5001 RTP-off / 5007 security-relevant only)' {
+    $r = Read-Events 'Microsoft-Windows-Windows Defender/Operational' @(5001,5007,5010,5012) 400
+    switch ($r.state) {
+        'denied' { Deny-Marker 'Defender operational log' $r.err; return }
+        'error'  { throw $r.err }
+    }
+    if ($r.state -eq 'empty' -or -not $r.events.Count) { '(none in window)'; return }
+    # 5007 ("Configuration has changed") fires on every signature/telemetry update -
+    # dozens per day of pure churn. Surface ONLY the security-relevant ones (the
+    # message echoes the changed value path): exclusions, real-time/behavior/tamper
+    # toggles, engine disables. Everything else collapses to a single count line so
+    # a genuine "someone disabled protection" event is not buried under update noise.
+    $relevant = 'Exclusions\\|DisableRealtimeMonitoring|DisableBehaviorMonitoring|DisableOnAccessProtection|DisableAntiSpyware|DisableAntiVirus|TamperProtection|DisableIOAVProtection|PUAProtection|MAPSReporting|SubmitSamplesConsent'
+    $churn = 0
+    foreach ($e in $r.events) {
+        $m = ($e.Message -replace "`r?`n",' ') -replace '\s{2,}',' '
+        if ($e.Id -eq 5001 -or $m -match $relevant) {
+            $tag = if ($m -match 'Exclusions\\') { ' [EXCLUSION-CHANGE]' } elseif ($e.Id -eq 5001) { ' [REALTIME-DISABLED]' } else { ' [SECURITY-SETTING]' }
+            '{0:yyyy-MM-dd HH:mm}  id={1}{2}  {3}' -f $e.TimeCreated,$e.Id,$tag,$m.Substring(0,[Math]::Min(160,$m.Length))
+        } else { $churn++ }
+    }
+    "(+ $churn generic 'configuration changed' events suppressed as signature/telemetry churn)"
+}
+
+# ============================================================================
+# D. DEFENSE EVASION - event-log integrity
+# ============================================================================
+Add-Section 'D1. EVENT-LOG CLEARED (System 104; Security 1102 = admin-gap)' {
+    $r = Read-Events 'System' @(104) 20
+    if ($r.state -eq 'ok' -and $r.events.Count) { $r.events | ForEach-Object { '{0:yyyy-MM-dd HH:mm}  System log cleared' -f $_.TimeCreated } }
+    elseif ($r.state -eq 'ok' -or $r.state -eq 'empty') { 'System-104: (no clears in window)' }
+    else { 'System-104: ' + (Deny-Marker 'System log' $r.err) }
+    $sec = Read-Events 'Security' @(1102) 5
+    if ($sec.state -eq 'denied') { 'Security-1102: ' + (Deny-Marker 'Security log (1102 clear-audit)' $sec.err) }
+    elseif ($sec.state -eq 'ok' -and $sec.events.Count) { $sec.events | ForEach-Object { '{0:yyyy-MM-dd HH:mm}  Security log cleared' -f $_.TimeCreated } }
+    else { 'Security-1102: (none in window)' }
+}
+
+Add-Section 'D2. EVENT CHANNEL HEALTH (fixed list; <absent> is affirmative)' {
+    $channels = 'System','Application','Microsoft-Windows-Windows Defender/Operational',
+                'Microsoft-Windows-PowerShell/Operational','Microsoft-Windows-TaskScheduler/Operational',
+                'Microsoft-Windows-CodeIntegrity/Operational'
+    foreach ($ch in $channels) {
+        $l = Get-WinEvent -ListLog $ch -ErrorAction SilentlyContinue
+        if (-not $l) { "{0,-52} <absent/unreadable>" -f $ch }
+        else { "{0,-52} enabled={1} records={2}" -f $ch, $l.IsEnabled, $l.RecordCount }
+    }
+}
+
+# ============================================================================
+# E. NETWORK - exposure
+# ============================================================================
+Add-Section 'E1. FIREWALL PROFILES' {
+    Get-NetFirewallProfile | Sort-Object Name | ForEach-Object {
+        $flag = if (-not $_.Enabled) { ' [DISABLED]' } else { '' }
+        '{0,-8} Enabled={1} DefaultInbound={2} DefaultOutbound={3}{4}' -f $_.Name,$_.Enabled,$_.DefaultInboundAction,$_.DefaultOutboundAction,$flag
+    }
+}
+
+Add-Section 'E2. TCP LISTENERS (well-known strict; dynamic/loopback volatile)' {
+    # Non-admin cannot read protected system-process image paths, so a signature
+    # is only meaningful for user-owned listeners (shown when present). Ports
+    # >=49152 are the dynamic/ephemeral RPC range - they rotate every boot, so
+    # they are fenced as VOLATILE and keyed by process, never by port number.
+    $conns = Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue
+    $rows = foreach ($c in $conns) {
+        $loop = $c.LocalAddress -in '127.0.0.1','::1'
+        $pr = Get-Process -Id $c.OwningProcess -ErrorAction SilentlyContinue
+        $img = $pr.Path
+        $sig = Sig-Status $img
+        [pscustomobject]@{ Loop=$loop; Dyn=([int]$c.LocalPort -ge 49152); Port=[int]$c.LocalPort; Proc=$pr.ProcessName; Sig=$sig; UW=(Is-UserWritable $img); HasImg=[bool]$img }
+    }
+    function _sigtag($r) { $t=''; if($r.HasImg -and $r.Sig -notin 'Valid'){$t+=' [SIG:'+$r.Sig+']'}; if($r.UW){$t+=' [USER-WRITABLE]'}; $t }
+    "[STABLE-EXPOSED] non-loopback, well-known ports <49152 (strict diff)"
+    $exp = @($rows | Where-Object { -not $_.Loop -and -not $_.Dyn } | Sort-Object Port,Proc -Unique)
+    if ($exp.Count) { $exp | ForEach-Object { '  {0,-6} <- {1}{2}' -f $_.Port,$_.Proc,(_sigtag $_) } } else { '  (none)' }
+    "[VOLATILE-DYNAMIC] non-loopback dynamic ports >=49152 (by process; ports rotate each boot)"
+    $dyn = @($rows | Where-Object { -not $_.Loop -and $_.Dyn } | Sort-Object Proc -Unique)
+    if ($dyn.Count) { $dyn | ForEach-Object { '  {0}{1}' -f $_.Proc,(_sigtag $_) } } else { '  (none)' }
+    "[VOLATILE-LOOPBACK] dev ports (by process; triage only)"
+    $lo = @($rows | Where-Object { $_.Loop } | Sort-Object Proc -Unique)
+    if ($lo.Count) { $lo | ForEach-Object { '  {0}{1}' -f $_.Proc,(_sigtag $_) } } else { '  (none)' }
+}
+
+Add-Section 'E3. SMB SHARES (non-default)' {
+    Get-SmbShare -ErrorAction SilentlyContinue | Where-Object { $_.Name -notmatch '^(ADMIN\$|[A-Z]\$|IPC\$|print\$)$' } |
+      Sort-Object Name | ForEach-Object { '{0,-20} -> {1}' -f $_.Name, $_.Path }
+}
+
+Add-Section 'E4. PORTPROXY FORWARDING (pivot surface)' {
+    $out = netsh interface portproxy show all 2>$null
+    $rows = @($out | Where-Object { $_ -match '^\s*\d' -or $_ -match '^\s*\d+\.\d+\.\d+\.\d+' })
+    if ($rows.Count) { $rows | ForEach-Object { '  ' + ($_ -replace '\s+',' ').Trim() } } else { '(no portproxy rules)' }
+}
+
+Add-Section 'E5. REMOTE-ACCESS SERVICES (state)' {
+    $names = 'TermService','UmRdpService','SessionEnv','sshd','TeamViewer','AnyDesk','tvnserver','winvnc','RustDesk'
+    $any = $false
+    foreach ($n in $names) { $s = Get-Service -Name $n -ErrorAction SilentlyContinue; if ($s) { $any=$true; $flag = if ($s.Status -eq 'Running') { ' [RUNNING]' } else { '' }; '{0,-14} {1} / {2}{3}' -f $s.Name,$s.Status,$s.StartType,$flag } }
+    if (-not $any) { '(no remote-access services present)' }
+}
+
+# ============================================================================
+# F. NETWORK - anomaly / C2
+# ============================================================================
+Add-Section 'F1. OUTBOUND TO PUBLIC IPs (process strict; endpoints volatile)' {
+    $conns = Get-NetTCPConnection -State Established -ErrorAction SilentlyContinue |
+      Where-Object { $_.RemoteAddress -notmatch '^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|127\.|169\.254\.|::1|fe80|0\.0\.0\.0|224\.)' }
+    $rows = foreach ($c in $conns) {
+        $pr = Get-Process -Id $c.OwningProcess -ErrorAction SilentlyContinue
+        [pscustomobject]@{ Proc=$pr.ProcessName; Sig=(Sig-Status $pr.Path); UW=(Is-UserWritable $pr.Path); Remote=$c.RemoteAddress; Port=[int]$c.RemotePort }
+    }
+    "[STABLE] processes making public connections (unsigned/user-writable = alarm)"
+    # sig is NoPath for protected system processes (can't read their image non-admin);
+    # only surface a sig tag when it is a real, non-Valid status on a readable image.
+    $byproc = @($rows | Sort-Object Proc -Unique)
+    if ($byproc.Count) { $byproc | ForEach-Object { $f=''; if($_.Sig -notin 'Valid','NoPath'){$f+=' [SIG:'+$_.Sig+']'}; if($_.UW){$f+=' [USER-WRITABLE]'}; '  {0}{1}' -f $_.Proc,$f } } else { '  (none)' }
+    "[VOLATILE] distinct endpoints (triage only - CDN rotation churns weekly)"
+    $eps = @($rows | Sort-Object Remote,Port -Unique | Select-Object -First 40)
+    if ($eps.Count) { $eps | ForEach-Object { '  {0}:{1} <- {2}' -f $_.Remote,$_.Port,$_.Proc } } else { '  (none)' }
+}
+
+Add-Section 'F2. HOSTS FILE (non-default entries)' {
+    $hf = "$env:windir\System32\drivers\etc\hosts"
+    if (-not (Test-Path $hf)) { '(hosts file absent)'; return }
+    $lines = @(Get-Content $hf | ForEach-Object { $_.Trim() } | Where-Object { $_ -and $_ -notmatch '^#' })
+    if (-not $lines.Count) { '(no active host entries - default)' } else { $lines | Sort-Object | ForEach-Object { "  $_" } }
+}
+
+Add-Section 'F3. DNS SERVERS (physical strict; virtual/VPN volatile)' {
+    $addrs = Get-DnsClientServerAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.ServerAddresses.Count }
+    "[STABLE] physical adapters"
+    $phys = @($addrs | Where-Object { $_.InterfaceAlias -notmatch 'vEthernet|WSL|VPN|Tailscale|TAP|VirtualBox|Hyper-V|Loopback|Bluetooth' } | Sort-Object InterfaceAlias)
+    if ($phys.Count) { $phys | ForEach-Object { '  {0,-24} {1}' -f $_.InterfaceAlias, ($_.ServerAddresses -join ', ') } } else { '  (none)' }
+    "[VOLATILE] virtual/VPN adapters"
+    $virt = @($addrs | Where-Object { $_.InterfaceAlias -match 'vEthernet|WSL|VPN|Tailscale|TAP|VirtualBox|Hyper-V' } | Sort-Object InterfaceAlias)
+    if ($virt.Count) { $virt | ForEach-Object { '  {0,-24} {1}' -f $_.InterfaceAlias, ($_.ServerAddresses -join ', ') } } else { '  (none)' }
+}
+
+Add-Section 'F4. PROXY CONFIGURATION (HKCU Internet Settings)' {
+    $k = Get-ItemProperty 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings' -ErrorAction SilentlyContinue
+    "ProxyEnable  = $($k.ProxyEnable)"
+    "ProxyServer  = $($k.ProxyServer)"
+    "AutoConfigURL= $($k.AutoConfigURL)"
+}
+
+# ============================================================================
+# G. PROCESS & BINARY ANOMALY
+# ============================================================================
+Add-Section 'G1. PROCESSES FROM USER-WRITABLE PATHS (unsigned strict; signed counted)' {
+    # Is-UserWritable is broad (the whole profile), so lots of legit Electron/dev
+    # apps live under AppData - listing them all is noise. The THREAT is an
+    # UNSIGNED/invalid image in a user-writable path, so those are listed in full
+    # (strict-diff surface); validly-signed user-writable processes collapse to a
+    # count line (informational).
+    $procs = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue
+    $byId = @{}; foreach ($p in $procs) { $byId[[int]$p.ProcessId] = $p }
+    $hits = foreach ($p in $procs) {
+        if (Is-UserWritable $p.ExecutablePath) {
+            $par = $byId[[int]$p.ParentProcessId]
+            [pscustomobject]@{ Name=$p.Name; Img=(Norm-Ver $p.ExecutablePath); Sig=(Sig-Status $p.ExecutablePath); Parent=($par.Name) }
+        }
+    }
+    $u = @($hits | Sort-Object Img -Unique)
+    $unsigned = @($u | Where-Object { $_.Sig -ne 'Valid' })
+    $signed   = @($u | Where-Object { $_.Sig -eq 'Valid' })
+    if ($unsigned.Count) { $unsigned | ForEach-Object { '[UNSIGNED] {0,-22} {1}  parent={2}  [SIG:{3}]' -f $_.Name,$_.Img,$_.Parent,$_.Sig } }
+    else { '(no unsigned/invalid processes from user-writable paths)' }
+    "(+ $($signed.Count) validly-signed user-writable processes - benign app baseline, not listed)"
+}
+
+Add-Section 'G2. SYSTEM-PROCESS MASQUERADE (critical names off System32)' {
+    $crit = 'svchost.exe','lsass.exe','services.exe','csrss.exe','winlogon.exe','smss.exe','wininit.exe','spoolsv.exe','taskhostw.exe','explorer.exe'
+    # Anchor the legit-root regex to the REAL SystemRoot, not an unanchored
+    # substring - otherwise a decoy path containing '\Windows\System32\' anywhere
+    # (a user-created folder in the profile) would be treated as legitimate.
+    $sr = [regex]::Escape($env:SystemRoot)
+    $legit = "^$sr\\(System32|SysWOW64|WinSxS)\\|^$sr\\explorer\.exe$"
+    $procs = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $_.Name -in $crit -and $_.ExecutablePath }
+    $bad = @($procs | Where-Object { $_.ExecutablePath -notmatch $legit } | Sort-Object ExecutablePath -Unique)
+    if (-not $bad.Count) { '(none - all critical processes run from the real System32/SysWOW64)' }
+    else { $bad | ForEach-Object { '[MASQUERADE] {0} @ {1}' -f $_.Name,$_.ExecutablePath } }
+}
+
+# ============================================================================
+# H. ACCOUNTS & PRIVILEGE
+# ============================================================================
+Add-Section 'H1. LOCAL USERS (enabled/pw flags)' {
+    Get-LocalUser | Sort-Object Name | ForEach-Object {
+        $flag = ''
+        if ($_.Enabled -and -not $_.PasswordRequired) { $flag += ' [PW-NOT-REQUIRED]' }
+        '{0,-20} Enabled={1,-5} PwReq={2,-5} PwExpires={3}{4}' -f $_.Name,$_.Enabled,$_.PasswordRequired,($_.PasswordExpires),$flag
+    }
+}
+
+Add-Section 'H2. PRIVILEGED GROUP MEMBERSHIP' {
+    # Get-LocalGroupMember THROWS (past -ErrorAction) if a group holds an
+    # unresolvable member SID (deleted account) - which would blank this CRITICAL
+    # lens. Per-group try/catch with a `net localgroup` fallback so one orphaned
+    # SID degrades to a partial result instead of failing the whole section.
+    foreach ($g in 'Administrators','Remote Desktop Users','Remote Management Users','Backup Operators') {
+        # Skip groups that don't exist on this edition (Home lacks some) so the
+        # fallback is only reached for a real orphaned-SID failure.
+        if (-not (Get-LocalGroup -Name $g -ErrorAction SilentlyContinue)) { '{0,-24} (group absent on this edition)' -f $g; continue }
+        try {
+            $m = @(Get-LocalGroupMember -Group $g -ErrorAction Stop)
+            if ($m.Count) { $m | Sort-Object Name | ForEach-Object { '{0,-24} {1} [{2}]' -f $g,$_.Name,$_.ObjectClass } }
+            else { '{0,-24} (empty)' -f $g }
+        } catch {
+            "{0,-24} [Get-LocalGroupMember failed ({1}); net-localgroup fallback:]" -f $g,$_.Exception.GetType().Name
+            # `net` writes to stderr on error; under Stop that becomes a
+            # NativeCommandError, so drop the preference locally for the call.
+            $eap = $ErrorActionPreference; $ErrorActionPreference = 'SilentlyContinue'
+            $raw = & net localgroup "$g" 2>&1
+            $ErrorActionPreference = $eap
+            $inList = $false
+            foreach ($line in @($raw)) {
+                $t = [string]$line
+                if ($t -match '^-{4,}') { $inList = $true; continue }
+                if ($t -match 'completed successfully') { $inList = $false; continue }
+                if ($inList -and $t.Trim()) { '{0,-24} {1}' -f $g, $t.Trim() }
+            }
+        }
+    }
+}
+
+Add-Section 'H3. BUILT-IN ACCOUNT STATE + AUTOLOGON' {
+    Get-LocalUser | Where-Object { $_.Name -in 'Administrator','Guest','DefaultAccount','WDAGUtilityAccount' } |
+      Sort-Object Name | ForEach-Object {
+        $flag = if ($_.Enabled -and $_.Name -in 'Administrator','Guest') { ' [ENABLED-REVIEW]' } else { '' }
+        '{0,-20} Enabled={1}{2}' -f $_.Name,$_.Enabled,$flag
+      }
+    $lg = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -ErrorAction SilentlyContinue
+    $ap = if ([bool]$lg.DefaultPassword) { ' [DEFAULTPASSWORD-STORED]' } else { '' }
+    "AutoAdminLogon=$($lg.AutoAdminLogon) DefaultUserName=$($lg.DefaultUserName)$ap"
+}
+
+Add-Section 'H4. HIDDEN USERS (Winlogon SpecialAccounts UserList)' {
+    $sa = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList'
+    if (-not (Test-Path $sa)) { '(no SpecialAccounts hidden list - default)'; return }
+    $names = @((Get-Item $sa).GetValueNames())
+    if (-not $names.Count) { '(list present but empty)' } else { $names | Sort-Object | ForEach-Object { $v=(Get-Item $sa).GetValue($_); "[HIDDEN-LOGIN-SCREEN] $_ = $v" } }
+}
+
+# ============================================================================
+# I. PATCH & INTEGRITY POSTURE
+# ============================================================================
+Add-Section 'I1. PATCH STALENESS + OS SERVICING' {
+    $hf = Get-HotFix | Where-Object { $_.InstalledOn } | Sort-Object InstalledOn -Descending | Select-Object -First 1
+    if ($hf) { "LastHotfix = $($hf.HotFixID) on $($hf.InstalledOn.ToString('yyyy-MM-dd'))  ($([int]((Get-Date)-$hf.InstalledOn).TotalDays)d ago)" }
+    else { "LastHotfix = (none reported by Get-HotFix)" }
+    if ($os) { "OS build   = $($os.BuildNumber)  installed $($os.InstallDate.ToString('yyyy-MM-dd'))" }
+    $upd = @('wuauserv','UsoSvc','WaaSMedicSvc') | ForEach-Object { $s=Get-Service -Name $_ -EA SilentlyContinue; if($s){ '{0}={1}/{2}' -f $s.Name,$s.Status,$s.StartType } }
+    "WU services: " + ($upd -join '  ')
+    $wu = Get-ItemProperty 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU' -ErrorAction SilentlyContinue
+    $wusvr = Get-ItemProperty 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate' -ErrorAction SilentlyContinue
+    if ($wu.NoAutoUpdate -eq 1) { "[WU-POLICY] NoAutoUpdate=1 (auto-update disabled by policy)" }
+    if ($wusvr.WUServer) { "[WSUS-REDIRECT] WUServer=$($wusvr.WUServer)" }
+}
+
+Add-Section 'I2. UAC / SMARTSCREEN / SIGNING POSTURE' {
+    $sys = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' -ErrorAction SilentlyContinue
+    $lua = if ($sys.EnableLUA -ne 1) { ' [UAC-DISABLED]' } else { '' }
+    "EnableLUA=$($sys.EnableLUA) ConsentPromptBehaviorAdmin=$($sys.ConsentPromptBehaviorAdmin)$lua"
+    $exp = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer' -ErrorAction SilentlyContinue
+    "SmartScreen(Explorer)=$($exp.SmartScreenEnabled)"
+    try { "SecureBoot=" + (Confirm-SecureBootUEFI) } catch { "SecureBoot: " + (Deny-Marker 'Confirm-SecureBootUEFI' $_.Exception) }
+}
+
+Add-Section 'I3. CODE-INTEGRITY EVENTS (unsigned/blocked images)' {
+    $r = Read-Events 'Microsoft-Windows-CodeIntegrity/Operational' @(3033,3034,3004,3010,3077) 30
+    switch ($r.state) {
+        'denied' { Deny-Marker 'CodeIntegrity operational log' $r.err }
+        'empty'  { '(none in window)' }
+        'error'  { throw $r.err }
+        default  { if (-not $r.events.Count) { '(none in window)' } else { $r.events | ForEach-Object { '{0:yyyy-MM-dd HH:mm}  id={1}  {2}' -f $_.TimeCreated,$_.Id,(($_.Message -split "`n")[0].Trim()) } } }
+    }
+}
+
+# ============================================================================
+# J. EVENT-LOG SIGNALS (non-admin, windowed)
+# ============================================================================
+Add-Section 'J1. SERVICE INSTALLED (System 7045)' {
+    $r = Read-Events 'System' @(7045) 50
+    if ($r.state -in 'empty') { '(none in window)'; return }
+    if ($r.state -ne 'ok') { if($r.err){throw $r.err} else {'(none in window)'}; return }
+    if (-not $r.events.Count) { '(none in window)'; return }
+    $r.events | ForEach-Object {
+        $x=[xml]$_.ToXml(); $d=@{}; $x.Event.EventData.Data | ForEach-Object { $d[$_.Name]=$_.'#text' }
+        $img = Norm-Ver $d['ImagePath']
+        $f = if (Is-UserWritable $d['ImagePath']) { ' [USER-WRITABLE]' } else { '' }
+        '{0:yyyy-MM-dd}  svc={1,-24} start={2} img={3}{4}' -f $_.TimeCreated,$d['ServiceName'],$d['StartType'],$img,$f
+    }
+}
+
+Add-Section 'J2. SERVICE START-TYPE CHANGED (System 7040; BITS/updater churn tagged)' {
+    $r = Read-Events 'System' @(7040) 50
+    if ($r.state -ne 'ok' -or -not $r.events.Count) { '(none in window)'; return }
+    $r.events | ForEach-Object {
+        $m = ($_.Message -replace "`r?`n",' ') -replace '\s{2,}',' '
+        $churn = if ($m -match '\b(Background Intelligent Transfer Service|Windows Update|wuauserv|BITS|Update Orchestrator|Windows Modules Installer|TrustedInstaller|WaaSMedic|Delivery Optimization|Windows Search)\b') { ' [CHURN]' } else { '' }
+        '{0:yyyy-MM-dd}{1}  {2}' -f $_.TimeCreated,$churn,$m.Substring(0,[Math]::Min(120,$m.Length))
+    }
+}
+
+Add-Section 'J3. POWERSHELL SUSPICIOUS SCRIPT-BLOCKS (4104; self-excluded)' {
+    # 4104 is HIGH VOLUME when script-block logging is on (this host: ~400/wk), and
+    # Level=3 (Warning) here fires for benign warning-level blocks - NOT an AMSI
+    # "malicious" signal - so we do not use it (it would report ~50 benign hits/run,
+    # including this collector's own blocks). Instead: a conservative regex built
+    # from CONCATENATED fragments so the collector's own source can never self-match,
+    # AND an explicit exclusion of the collector's script path. Reported as a count
+    # baseline + timestamps; keyword scans are noise-prone by nature, so the analysis
+    # treats a small nonzero count as "review if unexpected", not an automatic alarm.
+    $rx = (('Download'+'String'),('Invoke'+'-Expression'),('FromBase64'+'String'),
+           ('-nop'+' -w hidden'),('-e'+'ncodedcommand'),('Reflection.'+'Assembly'),
+           ('Net.'+'WebClient'),('IEX'+'\(')) -join '|'
+    $all = @()
+    try { $all = @(Get-WinEvent -FilterHashtable @{LogName='Microsoft-Windows-PowerShell/Operational';Id=4104;StartTime=$WINDOW} -MaxEvents 1000 -ErrorAction Stop) }
+    catch { if ($_.Exception.Message -match 'No events') { '(no 4104 script-block events in window - script-block logging may be off)'; return } else { throw } }
+    $selfRx = if ($SELF_PATH) { [regex]::Escape((Split-Path -Leaf $SELF_PATH)) } else { '\x00NOMATCH\x00' }
+    $susp = @($all | Where-Object { $_.Message -match $rx -and $_.Message -notmatch $selfRx })
+    "total 4104 in window = $($all.Count)   keyword-suspicious (self-excluded) = $($susp.Count)"
+    if ($susp.Count) { $susp | Select-Object -First 8 | ForEach-Object { '  [REVIEW] {0:yyyy-MM-dd HH:mm}  script block matched suspicious keyword' -f $_.TimeCreated } }
+    else { '  (no suspicious-keyword script blocks - clean)' }
+}
+
+Add-Section 'K. SECURITY-LOG VISIBILITY GAP (consolidated)' {
+    $probe = Read-Events 'Security' @() 1
+    if ($probe.state -eq 'denied') {
+        Deny-Marker 'Security event log' $probe.err
+        "  -> NOT audited non-admin: 4720 new-user, 4722/4724 enable/pwreset, 4728/4732 group-add, 4624/4625 logons, 4672 priv-assign, 1102 clear."
+        "  -> Enable by adding this account to 'Event Log Readers', or run the collector elevated, to light these up."
+    } elseif ($probe.state -eq 'ok') {
+        '(Security log READABLE - account is elevated or in Event Log Readers; account-change events available)'
+    } else {
+        '(Security log state: ' + $probe.state + ')'
+    }
+}
+
+# Test-only fault-injection lens: proves the throw -> '!! COLLECTION ERROR'
+# contract (marker appears, RC stays 0, later sections still render). Placed last
+# so a following section (the assemble step) still renders after it. Never set in
+# production - the scheduled task invokes the collector with no extra args.
+if ($FaultInject) {
+    Add-Section 'ZZ. FAULT-INJECT (test only - expected to error)' { throw 'injected fault (test)' }
+    Add-Section 'ZZ2. POST-FAULT SENTINEL (must still render)' { 'sentinel-ok' }
+}
+
+# ---- assemble + write ------------------------------------------------------
+$report = $sections -join "`r`n"
+
+if ($StdOut) { $report; return }
+
+$taskDir = Join-Path $env:USERPROFILE 'Claude\Scheduled\weekly-security-audit'
+$histDir = Join-Path $BaseDir 'history'
+New-Item -ItemType Directory -Force -Path $BaseDir, $histDir | Out-Null
+
+# Atomic canonical write: render to a temp file in the same dir, then Move-Item
+# over the canonical name. A transient AV/sync lock can then fail the temp write
+# without leaving latest-audit.txt half-written (the analysis reads a whole file).
+$canonical = Join-Path $BaseDir 'latest-audit.txt'
+$tmp = Join-Path $BaseDir (".latest-audit.$PID.tmp")
+$report | Set-Content -Path $tmp -Encoding UTF8
+Move-Item -LiteralPath $tmp -Destination $canonical -Force
+try { if (Test-Path $taskDir) { $report | Set-Content -Path (Join-Path $taskDir 'latest-audit.txt') -Encoding UTF8 } } catch { Write-Warning "task-folder copy: $($_.Exception.Message)" }
+try {
+    $report | Set-Content -Path (Join-Path $histDir ("audit-{0}.txt" -f (Get-Date -Format 'yyyy-MM-dd'))) -Encoding UTF8
+    Get-ChildItem $histDir -Filter 'audit-*.txt' | Sort-Object Name -Descending | Select-Object -Skip 20 | Remove-Item -Force
+} catch { Write-Warning "history: $($_.Exception.Message)" }
+try {
+    foreach ($gd in @((Join-Path $env:USERPROFILE 'My Drive'),'G:\My Drive')) {
+        if (Test-Path $gd) { Copy-Item $canonical (Join-Path $gd 'security-audit-latest.txt') -Force; break }
+    }
+} catch { Write-Warning "drive copy: $($_.Exception.Message)" }

--- a/opt/Desktop/Apps/scripts/security-audit-collect.ps1
+++ b/opt/Desktop/Apps/scripts/security-audit-collect.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+  Read-only weekly security-audit collector. Snapshots the five audit lenses
+  and writes them to text files that the Claude "weekly-security-audit"
+  scheduled task analyzes unattended (no computer-use, no approvals).
+
+.DESCRIPTION
+  Sections (keep formats/filters stable - the analysis baseline depends on them):
+    1. Non-Microsoft auto-start services
+    2. Non-Microsoft active scheduled tasks
+    3. Startup commands (Win32_StartupCommand lens)
+    4. Processes running from AppData\Roaming or AppData\Local\Temp
+    5. Microsoft Defender status
+  Writes:
+    %USERPROFILE%\Claude\SecurityAudit\latest-audit.txt          (canonical)
+    %USERPROFILE%\Claude\Scheduled\weekly-security-audit\latest-audit.txt
+        (the Claude task folder - delivered to the analysis run as its uploads)
+    %USERPROFILE%\Claude\SecurityAudit\history\audit-YYYY-MM-DD.txt (keeps 20)
+    <Google Drive>\security-audit-latest.txt                      (fallback,
+        only when a local Drive sync folder exists)
+  Registered by setup-security-audit.ps1 as user-level task
+  'ClaudeSecurityAuditCollector' (daily, hidden). Runs fine standalone too.
+  Read-only WMI/CIM + Defender queries; no admin, no network calls.
+#>
+$ErrorActionPreference = 'Continue'
+
+$base    = Join-Path $env:USERPROFILE 'Claude\SecurityAudit'
+$taskDir = Join-Path $env:USERPROFILE 'Claude\Scheduled\weekly-security-audit'
+$histDir = Join-Path $base 'history'
+New-Item -ItemType Directory -Force -Path $base, $histDir | Out-Null
+
+$sections = @()
+$sections += "AUDIT TIMESTAMP: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss zzz')"
+$sections += "COMPUTER: $env:COMPUTERNAME  USER: $env:USERNAME"
+
+$sections += "`r`n=== 1. NON-MICROSOFT AUTO-START SERVICES ==="
+$sections += (Get-CimInstance Win32_Service |
+    Where-Object { $_.StartMode -eq 'Auto' -and $_.PathName -notmatch '\\Windows\\' } |
+    Sort-Object DisplayName |
+    Format-Table -Auto State, DisplayName, PathName | Out-String -Width 400).TrimEnd()
+
+$sections += "`r`n=== 2. NON-MICROSOFT ACTIVE SCHEDULED TASKS ==="
+$sections += (Get-ScheduledTask |
+    Where-Object { $_.TaskPath -notmatch '^\\Microsoft' -and $_.State -ne 'Disabled' } |
+    Format-Table -Auto State, TaskPath, TaskName | Out-String -Width 400).TrimEnd()
+
+$sections += "`r`n=== 3. STARTUP COMMANDS ==="
+$sections += (Get-CimInstance Win32_StartupCommand |
+    Format-Table -Auto Name, Location | Out-String -Width 400).TrimEnd()
+
+$sections += "`r`n=== 4. PROCESSES FROM APPDATA/TEMP ==="
+$sections += ((Get-Process |
+    Where-Object { $_.Path -match 'AppData\\(Roaming|Local\\Temp)' } |
+    Select-Object -ExpandProperty Path | Sort-Object -Unique) -join "`r`n")
+
+$sections += "`r`n=== 5. DEFENDER ==="
+$sections += (Get-MpComputerStatus |
+    Format-List RealTimeProtectionEnabled, AntivirusEnabled, AntivirusSignatureLastUpdated, QuickScanEndTime |
+    Out-String).TrimEnd()
+
+$report = $sections -join "`r`n"
+
+$report | Set-Content -Path (Join-Path $base 'latest-audit.txt') -Encoding UTF8
+if (Test-Path $taskDir) {
+    $report | Set-Content -Path (Join-Path $taskDir 'latest-audit.txt') -Encoding UTF8
+}
+$report | Set-Content -Path (Join-Path $histDir ("audit-{0}.txt" -f (Get-Date -Format 'yyyy-MM-dd'))) -Encoding UTF8
+Get-ChildItem $histDir -Filter 'audit-*.txt' | Sort-Object Name -Descending |
+    Select-Object -Skip 20 | Remove-Item -Force
+
+# Optional Google Drive fallback copy (only when Drive for Desktop syncs locally).
+foreach ($gd in @((Join-Path $env:USERPROFILE 'My Drive'), 'G:\My Drive')) {
+    if (Test-Path $gd) {
+        Copy-Item (Join-Path $base 'latest-audit.txt') (Join-Path $gd 'security-audit-latest.txt') -Force
+        break
+    }
+}

--- a/opt/Desktop/Apps/scripts/security-audit-collect.ps1
+++ b/opt/Desktop/Apps/scripts/security-audit-collect.ps1
@@ -11,6 +11,13 @@
     3. Startup commands (Win32_StartupCommand lens)
     4. Processes running from AppData\Roaming or AppData\Local\Temp
     5. Microsoft Defender status
+
+  Every section resolves to exactly one of three states, so the analysis run can
+  never mistake a broken lens for a clean machine:
+    <data>                  - the lens ran and found items
+    (none)                  - the lens ran and found nothing
+    !! COLLECTION ERROR: .. - the lens itself failed (report it, do not read as clean)
+
   Writes:
     %USERPROFILE%\Claude\SecurityAudit\latest-audit.txt          (canonical)
     %USERPROFILE%\Claude\Scheduled\weekly-security-audit\latest-audit.txt
@@ -22,7 +29,12 @@
   'ClaudeSecurityAuditCollector' (daily, hidden). Runs fine standalone too.
   Read-only WMI/CIM + Defender queries; no admin, no network calls.
 #>
-$ErrorActionPreference = 'Continue'
+
+# 'Stop' (not 'Continue') so a failing cmdlet raises a catchable terminating
+# error that Add-Section turns into a visible "!! COLLECTION ERROR" marker.
+# Under 'Continue' the error went to a stderr nobody reads and the section was
+# written EMPTY - indistinguishable from "nothing suspicious found".
+$ErrorActionPreference = 'Stop'
 
 $base    = Join-Path $env:USERPROFILE 'Claude\SecurityAudit'
 $taskDir = Join-Path $env:USERPROFILE 'Claude\Scheduled\weekly-security-audit'
@@ -30,48 +42,93 @@ $histDir = Join-Path $base 'history'
 New-Item -ItemType Directory -Force -Path $base, $histDir | Out-Null
 
 $sections = @()
+
+# Add-Section - run one lens, and record its outcome unambiguously. A lens that
+# throws must never collapse into an empty section (see .DESCRIPTION).
+function Add-Section {
+    param(
+        [Parameter(Mandatory)][string]$Title,
+        [Parameter(Mandatory)][scriptblock]$Body
+    )
+    $script:sections += "`r`n=== $Title ==="
+    try {
+        $out = (& $Body | Out-String -Width 400).TrimEnd()
+        if ([string]::IsNullOrWhiteSpace($out)) { $out = '(none)' }
+        $script:sections += $out
+    } catch {
+        $script:sections += "!! COLLECTION ERROR: $($_.Exception.Message)"
+    }
+}
+
 $sections += "AUDIT TIMESTAMP: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss zzz')"
 $sections += "COMPUTER: $env:COMPUTERNAME  USER: $env:USERNAME"
 
-$sections += "`r`n=== 1. NON-MICROSOFT AUTO-START SERVICES ==="
-$sections += (Get-CimInstance Win32_Service |
-    Where-Object { $_.StartMode -eq 'Auto' -and $_.PathName -notmatch '\\Windows\\' } |
-    Sort-Object DisplayName |
-    Format-Table -Auto State, DisplayName, PathName | Out-String -Width 400).TrimEnd()
+# Path-based "non-Microsoft" heuristic: skip services under \Windows\, EXCEPT
+# \Windows\Temp\ - that directory is user-writable by default and is a classic
+# persistence location, so excluding it would blind the audit's most valuable
+# lens. Services with a null PathName fall through and stay visible on purpose.
+Add-Section '1. NON-MICROSOFT AUTO-START SERVICES' {
+    Get-CimInstance Win32_Service |
+        Where-Object {
+            $_.StartMode -eq 'Auto' -and
+            ($_.PathName -notmatch '\\Windows\\' -or $_.PathName -match '\\Windows\\Temp\\')
+        } |
+        Sort-Object DisplayName |
+        Format-Table -Auto State, DisplayName, PathName
+}
 
-$sections += "`r`n=== 2. NON-MICROSOFT ACTIVE SCHEDULED TASKS ==="
-$sections += (Get-ScheduledTask |
-    Where-Object { $_.TaskPath -notmatch '^\\Microsoft' -and $_.State -ne 'Disabled' } |
-    Format-Table -Auto State, TaskPath, TaskName | Out-String -Width 400).TrimEnd()
+Add-Section '2. NON-MICROSOFT ACTIVE SCHEDULED TASKS' {
+    Get-ScheduledTask |
+        Where-Object { $_.TaskPath -notmatch '^\\Microsoft' -and $_.State -ne 'Disabled' } |
+        Format-Table -Auto State, TaskPath, TaskName
+}
 
-$sections += "`r`n=== 3. STARTUP COMMANDS ==="
-$sections += (Get-CimInstance Win32_StartupCommand |
-    Format-Table -Auto Name, Location | Out-String -Width 400).TrimEnd()
+Add-Section '3. STARTUP COMMANDS' {
+    Get-CimInstance Win32_StartupCommand | Format-Table -Auto Name, Location
+}
 
-$sections += "`r`n=== 4. PROCESSES FROM APPDATA/TEMP ==="
-$sections += ((Get-Process |
-    Where-Object { $_.Path -match 'AppData\\(Roaming|Local\\Temp)' } |
-    Select-Object -ExpandProperty Path | Sort-Object -Unique) -join "`r`n")
+# .Path throws on processes this user cannot open (protected/elevated). Read it
+# per-process inside try/catch so those become $null instead of failing the
+# whole lens - an access-denied on one PID must not hide every other match.
+Add-Section '4. PROCESSES FROM APPDATA/TEMP' {
+    Get-Process -ErrorAction SilentlyContinue |
+        ForEach-Object { try { $_.Path } catch { $null } } |
+        Where-Object { $_ -and $_ -match 'AppData\\(Roaming|Local\\Temp)' } |
+        Sort-Object -Unique
+}
 
-$sections += "`r`n=== 5. DEFENDER ==="
-$sections += (Get-MpComputerStatus |
-    Format-List RealTimeProtectionEnabled, AntivirusEnabled, AntivirusSignatureLastUpdated, QuickScanEndTime |
-    Out-String).TrimEnd()
+Add-Section '5. DEFENDER' {
+    Get-MpComputerStatus |
+        Format-List RealTimeProtectionEnabled, AntivirusEnabled, AntivirusSignatureLastUpdated, QuickScanEndTime
+}
 
 $report = $sections -join "`r`n"
 
+# The canonical copy is the one the pipeline is allowed to fail on: if it cannot
+# be written there is nothing to analyze, so surface a non-zero task result.
 $report | Set-Content -Path (Join-Path $base 'latest-audit.txt') -Encoding UTF8
-if (Test-Path $taskDir) {
-    $report | Set-Content -Path (Join-Path $taskDir 'latest-audit.txt') -Encoding UTF8
-}
-$report | Set-Content -Path (Join-Path $histDir ("audit-{0}.txt" -f (Get-Date -Format 'yyyy-MM-dd'))) -Encoding UTF8
-Get-ChildItem $histDir -Filter 'audit-*.txt' | Sort-Object Name -Descending |
-    Select-Object -Skip 20 | Remove-Item -Force
+
+# Secondary copies are best-effort - a full disk, a locked file, or a missing
+# Drive folder must not discard the canonical report that already succeeded.
+try {
+    if (Test-Path $taskDir) {
+        $report | Set-Content -Path (Join-Path $taskDir 'latest-audit.txt') -Encoding UTF8
+    }
+} catch { Write-Warning "could not write the Claude task-folder copy: $($_.Exception.Message)" }
+
+try {
+    $report | Set-Content -Path (Join-Path $histDir ("audit-{0}.txt" -f (Get-Date -Format 'yyyy-MM-dd'))) -Encoding UTF8
+    # Names are ISO-dated, so a descending lexical sort is newest-first: keep 20.
+    Get-ChildItem $histDir -Filter 'audit-*.txt' | Sort-Object Name -Descending |
+        Select-Object -Skip 20 | Remove-Item -Force
+} catch { Write-Warning "could not update the history folder: $($_.Exception.Message)" }
 
 # Optional Google Drive fallback copy (only when Drive for Desktop syncs locally).
-foreach ($gd in @((Join-Path $env:USERPROFILE 'My Drive'), 'G:\My Drive')) {
-    if (Test-Path $gd) {
-        Copy-Item (Join-Path $base 'latest-audit.txt') (Join-Path $gd 'security-audit-latest.txt') -Force
-        break
+try {
+    foreach ($gd in @((Join-Path $env:USERPROFILE 'My Drive'), 'G:\My Drive')) {
+        if (Test-Path $gd) {
+            Copy-Item (Join-Path $base 'latest-audit.txt') (Join-Path $gd 'security-audit-latest.txt') -Force
+            break
+        }
     }
-}
+} catch { Write-Warning "could not write the Google Drive fallback copy: $($_.Exception.Message)" }

--- a/opt/Desktop/Apps/scripts/security-audit-skill.template.md
+++ b/opt/Desktop/Apps/scripts/security-audit-skill.template.md
@@ -1,0 +1,52 @@
+---
+name: weekly-security-audit
+description: Weekly Windows security check - diff services/startup/scheduled tasks against baseline, verify Defender status
+---
+
+Run the weekly security audit of this Windows machine by ANALYZING THE PRE-COLLECTED
+REPORT. Do NOT use computer use, do NOT call request_access, and do not ask the user to
+paste anything - this task is designed to run fully unattended. Collection is done
+separately by the Windows scheduled task "ClaudeSecurityAuditCollector"
+(security-audit-collect.ps1, installed by dotfiles setup-security-audit.ps1), which
+writes a fresh report daily.
+
+DATA SOURCE (try in order; use the first that works):
+
+1. Read latest-audit.txt from your uploads folder (this task's own folder receives it).
+2. Read %USERPROFILE%\Claude\SecurityAudit\latest-audit.txt (canonical copy).
+3. If a Google Drive connector is available, search it for "security-audit-latest.txt"
+   and read that.
+4. If none are readable: report that the collection pipeline is broken - the Windows
+   task 'ClaudeSecurityAuditCollector' may be missing or failing. Suggest running:
+   powershell -ExecutionPolicy Bypass -File %USERPROFILE%\Desktop\Apps\scripts\setup-security-audit.ps1 -Status
+   Do NOT fall back to computer use.
+
+FRESHNESS: the first line is "AUDIT TIMESTAMP: ...". If it is older than 3 days, note
+the staleness (collector may not be running) but still analyze the data.
+
+THE REPORT has 5 sections: (1) NON-MICROSOFT AUTO-START SERVICES,
+(2) NON-MICROSOFT ACTIVE SCHEDULED TASKS, (3) STARTUP COMMANDS,
+(4) PROCESSES FROM APPDATA/TEMP, (5) DEFENDER.
+
+COMPARE against the BASELINE below and report ONLY:
+
+- new or removed items (identify what a new item belongs to before alarming the user;
+  recommend removal steps only for genuinely unwanted items)
+- anything running from AppData\Roaming, AppData\Local\Temp, Downloads, or other
+  unusual paths
+- Defender problems: real-time protection off, signatures older than ~1 week, or no
+  recent quick scan
+- do NOT flag version-number churn (updater services embed version strings - treat
+  "Vendor Updater Service (NNN)" as the same item across versions)
+- expected: the collector's own artifacts (task 'ClaudeSecurityAuditCollector';
+  Win32 lens quirks vary by machine - see baseline notes once established).
+If everything matches, tell the user in one or two sentences that all is clean.
+
+BASELINE: none recorded yet - BOOTSTRAP MODE. On the first successful run: treat the
+report as the baseline candidate. Summarize each section briefly, ask the user to
+confirm anything unrecognized, then UPDATE THIS TASK (via the scheduled-task update
+tool) embedding the accepted baseline in this section, replacing this bootstrap text.
+On later runs, keep the baseline current the same way: fold in user-accepted changes
+and append a dated line to AUDIT HISTORY below.
+
+AUDIT HISTORY: (none yet)

--- a/opt/Desktop/Apps/scripts/security-audit-skill.template.md
+++ b/opt/Desktop/Apps/scripts/security-audit-skill.template.md
@@ -1,62 +1,142 @@
 ---
 name: weekly-security-audit
-description: Weekly Windows security check - diff services/startup/scheduled tasks against baseline, verify Defender status
+description: Weekly Windows security audit - diff a pre-collected read-only anomaly report (persistence, defense-evasion, network, process, accounts, posture) against a saved baseline and report only genuine surprises. Unattended, no computer use.
 ---
 
 Run the weekly security audit of this Windows machine by ANALYZING THE PRE-COLLECTED
 REPORT. Do NOT use computer use, do NOT call request_access, and do not ask the user to
-paste anything - this task is designed to run fully unattended. Collection is done
-separately by the Windows scheduled task "ClaudeSecurityAuditCollector"
-(security-audit-collect.ps1, installed by dotfiles setup-security-audit.ps1), which
-writes a fresh report daily.
+paste anything - this task runs fully unattended. Collection is done separately by the
+Windows scheduled task "ClaudeSecurityAuditCollector" (security-audit-collect.ps1,
+installed by dotfiles setup-security-audit.ps1), which writes a fresh read-only report
+daily. You never run commands; you read one text file and reason about it.
 
-DATA SOURCE (try in order; use the first that works):
+## DATA SOURCE (try in order; use the first that works)
 
-1. Read latest-audit.txt from your uploads folder (this task's own folder receives it).
-2. Read %USERPROFILE%\Claude\SecurityAudit\latest-audit.txt (canonical copy).
-3. If a Google Drive connector is available, search it for "security-audit-latest.txt"
-   and read that.
-4. If none are readable: report that the collection pipeline is broken - the Windows
-   task 'ClaudeSecurityAuditCollector' may be missing or failing. Suggest running:
-   powershell -ExecutionPolicy Bypass -File %USERPROFILE%\Desktop\Apps\scripts\setup-security-audit.ps1 -Status
+1. Read `latest-audit.txt` from your uploads folder (this task's own folder receives it).
+2. Read `%USERPROFILE%\Claude\SecurityAudit\latest-audit.txt` (canonical copy).
+3. If a Google Drive connector is available, search it for `security-audit-latest.txt`.
+4. If none are readable: report that the collection pipeline is broken - the Windows task
+   `ClaudeSecurityAuditCollector` may be missing or failing. Suggest running:
+   `powershell -ExecutionPolicy Bypass -File %USERPROFILE%\Desktop\Apps\scripts\setup-security-audit.ps1 -Status`
    Do NOT fall back to computer use.
 
-FRESHNESS: the first line is "AUDIT TIMESTAMP: ...". If it is older than 3 days, note
-the staleness (collector may not be running) but still analyze the data.
+## REPORT SHAPE
 
-THE REPORT has 5 sections: (1) NON-MICROSOFT AUTO-START SERVICES,
-(2) NON-MICROSOFT ACTIVE SCHEDULED TASKS, (3) STARTUP COMMANDS,
-(4) PROCESSES FROM APPDATA/TEMP, (5) DEFENDER.
+The header carries `AUDIT TIMESTAMP`, `COLLECTOR: vN`, `WINDOW: Nd`, `ELEVATED`, host, and
+OS build. Then ~30 lettered sections (A1..K). **Every section resolves to exactly one of
+these four states — they mean very different things, so tell them apart:**
 
-SECTION STATES - each section is exactly one of these; do not confuse the last two:
+- **`<data lines>`** - the lens found items; analyze them.
+- **`(none)`** / `<empty>` / `<absent>` - the lens ran and genuinely found nothing. CLEAN.
+- **`!! COLLECTION ERROR: <msg>`** - the lens itself FAILED. This is NOT clean. Report the
+  section as *unverified this run* and quote the error. Never summarize the machine as clean
+  while any COLLECTION ERROR is present.
+- **`## ADMIN-REQUIRED (<Type>): <what>`** - the data needs elevation the collector does not
+  have (Security event log, Secure Boot). This is an EXPECTED, standing coverage gap, not an
+  anomaly. State once that these lenses are unavailable non-admin; do not re-alarm each week.
+- **`HIDDEN-BY-POLICY (contents UNKNOWN without elevation)`** (C2 exclusions) - the same kind
+  of standing gap: `HideExclusionsFromLocalUsers=True` hides Defender exclusion CONTENTS from a
+  non-admin. Treat it exactly like `## ADMIN-REQUIRED` (note once, don't re-alarm). The only
+  non-admin signal that an exclusion CHANGED is a C4 `[EXCLUSION-CHANGE]` event - that IS
+  CRITICAL.
 
-- items listed        -> analyze them normally against the baseline.
-- "(none)"            -> the lens ran and genuinely found nothing. Clean.
-- `!! COLLECTION ERROR: <msg>` -> the lens FAILED. This is NOT a clean result.
-  Report the section as unverified this run, quote the message, and say which
-  lens is blind. Never summarize a machine as "all clean" when any section
-  carries a COLLECTION ERROR - say explicitly which lenses did and did not run.
+Many sections split into **`[STABLE]`** and **`[VOLATILE]`** blocks. Strict-diff the STABLE
+block (any change = investigate). The VOLATILE block (ephemeral ports, per-run outbound
+endpoints, virtual-adapter DNS, dynamic RPC ports) is for triage only - **do NOT alarm on
+its churn**; use it only to corroborate a STABLE-block finding.
 
-COMPARE against the BASELINE below and report ONLY:
+**Event-log sections** (C3, C4, D1, I3, J1, J2) list dated events inside the window. Compare
+the *set and kind* of events against the baseline, not exact timestamps. Lines tagged
+`[CHURN]` (BITS/Windows-Update/servicing start-type flapping) are benign noise - ignore
+unless the target is a *security* service being disabled.
 
-- new or removed items (identify what a new item belongs to before alarming the user;
-  recommend removal steps only for genuinely unwanted items)
-- anything running from AppData\Roaming, AppData\Local\Temp, Downloads, or other
-  unusual paths
-- Defender problems: real-time protection off, signatures older than ~1 week, or no
-  recent quick scan
-- do NOT flag version-number churn (updater services embed version strings - treat
-  "Vendor Updater Service (NNN)" as the same item across versions)
-- expected: the collector's own artifacts (task 'ClaudeSecurityAuditCollector';
-  Win32 lens quirks vary by machine - see baseline notes once established).
-If everything matches AND every section ran (no COLLECTION ERROR), tell the user in
-one or two sentences that all is clean.
+**A `[SIG:*]` or `[USER-WRITABLE]` tag is alarm-worthy WHEREVER it appears - including inside a
+`[VOLATILE]` block.** The volatile-block rule ignores the *identity* that churns (the ephemeral
+port number, the specific remote endpoint), NOT the signature verdict on the owning process: an
+unsigned / user-writable process listening on a dynamic port (E2 `[VOLATILE-DYNAMIC]`) or holding
+a public connection is a real backdoor indicator. Read every block for those two tags; only
+suppress churn on the port/endpoint identity itself.
 
-BASELINE: none recorded yet - BOOTSTRAP MODE. On the first successful run: treat the
-report as the baseline candidate. Summarize each section briefly, ask the user to
-confirm anything unrecognized, then UPDATE THIS TASK (via the scheduled-task update
-tool) embedding the accepted baseline in this section, replacing this bootstrap text.
-On later runs, keep the baseline current the same way: fold in user-accepted changes
-and append a dated line to AUDIT HISTORY below.
+## FRESHNESS
+
+The first line is `AUDIT TIMESTAMP: ...`. If it is older than 3 days, note the staleness
+(the collector may not be running - suggest `-Status`) but still analyze the data.
+
+## HOW TO TRIAGE - severity tiers
+
+Report findings grouped by severity, most-severe first. Report **only deltas from baseline
+and standing red flags** - never re-list the whole benign inventory.
+
+- **CRITICAL (act now)** - real-time protection / tamper protection OFF (C1); a firewall profile
+  DISABLED (E1); UAC disabled `EnableLUA=0` (I2); a NEW member of Administrators (H2); an enabled
+  Administrator/Guest account that was disabled (H3); a Defender `[EXCLUSION-CHANGE]` or
+  `[REALTIME-DISABLED]` event (C4); **a Defender detection event (C3, 1116/1117 = live malware
+  hit)**; **any change to Winlogon `Shell`/`Userinit` beyond the exact defaults, or any HKCU
+  Winlogon value set (A3)**; **any IFEO `Debugger` or non-empty `AppInit_DLLs` (A4)**; **any value
+  appearing in A2 (`Policies\Explorer\Run`/`RunOnceEx` - these should be empty)**; a new WMI
+  `__EventConsumer` running a command/script (B4); a new `COR_PROFILER`/`UserInitMprLogonScript`
+  or handler-hijack (A6/A7); an unsigned service or process from a user-writable path (B1/G1); a
+  `[MASQUERADE]` critical process off System32 (G2); a new listener on an exposed well-known port,
+  or ANY listener/connection whose process carries a `[SIG:*]`/`[USER-WRITABLE]` tag (E2/F1); a new
+  portproxy rule (E4); a rogue DNS server on a physical adapter (F3); a hosts-file entry hijacking
+  a security/OS domain (F2); **`Security log cleared` OR `System log cleared` (D1 - anti-forensics)**;
+  a new `AutoAdminLogon`/`[DEFAULTPASSWORD-STORED]` (H3); a new `[HIDDEN-LOGIN-SCREEN]` user (H4).
+- **WARN (review)** - a new non-Microsoft auto-start service or scheduled task (B1/B2 - identify
+  what it belongs to first); **a new Run-key value (A1) or Startup-folder item (B3) or COM
+  server (A5)**; a new `[SUSPICIOUS-ACTION]` task (B2); a new CodeIntegrity unsigned-load target
+  that is not a known browser/vendor (I3); a new 7045 service install, especially `[USER-WRITABLE]`
+  (J1); a new remote-access service present/running (E5); a password-not-required enabled account
+  (H1); proxy `ProxyServer`/`AutoConfigURL` newly set (F4); a jump in `keyword-suspicious` 4104
+  count with `[REVIEW]` lines you can't explain (J3).
+- **INFO (note, don't alarm)** - version-string churn in paths/names/services; VOLATILE-block
+  *identity* changes (ports/endpoints); `[CHURN]` start-type flaps; benign vendor updater
+  services/tasks re-registering; new patches; per-run outbound endpoint rotation; the drift of
+  `SignatureAge(days)`, `LastQuickScanEnd`, `records=N`, `(Nd ago)`, and the suppressed-count
+  lines in C4/J3 (all increment normally). **But: a `records=N` that DROPS on any channel (D2)
+  corroborates a D1 log-clear - escalate that; and a `SignatureAge` above ~7 days (C1) is a WARN.**
+
+## KNOWN-BENIGN PATTERNS (do NOT flag these)
+
+- **Version churn**: treat `Vendor Updater Service (148.0.7778)` and `...(150.0.8001)` as the
+  same item; the collector already normalizes many versions to `X.X` - ignore residual churn.
+- **Vendor autostarts**: browser/updater/vendor tray services and tasks (Chrome/Edge auto-launch,
+  OneDrive, Discord/Slack/Spotify/Steam/Zoom updaters, Razer/Asus/vendor services) are baseline.
+- **Browser CodeIntegrity events**: Chrome/Edge loading `vulkan-1.dll`/`vk_swiftshader.dll`, and
+  screen-capture hooks (OBS `graphics-hook64.dll`) flagged by CodeIntegrity, are routine - note
+  only a NEW, non-browser, non-vendor unsigned-load target.
+- **The collector's own artifacts**: the `ClaudeSecurityAuditCollector` task; the benign built-in
+  WMI `SCM Event Log Filter`; this dotfiles machine's own `macOS Hotkeys` / PowerToys tasks.
+- **Servicing churn**: 5007 "configuration changed" volume (already suppressed to a count),
+  BITS/TrustedInstaller/WaaSMedic `[CHURN]` start-type flaps.
+
+Always identify what a new item belongs to before alarming, and recommend removal steps only
+for genuinely unwanted items. Do NOT propose changing configuration the user runs deliberately
+(firewall posture, installed vendor tools, the portproxy the user set up) - only surface the
+*surprise*.
+
+## BASELINE
+
+BASELINE: none recorded yet - **BOOTSTRAP MODE**. On the first successful run: treat the report
+as the baseline candidate. Summarize each section group briefly (persistence / defense-evasion /
+network / process / accounts / posture), then UPDATE THIS TASK (via the scheduled-task update
+tool) embedding the accepted baseline in the section below, replacing this bootstrap text. Record
+per-section what is known-good on THIS host (the services, tasks, Run keys, listeners, admin-group
+members, portproxy rules, WMI subscriptions) so later runs diff against it. On later runs, keep
+the baseline current the same way: fold in user-accepted changes and append a dated line to
+AUDIT HISTORY.
+
+**Baseline-poisoning guard (first run only).** The first snapshot is auto-accepted as ground
+truth, so if the host is ALREADY compromised at bootstrap the persistence gets baked in as
+"known-good" and never alarms again. So on the FIRST run, do NOT silently baseline the
+higher-risk items - explicitly LIST them in the report for the user to confirm before they
+become baseline: any unsigned service or user-writable-path autostart (B1/G1), every
+Administrators member (H2), any WMI `__EventConsumer` (B4), any portproxy rule (E4), any
+non-empty A2/A6/A7 entry, and any enabled non-standard local user (H1/H3). Frame them as "please
+confirm these are expected" rather than as alarms. Everything else may be baselined silently.
+
+If everything matches the baseline AND every section ran (no COLLECTION ERROR), tell the user in
+one or two sentences that all is clean, noting the standing ADMIN-REQUIRED coverage gaps once.
+
+BASELINE DATA: (none yet - bootstrap)
 
 AUDIT HISTORY: (none yet)

--- a/opt/Desktop/Apps/scripts/security-audit-skill.template.md
+++ b/opt/Desktop/Apps/scripts/security-audit-skill.template.md
@@ -28,6 +28,15 @@ THE REPORT has 5 sections: (1) NON-MICROSOFT AUTO-START SERVICES,
 (2) NON-MICROSOFT ACTIVE SCHEDULED TASKS, (3) STARTUP COMMANDS,
 (4) PROCESSES FROM APPDATA/TEMP, (5) DEFENDER.
 
+SECTION STATES - each section is exactly one of these; do not confuse the last two:
+
+- items listed        -> analyze them normally against the baseline.
+- "(none)"            -> the lens ran and genuinely found nothing. Clean.
+- `!! COLLECTION ERROR: <msg>` -> the lens FAILED. This is NOT a clean result.
+  Report the section as unverified this run, quote the message, and say which
+  lens is blind. Never summarize a machine as "all clean" when any section
+  carries a COLLECTION ERROR - say explicitly which lenses did and did not run.
+
 COMPARE against the BASELINE below and report ONLY:
 
 - new or removed items (identify what a new item belongs to before alarming the user;
@@ -40,7 +49,8 @@ COMPARE against the BASELINE below and report ONLY:
   "Vendor Updater Service (NNN)" as the same item across versions)
 - expected: the collector's own artifacts (task 'ClaudeSecurityAuditCollector';
   Win32 lens quirks vary by machine - see baseline notes once established).
-If everything matches, tell the user in one or two sentences that all is clean.
+If everything matches AND every section ran (no COLLECTION ERROR), tell the user in
+one or two sentences that all is clean.
 
 BASELINE: none recorded yet - BOOTSTRAP MODE. On the first successful run: treat the
 report as the baseline candidate. Summarize each section briefly, ask the user to

--- a/opt/Desktop/Apps/scripts/setup-security-audit.ps1
+++ b/opt/Desktop/Apps/scripts/setup-security-audit.ps1
@@ -1,0 +1,119 @@
+<#
+.SYNOPSIS
+  Install (or remove) the unattended weekly security-audit pipeline:
+  a user-level Windows scheduled task that collects audit data daily, plus
+  the Claude "weekly-security-audit" analysis task prompt (seeded if absent).
+  Opt-in: gated at the install.sh call site by gff flag
+  install.windows.security-audit (boolDefault: false, fail-closed).
+
+.DESCRIPTION
+  Why two halves: Claude's scheduled runs cannot approve computer-use access,
+  and terminals are never typeable by Claude, so interactive collection can
+  never be unattended. Decoupling fixes it - Windows Task Scheduler runs
+  security-audit-collect.ps1 (read-only queries) and writes text reports;
+  Claude's weekly task just reads latest-audit.txt from its own task folder
+  and diffs it against the baseline kept in its SKILL.md.
+
+  This installer (no admin needed - a per-user task):
+    1. Copies security-audit-collect.ps1 to %USERPROFILE%\Claude\SecurityAudit
+       (NOT run from the Desktop: OneDrive dehydration can break Desktop runs).
+    2. Registers user-level task 'ClaudeSecurityAuditCollector'
+       (daily at -At, hidden window, battery-friendly, StartWhenAvailable).
+    3. Seeds %USERPROFILE%\Claude\Scheduled\weekly-security-audit\SKILL.md from
+       security-audit-skill.template.md ONLY when missing - never overwrites,
+       because audit runs evolve the baseline inside that file.
+    4. Runs the first collection immediately.
+  Registering the Claude-side schedule itself is app-managed: after install,
+  tell Claude "schedule the weekly-security-audit task for Saturday 10:00".
+
+.PARAMETER At
+  Daily collection time (default 09:00 - keep it before the Claude analysis).
+
+.PARAMETER Uninstall
+  Remove the scheduled task and installed collector (keeps collected data and
+  the Claude task folder; prints what was kept).
+
+.PARAMETER Status
+  Report task state, last/next run times, and report freshness, then exit.
+
+.EXAMPLE
+  powershell -ExecutionPolicy Bypass -File setup-security-audit.ps1
+  powershell -ExecutionPolicy Bypass -File setup-security-audit.ps1 -Status
+  powershell -ExecutionPolicy Bypass -File setup-security-audit.ps1 -Uninstall
+#>
+param(
+    [string]$At = '09:00',
+    [switch]$Uninstall,
+    [switch]$Status
+)
+$ErrorActionPreference = 'Stop'
+
+$taskName  = 'ClaudeSecurityAuditCollector'
+$base      = Join-Path $env:USERPROFILE 'Claude\SecurityAudit'
+$collector = Join-Path $base 'security-audit-collect.ps1'
+$claudeDir = Join-Path $env:USERPROFILE 'Claude\Scheduled\weekly-security-audit'
+$skillMd   = Join-Path $claudeDir 'SKILL.md'
+$latest    = Join-Path $base 'latest-audit.txt'
+
+if ($Status) {
+    $t = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+    if ($t) {
+        $info = $t | Get-ScheduledTaskInfo
+        Write-Host "Task    : $taskName  [$($t.State)]"
+        Write-Host "LastRun : $($info.LastRunTime)  (result $($info.LastTaskResult))"
+        Write-Host "NextRun : $($info.NextRunTime)"
+    } else { Write-Host "Task    : $taskName NOT registered" }
+    if (Test-Path $latest) {
+        $f = Get-Item $latest
+        Write-Host "Report  : $latest"
+        Write-Host "Written : $($f.LastWriteTime)  ($([int]((Get-Date) - $f.LastWriteTime).TotalHours)h ago)"
+    } else { Write-Host "Report  : none at $latest" }
+    Write-Host "Claude  : $(if (Test-Path $skillMd) { "SKILL.md present at $claudeDir" } else { 'SKILL.md not seeded' })"
+    return
+}
+
+if ($Uninstall) {
+    if (Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue) {
+        Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+        Write-Host "Removed scheduled task $taskName"
+    } else { Write-Host "No scheduled task $taskName (nothing to remove)" }
+    if (Test-Path $collector) { Remove-Item $collector -Force; Write-Host "Removed $collector" }
+    Write-Host "Kept: $base (history/reports) and $claudeDir (Claude task + baseline)."
+    Write-Host "Delete those folders manually if you want a full wipe."
+    return
+}
+
+# --- 1. Install the collector to its permanent, OneDrive-free home ----------
+New-Item -ItemType Directory -Force -Path $base | Out-Null
+Copy-Item -Force (Join-Path $PSScriptRoot 'security-audit-collect.ps1') $collector
+Write-Host "Installed collector: $collector"
+
+# --- 2. Register the user-level daily task (no admin) -----------------------
+$action   = New-ScheduledTaskAction -Execute 'powershell.exe' `
+            -Argument ('-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{0}"' -f $collector)
+$trigger  = New-ScheduledTaskTrigger -Daily -At $At
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+            -StartWhenAvailable -ExecutionTimeLimit (New-TimeSpan -Minutes 10) -MultipleInstances IgnoreNew
+Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Force | Out-Null
+Write-Host "Registered task '$taskName' (daily at $At, StartWhenAvailable)."
+
+# --- 3. Seed the Claude analysis task prompt (never overwrite) ---------------
+if (-not (Test-Path $skillMd)) {
+    New-Item -ItemType Directory -Force -Path $claudeDir | Out-Null
+    Copy-Item (Join-Path $PSScriptRoot 'security-audit-skill.template.md') $skillMd
+    Write-Host "Seeded Claude analysis task prompt: $skillMd"
+    Write-Host "  -> Finish once in the Claude app: 'schedule the weekly-security-audit task for Saturday 10:00'."
+} else {
+    Write-Host "Claude task prompt already present (left untouched): $skillMd"
+}
+
+# --- 4. First collection now, so the pipeline is verified end-to-end --------
+Write-Host "Running first collection..."
+& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $collector
+if (Test-Path $latest) {
+    $f = Get-Item $latest
+    Write-Host "OK: $($f.FullName) ($($f.Length) bytes, $($f.LastWriteTime))"
+} else {
+    Write-Warning "collector ran but $latest was not created - investigate before relying on it."
+}
+Write-Host "Done. Check state anytime with: setup-security-audit.ps1 -Status"

--- a/opt/Desktop/Apps/scripts/setup-security-audit.ps1
+++ b/opt/Desktop/Apps/scripts/setup-security-audit.ps1
@@ -42,6 +42,10 @@
   powershell -ExecutionPolicy Bypass -File setup-security-audit.ps1 -Uninstall
 #>
 param(
+    # Validated here rather than letting New-ScheduledTaskTrigger fail later:
+    # -At is parsed culture-sensitively, so an unvalidated string can register a
+    # task at an unintended hour instead of erroring. HH:mm, 24-hour, only.
+    [ValidatePattern('^([01]\d|2[0-3]):[0-5]\d$')]
     [string]$At = '09:00',
     [switch]$Uninstall,
     [switch]$Status

--- a/opt/bin/install_windows.sh
+++ b/opt/bin/install_windows.sh
@@ -32,15 +32,20 @@ if [ -z "$BASE_DIR" ]; then
   exit 1
 fi
 
-# gff gate (fail-open): source the helper relative to THIS script's location so
-# direct runs work too; a missing helper must never block the deploy, so stub
-# gff_on/gff_skip_msg to "always run" when the lib is absent.
+# gff gate: source the helper relative to THIS script's location so direct runs
+# work too. Stubs mirror each helper's DIRECTION when the lib is absent:
+#   gff_on      fail-OPEN  — a missing helper must never block the deploy.
+#   gff_opt_in  fail-CLOSED — an opt-in step must never install itself by
+#               accident. Without this stub the call would merely be a
+#               "command not found" (rc 127) that happens to read as false;
+#               state the contract explicitly rather than lean on that.
 _gff_lib="$(cd -- "$(dirname "$0")" && pwd -P)/../lib/gff.sh"
 if [ -f "$_gff_lib" ]; then
   # shellcheck source=opt/lib/gff.sh
   . "$_gff_lib"
 else
   gff_on() { return 0; }
+  gff_opt_in() { return 1; }
   gff_skip_msg() { echo "SKIP (gff: $1=false)"; }
 fi
 # Choice persistence + gff-owned skip state (needs gff_on, so sourced after).

--- a/opt/bin/install_windows.sh
+++ b/opt/bin/install_windows.sh
@@ -179,25 +179,30 @@ deploy_windows_files() {
   cp -r --remove-destination "${BASE_DIR}/opt/Desktop/." "${win_desktop}/"
 }
 
-run_windows_customization() {
-  echo "Starting Windows customization... (this may take a few minutes)"
-
-  # -------------------------------------------------------------------------
-  # gff flag pass-through: append every exported GFF_INSTALL_WINDOWS_* name to
-  # WSLENV (/w = include when invoking Win32 from WSL) BEFORE the powershell.exe
-  # invocation, so the PowerShell setup scripts' Test-GffOn gates see the same
-  # flags. NOTE: the flag was originally /u per the plan — refuted empirically
-  # 2026-07-26 (P2-T5): /u means Win32->WSL only, so the vars never crossed;
-  # /w is the WSL->Win32 direction (learn.microsoft.com WSLENV flags). Runs at
-  # DEFERRED time — after install.sh's gff bootstrap `set -a` export — and
-  # de-duplicates, so re-runs never grow WSLENV. Unset vars simply never appear
-  # (fail-open on the Windows side too).
-  # -------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# gff flag pass-through: append every exported GFF_INSTALL_WINDOWS_* name to
+# WSLENV (/w = include when invoking Win32 from WSL) BEFORE a powershell.exe
+# invocation, so the PowerShell setup scripts' Test-GffOn/Test-GffOptIn gates
+# see the same flags. NOTE: the flag was originally /u per the plan — refuted
+# empirically 2026-07-26 (P2-T5): /u means Win32->WSL only, so the vars never
+# crossed; /w is the WSL->Win32 direction (learn.microsoft.com WSLENV flags).
+# Called at DEFERRED time — after install.sh's gff bootstrap `set -a` export —
+# and de-duplicates, so repeat calls never grow WSLENV. Unset vars simply never
+# appear (fail-open on the Windows side too).
+# -----------------------------------------------------------------------------
+export_gff_wslenv() {
   _gff_wslenv="${WSLENV:-}"
   for _v in $(env | sed -n 's/^\(GFF_INSTALL_WINDOWS_[A-Z_]*\)=.*/\1/p'); do
     case ":${_gff_wslenv}:" in *":${_v}/w:"*) : ;; *) _gff_wslenv="${_gff_wslenv:+${_gff_wslenv}:}${_v}/w" ;; esac
   done
   export WSLENV="${_gff_wslenv}"
+}
+
+run_windows_customization() {
+  echo "Starting Windows customization... (this may take a few minutes)"
+
+  # gff flag pass-through to the powershell.exe child (see export_gff_wslenv).
+  export_gff_wslenv
 
   # setup-apps.ps1 does the non-elevated app installs, then fires ONE
   # Start-Process -Verb RunAs (setup-elevated.ps1) that performs all admin work
@@ -232,6 +237,43 @@ run_windows_customization() {
   : > "$WIN_SETUP_MARKER"
 }
 
+# -----------------------------------------------------------------------------
+# Opt-in unattended security-audit pipeline (docs/security-audit.md). FAIL-
+# CLOSED: unlike every other windows step, this runs ONLY when
+# install.windows.security-audit resolves to exactly 'true'
+# (gff set install.windows.security-audit true) — an audit installer must never
+# appear on a machine by accident, so absent-gff/unset means SKIP (gff_opt_in).
+# Independent of the y/n/s customization answer: it rides --deferred right
+# after the file deploy, so the deployed Desktop scripts are guaranteed present.
+# -----------------------------------------------------------------------------
+run_security_audit_setup() {
+  if ! gff_opt_in install.windows.security-audit; then
+    echo "SKIP (gff: install.windows.security-audit is opt-in and not enabled)"
+    return 0
+  fi
+  if [ -z "${ps_exe:-}" ] || [ -z "${win_desktop:-}" ] || [ ! -d "${win_desktop}" ]; then
+    echo "WARNING: Windows paths unresolved; cannot run security-audit setup." >&2
+    return 0
+  fi
+  export_gff_wslenv
+  _ssa_ps1_w="$(wslpath -w "${win_desktop}/Apps/scripts/setup-security-audit.ps1" 2>/dev/null || true)"
+  if [ -z "${_ssa_ps1_w}" ]; then
+    echo "WARNING: could not resolve setup-security-audit.ps1 as a Windows path; skipping." >&2
+    return 0
+  fi
+  echo "Setting up the unattended security-audit pipeline (opt-in flag is ON)..."
+  # Same rc-capture pattern as setup-apps.ps1: never die silently under set -e;
+  # always surface the log. </dev/null: powershell.exe eats parent stdin (above).
+  _ssa_rc=0
+  "$ps_exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "${_ssa_ps1_w}" </dev/null > /tmp/setup_security_audit.log 2>&1 || _ssa_rc=$?
+  cat /tmp/setup_security_audit.log
+  if [ "${_ssa_rc}" -ne 0 ]; then
+    echo "WARNING: setup-security-audit.ps1 exited with code ${_ssa_rc} — see the output above." >&2
+    echo "         Re-run standalone: powershell.exe -ExecutionPolicy Bypass -File \"${_ssa_ps1_w}\"" >&2
+  fi
+  return 0
+}
+
 case "$MODE" in
   --ask)
     # Skip state: legacy sentinel (migrated when gff is available) or the gff
@@ -255,6 +297,7 @@ case "$MODE" in
     # behavior where the file deploy preceded the prompt); the customization
     # and the permanent-skip recording follow the recorded choice.
     deploy_windows_files
+    run_security_audit_setup
     case "$(winsetup_take_choice)" in
       y) run_windows_customization ;;
       s) winsetup_record_skip ;;
@@ -264,6 +307,7 @@ case "$MODE" in
   --full|*)
     winsetup_skip_state && exit 0
     deploy_windows_files
+    run_security_audit_setup
     print_prompt_text
     case "$(winsetup_ask)" in
       __notty__) notty_guidance ;;

--- a/opt/lib/gff.sh
+++ b/opt/lib/gff.sh
@@ -20,4 +20,3 @@ gff_opt_in() {
   eval "_gff_val=\${GFF_${_gff_key}:-}"
   [ "${_gff_val}" = "true" ]
 }
-

--- a/opt/lib/gff.sh
+++ b/opt/lib/gff.sh
@@ -8,3 +8,16 @@ gff_on() {
   [ "${_gff_val}" != "false" ]
 }
 gff_skip_msg() { echo "SKIP (gff: $1=false)"; }
+
+# gff_opt_in - FAIL-CLOSED gate for opt-in steps (boolDefault: false in
+# features.yaml): the step runs ONLY when the resolved flag is exactly 'true'
+# (via gff set <key> true). Complements the fail-open gff_on above: an opt-in
+# step must never run by accident on a machine where gff or the flag export is
+# missing, so unset/absent => skip.
+# shellcheck disable=SC2154 # _gff_val is assigned by the eval one line above its use
+gff_opt_in() {
+  _gff_key=$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]' | tr '.-' '__')
+  eval "_gff_val=\${GFF_${_gff_key}:-}"
+  [ "${_gff_val}" = "true" ]
+}
+

--- a/opt/lib/gff_test.sh
+++ b/opt/lib/gff_test.sh
@@ -38,6 +38,21 @@ assert_gff_on() {
     fi
 }
 
+# usage: assert_gff_opt_in <expected_rc> <key> <label>
+# Caller prepares the relevant GFF_* variable (set/unset) before calling.
+assert_gff_opt_in() {
+    _expected="$1"; _akey="$2"; _label="$3"
+    gff_opt_in "$_akey"
+    _rc=$?
+    if [ "$_rc" -eq "$_expected" ]; then
+        echo "PASS: $_label (exit $_rc)"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL: $_label (expected $_expected, got $_rc)"
+        FAIL=$((FAIL+1))
+    fi
+}
+
 # usage: assert_out <expected_string> <actual_string> <label>
 assert_out() {
     if [ "$2" = "$1" ]; then
@@ -76,6 +91,53 @@ assert_gff_on 1 install.windows.wispr-flow \
 unset GFF_INSTALL_WINDOWS_WISPR_FLOW 2>/dev/null || true
 assert_gff_on 0 install.windows.wispr-flow "mangled var unset again => run"
 
+# === fail-CLOSED semantics: only the literal lowercase "true" enables ===
+# gff_opt_in is the deliberate inversion of gff_on, used for boolDefault:false
+# steps (install.windows.security-audit). Anything that is not exactly "true" —
+# including an unset var, an absent gff, or a garbage value — must SKIP, so an
+# opt-in installer can never appear on a machine by accident.
+unset GFF_INSTALL_WINDOWS_SECURITY_AUDIT 2>/dev/null || true
+assert_gff_opt_in 1 install.windows.security-audit "opt-in: var unset => skip (fail-closed)"
+
+GFF_INSTALL_WINDOWS_SECURITY_AUDIT=true
+assert_gff_opt_in 0 install.windows.security-audit "opt-in: =true => run (the only enabling value)"
+
+GFF_INSTALL_WINDOWS_SECURITY_AUDIT=false
+assert_gff_opt_in 1 install.windows.security-audit "opt-in: =false => skip"
+
+GFF_INSTALL_WINDOWS_SECURITY_AUDIT=TRUE
+assert_gff_opt_in 1 install.windows.security-audit "opt-in: =TRUE => skip (uppercase is not true)"
+
+GFF_INSTALL_WINDOWS_SECURITY_AUDIT=1
+assert_gff_opt_in 1 install.windows.security-audit "opt-in: =1 => skip (1 is not true)"
+
+GFF_INSTALL_WINDOWS_SECURITY_AUDIT='true '
+assert_gff_opt_in 1 install.windows.security-audit "opt-in: ='true ' => skip (no trimming)"
+
+GFF_INSTALL_WINDOWS_SECURITY_AUDIT=''
+assert_gff_opt_in 1 install.windows.security-audit "opt-in: empty => skip"
+unset GFF_INSTALL_WINDOWS_SECURITY_AUDIT 2>/dev/null || true
+
+# gff_on and gff_opt_in must disagree on an unset var — that inversion IS the
+# feature. A refactor that accidentally unified them would pass every test
+# above; this case is what catches it.
+unset GFF_INSTALL_WINDOWS_SECURITY_AUDIT 2>/dev/null || true
+gff_on install.windows.security-audit; _on_rc=$?
+gff_opt_in install.windows.security-audit; _in_rc=$?
+if [ "$_on_rc" -eq 0 ] && [ "$_in_rc" -eq 1 ]; then
+    echo "PASS: unset var: gff_on runs (0) but gff_opt_in skips (1) — directions are inverted"
+    PASS=$((PASS+1))
+else
+    echo "FAIL: unset var inversion (gff_on=$_on_rc expected 0, gff_opt_in=$_in_rc expected 1)"
+    FAIL=$((FAIL+1))
+fi
+
+# === opt-in key mangling: dots AND hyphens -> underscores, uppercased ===
+GFF_INSTALL_WINDOWS_SECURITY_AUDIT=true
+assert_gff_opt_in 0 install.windows.security-audit \
+    "opt-in key mangling: install.windows.security-audit reads GFF_INSTALL_WINDOWS_SECURITY_AUDIT"
+unset GFF_INSTALL_WINDOWS_SECURITY_AUDIT 2>/dev/null || true
+
 # === gff_skip_msg output contract ===
 _out=$(gff_skip_msg install.tools.sops)
 assert_out "SKIP (gff: install.tools.sops=false)" "$_out" \
@@ -98,6 +160,23 @@ if [ "$_rc" -eq 0 ]; then
     PASS=$((PASS+1))
 else
     echo "FAIL: gff binary absent from PATH => run (expected 0, got $_rc)"
+    FAIL=$((FAIL+1))
+fi
+
+# === missing binary: gff off PATH => opt-in gate still fails CLOSED ===
+# The mirror of the case above. gff_opt_in is env-only by the same contract, so
+# a machine with no gff binary must still refuse to run the opt-in step.
+(
+    PATH="/usr/bin:/bin"
+    unset GFF_INSTALL_WINDOWS_SECURITY_AUDIT 2>/dev/null || true
+    gff_opt_in install.windows.security-audit
+)
+_rc=$?
+if [ "$_rc" -eq 1 ]; then
+    echo "PASS: gff binary absent from PATH => opt-in skips (exit $_rc)"
+    PASS=$((PASS+1))
+else
+    echo "FAIL: gff binary absent from PATH => opt-in skips (expected 1, got $_rc)"
     FAIL=$((FAIL+1))
 fi
 

--- a/opt/scripts/system/security-audit-collect_test.sh
+++ b/opt/scripts/system/security-audit-collect_test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# =============================================================================
+# security-audit-collect_test.sh - test driver for the Windows security-audit
+# collector (opt/Desktop/Apps/scripts/security-audit-collect.ps1).
+#
+# Two tiers, so it is useful in CI AND on a real Windows/WSL host:
+#
+#   STATIC (always, incl. Linux CI) - grep the .ps1 source for the invariants
+#     the collector's whole safety model depends on (fail-loud error handling,
+#     the three-state Add-Section contract, byte-stable admin-gap markers, the
+#     4104 self-exclusion, probe-first event reads, the expected section set).
+#     A regression here (e.g. ErrorActionPreference flipped back to 'Continue')
+#     fails CI even though CI has no PowerShell.
+#
+#   LIVE (only when a powershell.exe is resolvable - WSL/Windows dev) - actually
+#     run the collector with -StdOut -Days 7 (read-only, writes nothing) against
+#     the real host and assert the OUTPUT contract: header present, every
+#     expected section emitted, NO '!! COLLECTION ERROR', no empty section,
+#     exit 0. On a pure-Linux box with no PowerShell this tier SKIPs (not fails).
+#
+# Run standalone: bash opt/scripts/system/security-audit-collect_test.sh
+# POSIX-friendly; no bashisms that trip the portability gate.
+# =============================================================================
+set -u
+
+SCRIPT_DIR=$(cd -- "$(dirname "$0")" && pwd -P)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../../.." && pwd -P)
+COLLECTOR="${REPO_ROOT}/opt/Desktop/Apps/scripts/security-audit-collect.ps1"
+
+PASS=0
+FAIL=0
+ok()   { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# has_lit <label> <literal-substring>  - fixed-string (grep -F) presence check.
+has_lit() {
+    if grep -Fq -- "$2" "$COLLECTOR"; then ok "$1"; else bad "$1 (missing: $2)"; fi
+}
+# lacks_lit <label> <literal-substring> - fixed-string absence check.
+lacks_lit() {
+    if grep -Fq -- "$2" "$COLLECTOR"; then bad "$1 (present but must not be: $2)"; else ok "$1"; fi
+}
+
+if [ ! -f "$COLLECTOR" ]; then
+    echo "FAIL: collector not found at $COLLECTOR"
+    echo "----"
+    echo "PASS: 0  FAIL: 1"
+    exit 1
+fi
+
+echo "==== STATIC contract checks (source of $COLLECTOR) ===="
+
+# Fail-loud error handling: Stop present, Continue absent (the v1 silent-empty bug).
+has_lit   "ErrorActionPreference = Stop"            "\$ErrorActionPreference = 'Stop'"
+lacks_lit "no ErrorActionPreference = Continue"     "\$ErrorActionPreference = 'Continue'"
+
+# Three-state Add-Section contract. Anchor to CODE tokens, not the docstring:
+# the bare strings "!! COLLECTION ERROR" / "## ADMIN-REQUIRED" also appear in the
+# .SYNOPSIS comment, so a grep for those would stay green even if the code were
+# deleted. Match the interpolation/definition that appears ONLY in code.
+has_lit   "Add-Section function defined"            "function Add-Section"
+has_lit   "empty section -> (none), never blank"    "IsNullOrWhiteSpace"
+has_lit   "lens failure emits COLLECTION ERROR"     "\"!! COLLECTION ERROR: \$("
+
+# Byte-stable admin-gap marker: exception TYPE only, never the localized .Message.
+has_lit   "Deny-Marker uses exception type name"    "\"## ADMIN-REQUIRED (\$(\$e.GetType().Name))"
+# Regression guard: the Deny-Marker definition must not interpolate .Message
+# (locale-variable text would break the byte-stable diff contract).
+if grep -n 'function Deny-Marker' "$COLLECTOR" >/dev/null 2>&1; then
+    deny_body=$(sed -n '/function Deny-Marker/,/^}/p' "$COLLECTOR")
+    if printf '%s' "$deny_body" | grep -Fq '.Message'; then bad "Deny-Marker must not use .Message (breaks byte-stability)"; else ok "Deny-Marker has no .Message (byte-stable)"; fi
+fi
+
+# 4104 self-exclusion: regex built from fragments AND the own-path filter APPLIED
+# (not just declared), so the collector never flags its own script.
+has_lit   "4104 self-exclusion filter applied"      "-notmatch \$selfRx"
+has_lit   "4104 regex built from fragments"         "'Download'+'String'"
+
+# Probe-first event reads: the DENIED catch must be the typed catch, not a comment.
+has_lit   "probe-first Read-Events helper"          "function Read-Events"
+has_lit   "denied-log caught by type"               "catch [System.UnauthorizedAccessException]"
+# Empty-vs-denied uses the locale-independent error id, not an English message.
+has_lit   "empty-log detected locale-independently" "NoMatchingEventsFound"
+
+# Path anchoring (no unanchored \Windows\ substring bypass) + IPv4 preservation.
+has_lit   "masquerade path anchored to SystemRoot"  "env:SystemRoot"
+has_lit   "Norm-Ver preserves IPv4 literals"        "ipv4"
+
+# Testability: params that let this driver run read-only into a temp dir.
+has_lit   "-StdOut param (no-write mode)"           "[switch]\$StdOut"
+has_lit   "-BaseDir param"                          "\$BaseDir"
+has_lit   "-Days param"                             "\$Days"
+
+# Expected section set (a representative sample across every category group).
+for marker in \
+    "A1. RUN / RUNONCE" "A3. WINLOGON" "A4. IFEO" "A5. COM hijack" \
+    "A6. LOGON-SCRIPT" "A7. UAC-BYPASS" \
+    "B1. NON-MICROSOFT AUTO-START SERVICES" "B4. WMI EVENT-SUBSCRIPTION" \
+    "C1. DEFENDER CORE STATUS" "C2. DEFENDER EXCLUSIONS" \
+    "E2. TCP LISTENERS" "E4. PORTPROXY" \
+    "F1. OUTBOUND TO PUBLIC IPs" "F2. HOSTS FILE" \
+    "G2. SYSTEM-PROCESS MASQUERADE" "H2. PRIVILEGED GROUP MEMBERSHIP" \
+    "I2. UAC" "J1. SERVICE INSTALLED" "K. SECURITY-LOG VISIBILITY GAP"
+do
+    has_lit "section present: $marker" "$marker"
+done
+
+# ---- LIVE tier: resolve a PowerShell, run read-only, assert the output -----
+echo "==== LIVE run tier ===="
+PS_EXE=""
+if command -v powershell.exe >/dev/null 2>&1; then
+    PS_EXE=$(command -v powershell.exe)
+elif [ -x "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" ]; then
+    PS_EXE="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+fi
+
+if [ -z "$PS_EXE" ]; then
+    echo "SKIP: no powershell.exe resolvable - live collector run not executed (expected in Linux CI)."
+else
+    COLLECTOR_WIN=$(wslpath -w "$COLLECTOR" 2>/dev/null || echo "$COLLECTOR")
+    # Write to a temp file (not a pipe) so $? is PowerShell's real exit, not tr's.
+    TMP_OUT=$(mktemp)
+    "$PS_EXE" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$COLLECTOR_WIN" -StdOut -Days 7 </dev/null >"$TMP_OUT" 2>/dev/null
+    RC=$?
+    OUT=$(tr -d '\r' <"$TMP_OUT")
+    rm -f "$TMP_OUT"
+    if [ "$RC" -eq 0 ]; then ok "collector exited 0"; else bad "collector exit code $RC"; fi
+
+    if printf '%s\n' "$OUT" | grep -q '^AUDIT TIMESTAMP:'; then
+        ok "output has AUDIT TIMESTAMP header"
+    else
+        bad "no AUDIT TIMESTAMP header"
+    fi
+
+    # No lens may have thrown.
+    if printf '%s\n' "$OUT" | grep -q '!! COLLECTION ERROR'; then
+        bad "output contains a COLLECTION ERROR:"
+        printf '%s\n' "$OUT" | grep '!! COLLECTION ERROR' | sed 's/^/      /'
+    else
+        ok "output has no COLLECTION ERROR"
+    fi
+
+    # Every declared section must be present in the output and non-empty (the
+    # header line is immediately followed by at least one non-blank content line).
+    SECTIONS=$(printf '%s\n' "$OUT" | grep -c '^=== ')
+    if [ "$SECTIONS" -ge 25 ]; then ok "output has >=25 sections ($SECTIONS)"; else bad "only $SECTIONS sections in output"; fi
+
+    EMPTY=$(printf '%s\n' "$OUT" | awk '
+        /^=== /   { if (prev_hdr) { empties++ }; prev_hdr=1; next }
+        /^[^[:space:]]/ { prev_hdr=0 }
+        /^[[:space:]]*[^[:space:]]/ { prev_hdr=0 }
+        END { print empties+0 }')
+    if [ "$EMPTY" -eq 0 ]; then ok "no section header is followed immediately by another header"; else bad "$EMPTY section(s) rendered empty"; fi
+
+    # The collector must NOT self-flag its own script in the 4104 lens (the
+    # self-detection loop). A clean run reports suspicious = 0.
+    if printf '%s\n' "$OUT" | grep -q 'keyword-suspicious (self-excluded) = 0'; then
+        ok "4104 lens does not self-flag (suspicious = 0)"
+    else
+        bad "4104 keyword-suspicious is non-zero on a clean self-run (self-exclusion may be broken)"
+    fi
+
+    # Fault-injection: prove the throw -> marker contract behaviorally, not just by
+    # static grep. With -FaultInject the collector adds one throwing lens followed
+    # by a sentinel lens; assert the marker appears, the sentinel STILL renders
+    # after it (script did not abort), and the exit code is still 0.
+    TMP_F=$(mktemp)
+    "$PS_EXE" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$COLLECTOR_WIN" -StdOut -Days 7 -FaultInject </dev/null >"$TMP_F" 2>/dev/null
+    FRC=$?
+    FOUT=$(tr -d '\r' <"$TMP_F")
+    rm -f "$TMP_F"
+    if [ "$FRC" -eq 0 ]; then ok "fault-inject run still exits 0"; else bad "fault-inject run exit $FRC (a thrown lens aborted the script)"; fi
+    if printf '%s\n' "$FOUT" | grep -Fq '!! COLLECTION ERROR: injected fault'; then ok "thrown lens renders a COLLECTION ERROR marker"; else bad "thrown lens did not produce a marker"; fi
+    if printf '%s\n' "$FOUT" | grep -Fq 'sentinel-ok'; then ok "section AFTER the fault still renders (no abort)"; else bad "post-fault sentinel missing (script aborted at the throw)"; fi
+fi
+
+echo "----"
+echo "PASS: $PASS  FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/sdk/gff/cmd/install_test.go
+++ b/sdk/gff/cmd/install_test.go
@@ -6,9 +6,9 @@ import (
 
 func TestDeriveNamespace(t *testing.T) {
 	tests := []struct {
-		name    string
-		url     string
-		want    string
+		name string
+		url  string
+		want string
 	}{
 		// HTTPS URLs
 		{

--- a/sdk/gff/e2e/e2e_test.go
+++ b/sdk/gff/e2e/e2e_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package e2e_test
@@ -172,7 +173,7 @@ func TestHappyPath(t *testing.T) {
 		// Install requires CWD to be the repo; create a wrapper command
 		bin := getGffBinary(t)
 		cmd := exec.Command(bin, "install")
-		cmd.Dir = repoA  // CWD = the repo
+		cmd.Dir = repoA // CWD = the repo
 		cmd.Env = []string{
 			"HOME=" + world,
 			"XDG_DATA_HOME=" + filepath.Join(world, ".local", "share"),
@@ -440,7 +441,7 @@ gff_on install.pkg.manager && echo "pkg-on" || echo "pkg-off"
 
 		bin := getGffBinary(t)
 		cmd := exec.Command(bin, "get", "--source", repoA, "install.ai.claude")
-		cmd.Dir = otherCwd  // CWD is unrelated to repoA
+		cmd.Dir = otherCwd // CWD is unrelated to repoA
 		cmd.Env = []string{
 			"HOME=" + world,
 			"XDG_DATA_HOME=" + filepath.Join(world, ".local", "share"),

--- a/sdk/gff/internal/registry/registry_test.go
+++ b/sdk/gff/internal/registry/registry_test.go
@@ -102,8 +102,8 @@ func TestInstallRefresh(t *testing.T) {
 	reg := &registry.Registry{P: p}
 
 	const (
-		ns     = "com.example.demo"
-		url    = "https://github.com/example/demo"
+		ns      = "com.example.demo"
+		url     = "https://github.com/example/demo"
 		commit1 = "abc1234"
 		commit2 = "def5678"
 	)
@@ -141,10 +141,10 @@ func TestInstallNamespaceTaken(t *testing.T) {
 	reg := &registry.Registry{P: p}
 
 	const (
-		ns      = "com.example.demo"
-		url1    = "https://github.com/example/demo"
-		url2    = "https://github.com/OTHER/demo"
-		commit  = "abc1234"
+		ns     = "com.example.demo"
+		url1   = "https://github.com/example/demo"
+		url2   = "https://github.com/OTHER/demo"
+		commit = "abc1234"
 	)
 
 	content := "namespace: com.example.demo\nsets: []\n"

--- a/sdk/gff/internal/schema/lint_test.go
+++ b/sdk/gff/internal/schema/lint_test.go
@@ -42,10 +42,10 @@ func singleOpt(id string, selected bool) *gffv1.ChoiceOption {
 
 func TestLint(t *testing.T) {
 	tests := []struct {
-		name        string
-		ff          *gffv1.FeatureFile
-		wantFindings bool // true = expect at least one finding; false = expect zero findings
-		wantRule    string // if non-empty, at least one finding must have this Rule
+		name         string
+		ff           *gffv1.FeatureFile
+		wantFindings bool   // true = expect at least one finding; false = expect zero findings
+		wantRule     string // if non-empty, at least one finding must have this Rule
 	}{
 		// --- Clean file: zero findings ---
 		{

--- a/sdk/gff/internal/schema/white_cover_test.go
+++ b/sdk/gff/internal/schema/white_cover_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNormalizeMapKeysVariants(t *testing.T) {
 	in := map[any]any{
-		1: map[any]any{true: "x"},
+		1:      map[any]any{true: "x"},
 		"list": []any{map[any]any{2: "y"}, "z"},
 	}
 	out, ok := normalizeMapKeys(in).(map[string]any)

--- a/sdk/gsl/cmd/config.go
+++ b/sdk/gsl/cmd/config.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/spf13/cobra"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/config"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/style"
+	"github.com/spf13/cobra"
 )
 
 var configCmd = &cobra.Command{

--- a/sdk/gsl/cmd/preview.go
+++ b/sdk/gsl/cmd/preview.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/spf13/cobra"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/preview"
+	"github.com/spf13/cobra"
 )
 
 var previewOnce bool

--- a/sdk/gsl/cmd/render.go
+++ b/sdk/gsl/cmd/render.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/observe"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var renderCmd = &cobra.Command{

--- a/sdk/gsl/cmd/status.go
+++ b/sdk/gsl/cmd/status.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/payload"
+	"github.com/spf13/cobra"
 )
 
 var statusCmd = &cobra.Command{

--- a/sdk/gsl/cmd/version.go
+++ b/sdk/gsl/cmd/version.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gsl/internal/version"
+	"github.com/spf13/cobra"
 )
 
 // VersionInfo is the shape returned by `gsl version --json`.

--- a/sdk/gss/cmd/config.go
+++ b/sdk/gss/cmd/config.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/spf13/cobra"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gss/internal/config"
+	"github.com/spf13/cobra"
 )
 
 var configCmd = &cobra.Command{

--- a/sdk/gss/cmd/version.go
+++ b/sdk/gss/cmd/version.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gss/internal/version"
+	"github.com/spf13/cobra"
 )
 
 type VersionInfo struct {


### PR DESCRIPTION
# feat(windows): unattended weekly security audit behind opt-in gff flag

Branch: `security-audit` · MBO slug: `security-audit` (spec + plan + index registered)

## Problem

The Claude `weekly-security-audit` scheduled task needed a human twice per run:
unattended runs cannot approve computer-use access (2026-08-16: even grants stored on
the task did not carry into the run), and terminals are click-tier, so Claude can never
type or paste into PowerShell regardless. A "scheduled" audit that stalls until someone
replies and pastes is not scheduled.

## Solution

Decouple collection from analysis:

```text
Windows Task Scheduler                          Claude scheduled task (weekly)
ClaudeSecurityAuditCollector (daily 09:00)      weekly-security-audit
  security-audit-collect.ps1  ──────────────►     reads latest-audit.txt from its
  read-only queries, writes:                      own task folder, diffs against the
  %USERPROFILE%\Claude\SecurityAudit\             baseline in its SKILL.md, reports —
    latest-audit.txt + history\                   no computer use, no approvals,
  + copy into the Claude task folder              no user interaction
  + optional Google Drive fallback copy
```

## Changes

| File | Change |
| :-- | :-- |
| `opt/Desktop/Apps/scripts/security-audit-collect.ps1` | new — read-only collector: 5 lenses (non-MS auto-start services, non-MS active scheduled tasks, startup commands, AppData/Temp processes, Defender), stable formats, dated history (keeps 20) |
| `opt/Desktop/Apps/scripts/setup-security-audit.ps1` | new — installer: user-level daily task (no admin, `StartWhenAvailable`, battery-friendly), installs collector to `%USERPROFILE%\Claude\SecurityAudit` (OneDrive-safe), seeds the Claude SKILL.md **only when absent**, first collection immediately; `-Status` / `-Uninstall` / `-At HH:mm` |
| `opt/Desktop/Apps/scripts/security-audit-skill.template.md` | new — Claude analysis prompt: data-source fallback chain, freshness rule, bootstrap-baseline mode, hard no-computer-use rule |
| `opt/lib/gff.sh` + `opt/Desktop/Apps/scripts/lib/gff.ps1` | new `gff_opt_in` / `Test-GffOptIn` — **fail-closed** gates for `boolDefault: false` flags (opt-in steps must never run where gff/flag export is missing; deliberate inversion of fail-open `gff_on`) |
| `opt/lib/gff_test.sh` | `gff_opt_in` truth table + the `gff_on`/`gff_opt_in` inversion assertion (20/20 under bash **and** dash) |
| `.github/gff/features.yaml` | new flag `install.windows.security-audit`, `boolDefault: false` |
| `opt/bin/install_windows.sh` | `run_security_audit_setup` at the deferred Windows phase (independent of the y/n/s customization answer, after the Desktop deploy; setup-apps rc-capture/log pattern); `export_gff_wslenv` extracted for reuse |
| `docs/security-audit.md`, `opt/Desktop/Apps/scripts/AGENTS.md`, `docs/AGENTS.md`, `docs/mbo/{specs,plans,index}` | docs, inventory, MBO registration |
| `sdk/**` (12 files) | separate commit — `gofmt` import ordering only, no logic |

## Review pass (commit 2 — `fix(security-audit): harden the collector…`)

A full audit of the above surfaced five real defects and one missing test suite:

| # | Defect | Fix |
| :-- | :-- | :-- |
| 1 | **A failed lens wrote an empty section.** `$ErrorActionPreference='Continue'` sent the error to a stderr nobody reads, so an unavailable `Get-MpComputerStatus` produced an empty DEFENDER section indistinguishable from "Defender is fine" — silent blindness, the worst failure mode for an audit | Every lens runs through `Add-Section` and resolves to exactly one of: items, `(none)`, `!! COLLECTION ERROR: <msg>`. The analysis prompt may no longer report the host clean while any section carries an error |
| 2 | **Section 1 excluded `C:\Windows\Temp\`.** The `\Windows\` "non-Microsoft" heuristic blinded the audit to a user-writable, standard persistence location | Exclude `\Windows\` *except* `\Windows\Temp\`; services with a null `PathName` stay visible |
| 3 | **The fail-closed gate shipped with no tests**, though CI runs `opt/lib/gff_test.sh` | +12 cases incl. an explicit assertion that `gff_on` and `gff_opt_in` **disagree** on an unset var — the inversion is the whole feature, and a refactor unifying them would pass every other case |
| 4 | **`gff_opt_in` had no fallback stub** in `install_windows.sh` — correct only by accident (`command not found` → rc 127 → reads as false) | Explicit `gff_opt_in() { return 1; }`, mirroring each helper's direction |
| 5 | **`ToUpper()` is culture-sensitive.** Under a Turkish locale `i` → U+0130, so every `install.*` key mis-mangles and no `GFF_*` var matches — flags silently ignored (`Test-GffOn`) or opt-in never enabling | `ToUpperInvariant()` via a shared `Get-GffVarName`; also fixes the pre-existing `Test-GffOn` |
| 6 | `-At` unvalidated and parsed culture-sensitively — bad input could register the task at an *unintended hour* rather than erroring | 24-hour `HH:mm` `[ValidatePattern]` |

Also: secondary writes (task folder, history, Drive) could discard an already-good
canonical report — canonical is now the only fatal write. And `gff.ps1` documented
`WSLENV /u`, which `install_windows.sh` records as empirically refuted — corrected to `/w`.

## `make lint` (commit 3 — `style(sdk): gofmt…`)

`make lint` was failing at the gofmt step on 12 files. CI did not catch it because
`docker-image.yml` runs `make lint` with `continue-on-error: true` (warn-only while the
phase-1 backlog is burned down), so the drift accumulated silently on `main`.
`.ci-baseline-issues.md` records gofmt as **clean**, so this was a real regression
against the documented state, not accepted backlog. `gofmt -l ./sdk` is now empty.

**Not addressed:** the 27 remaining `golangci-lint` findings (20 errcheck, all in
`sdk/gff`). Those *are* the acknowledged warn-only backlog; burning them down is
separate, out-of-scope work — so `make lint` still stops there.

## Rollout

Off for everyone by default (fail-closed). Per machine:

```sh
gff set install.windows.security-audit true
./install.sh    # runs in the deferred Windows phase
```

then once in Claude: "schedule the weekly-security-audit task for Saturdays at 10:00".
Standalone alternative (manual run = explicit intent, flag not required):
`powershell -ExecutionPolicy Bypass -File %USERPROFILE%\Desktop\Apps\scripts\setup-security-audit.ps1`

## Testing (sandbox — Linux, no PowerShell)

- `make lint-shell` (shellcheck) — pass
- `make lint-portability` — Tier 1: 0, Tier 2: 0
- `make lint-markdown` on touched markdown — 0 issues
- `gofmt -l ./sdk` — empty
- `bash opt/lib/gff_test.sh` **and** `sh opt/lib/gff_test.sh` — 20/20
- `gff export --shell` emits `GFF_INSTALL_WINDOWS_SECURITY_AUDIT=false` by default (fail-closed confirmed end-to-end)

**The four `.ps1` files are review-verified only** — there is no PowerShell in the build
sandbox. The post-merge plan below remains the real gate for them.

## Post-merge test plan (Windows host)

1. Flag unset → `install.sh` prints `SKIP (gff: install.windows.security-audit is opt-in and not enabled)`; nothing installed (spec AC1).
2. Enable + `install.sh` → task registered, first `latest-audit.txt` written, SKILL.md seeded (AC2).
3. Re-run installer → existing SKILL.md untouched (AC3).
4. `-Status` / `-Uninstall` behave per spec (AC4).
5. One unattended Claude `weekly-security-audit` run completes by reading the report (AC5).
6. Force a lens failure (e.g. on a host without the Defender module) → the section reads `!! COLLECTION ERROR`, and the analysis run reports it as unverified rather than clean.

## Rollback

`setup-security-audit.ps1 -Uninstall` + `gff unset install.windows.security-audit`.
Data and baseline folders are kept (documented in docs/security-audit.md).


---

## Update — v2: ultra collector expansion (commit `7fe7c4c`)

The collector went from a 5-lens snapshot to a **comprehensive ~40-lens, non-admin,
read-only anomaly detector**, designed via an adversarially-reviewed lens catalog and
hardened by a 4-agent review, then **validated by a live read-only run against a real
Windows 11 host** (non-admin). Detection only — it never changes configuration.

### Coverage (39 sections, ATT&CK-mapped)

| Group | Sections |
| :-- | :-- |
| Persistence — registry ASEPs | Run/RunOnce all hives (A1), Policies\Run + RunOnceEx (A2), Winlogon (A3), IFEO + AppInit_DLLs (A4), **logon-script / `COR_PROFILER` .NET-injection / win.ini / `$PROFILE` / Active Setup (A6)**, **UAC-bypass + file-handler hijacks (A7)**, COM hijack (A5) |
| Persistence — execution | services + signature/path-hygiene (B1), scheduled tasks (B2), startup folder + shell-folder redirect (B3), WMI subscriptions (B4) |
| Defense evasion | Defender status (C1), exclusions honest-gap (C2), detections 1116/1117 (C3), 5007 config-change (C4), log-clear 104/1102 (D1), channel health (D2) |
| Network exposure + C2 | firewall (E1), TCP listeners (E2), SMB (E3), **portproxy pivot (E4)**, remote-access (E5), outbound-to-public (F1), hosts (F2), DNS (F3), proxy (F4) |
| Process / accounts / posture | user-writable + masquerade (G1/G2); users/priv-groups/built-ins/hidden (H1–H4); patch/UAC/SmartScreen/SecureBoot/CodeIntegrity (I1–I3) |
| Event signals (7d) | 7045 (J1), 7040 (J2), 4104 self-excluded (J3); consolidated Security-log gap (K) |

### Design & review process

- **Lens-catalog workflow** (11 agents) produced 103 adversarially-reviewed lenses; the FP-calibration pass **live-confirmed** three corrections (Defender exclusions blind non-admin, the Security-log `FilterHashtable` trap, the 4104 self-detection loop).
- **4-agent adversarial review** (PowerShell correctness / detection-evasion / false-positive / contract-robustness) surfaced and I fixed: `Is-UserWritable` under-coverage (weakened 7 lenses), unanchored path-check evasions (G2/B1/B2 — a decoy `…\Windows\System32\` path could evade), the `A4` scope bug, `C1` ASR miscount, `Norm-Ver` masking embedded C2 IPs, `H2` throwing on orphaned SIDs, and **vacuous test greps** matching the docstring instead of code.

### Contract & FP discipline

Every section resolves to `items` / `(none)` / `!! COLLECTION ERROR` / `## ADMIN-REQUIRED`
(byte-stable) — a blocked lens is never silently empty. `[STABLE]` vs `[VOLATILE]` fencing
separates strict-diff surfaces from churn; versions normalize to `X.X` while **IPv4 literals
are preserved** (a hard-coded C2 IP still diffs). `[USER-WRITABLE-PATH]` alarms only when
unsigned; 5007 update-churn collapses to a count; the 4104 lens self-excludes its own script.

### New: test driver + rewritten analysis prompt

- `opt/scripts/system/security-audit-collect_test.sh` — static contract checks (CI, anchored to
  **code tokens** not the docstring) + a behavioral `-FaultInject` assertion (thrown lens →
  marker, sentinel still renders, exit 0) + a live read-only run assertion. **45/45** locally;
  SKIPs the live tier cleanly in Linux CI.
- `security-audit-skill.template.md` — CRITICAL/WARN/INFO triage with explicit per-section tier
  anchors (A3/A4/C3/D1 → CRITICAL), STABLE/VOLATILE + event-set handling, and a first-run
  **baseline-poisoning guard**.

### Validation

`bash opt/scripts/system/security-audit-collect_test.sh` — 45/45 · collector exit 0, 0 collection
errors, 39 sections against a live Win11 host (non-admin) · `make lint-shell` / portability
(Tier 1/2: 0) / markdownlint — pass. The `.ps1` files still need a Windows host for the
`setup-security-audit.ps1` end-to-end task registration (AC1–AC5); the collector **output
contract is now machine-verified**.
