### PR TITLE
fix(install): unbreak fleet update — false license FAIL + non-login PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,27 @@ function install_zsh_centos7() {
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 export BASE_DIR
 
+# --- Self-sufficient PATH -----------------------------------------------------
+# This script INSTALLS into ~/opt/bin (sops, yq, kubectl, helm, kind, and every
+# sdk/ binary) and ~/.local/bin (pipx CLIs, agy, claude) and then immediately
+# CONSUMES those tools — install_ai_teams.sh and sync-plugins.sh both hard-require
+# `yq`, the gff early-export below probes `command -v gff`.
+#
+# Those directories are only added to PATH by ~/.profile, which is sourced by
+# LOGIN shells. `fleet update <host>` runs install.sh over `ssh -t host "...
+# ./install.sh"` — a NON-login shell — so PATH lacked both, and the run failed
+# with a cascade of "installed but not resolvable" errors ("yq not resolvable
+# after install", "sync-plugins: 'yq' not found", "install_ai_teams: yq is
+# required"). Make the script independent of the caller's shell startup files.
+for _ip_dir in "${HOME}/opt/bin" "${HOME}/.local/bin"; do
+  case ":${PATH}:" in
+    *":${_ip_dir}:"*) ;;                    # already present — don't duplicate
+    *) PATH="${_ip_dir}:${PATH}" ;;
+  esac
+done
+unset _ip_dir
+export PATH
+
 # gff_on is env-only and fail-open; it must exist before the FIRST gate. Sourcing
 # it here (not at the bootstrap point) is load-bearing: a gate that calls an
 # undefined gff_on gets exit 127, takes the else branch, and SKIPS the step —

--- a/install_test.sh
+++ b/install_test.sh
@@ -90,4 +90,50 @@ TAIL_CODE="$(tail -n "+$((STAMP_LINE + 1))" "$INSTALL" | sed 's/#.*//' | tr -d '
 assert_eq "$TAIL_CODE" "fi" \
     "nothing runs after the stamp (only its closing 'fi')"
 
+# === Self-sufficient PATH (fleet update regression) ===
+# install.sh WRITES into ~/opt/bin (yq, sops, kubectl, every sdk/ binary) and
+# ~/.local/bin (pipx CLIs) and then immediately CONSUMES those tools. Those dirs
+# are put on PATH only by ~/.profile — a LOGIN-shell file. `fleet update <host>`
+# runs install.sh over `ssh -t host "... ./install.sh"`, a NON-login shell, so a
+# real run produced "yq not resolvable after install", "sync-plugins: 'yq' not
+# found" and "install_ai_teams: yq is required" on a host where yq had just been
+# installed correctly. install.sh must therefore fix its own PATH.
+#
+# The block is EXECUTED here, extracted verbatim from the shipped install.sh
+# rather than re-implemented, so deleting or breaking it fails these cases.
+PATH_BLOCK="$(awk '/^# --- Self-sufficient PATH/{f=1} f{print} f&&/^export PATH$/{exit}' "$INSTALL")"
+assert_grep "install.sh carries the self-sufficient PATH block" \
+    '^# --- Self-sufficient PATH' "$INSTALL"
+
+# run_path_block <initial PATH> -> resulting PATH, with HOME pinned to a fixture.
+run_path_block() {
+    env HOME=/fixture/home PATH="$1" bash -c "$PATH_BLOCK"'; printf %s "$PATH"'
+}
+
+assert_eq "$(run_path_block '/usr/local/bin:/usr/bin:/bin')" \
+    "/fixture/home/.local/bin:/fixture/home/opt/bin:/usr/local/bin:/usr/bin:/bin" \
+    "non-login PATH gains ~/opt/bin and ~/.local/bin"
+
+# Repeated fleet runs must not accumulate duplicate entries.
+CONFIGURED_PATH="/fixture/home/.local/bin:/fixture/home/opt/bin:/usr/bin:/bin"
+assert_eq "$(run_path_block "$CONFIGURED_PATH")" "$CONFIGURED_PATH" \
+    "already-configured PATH is unchanged (no duplicates)"
+
+assert_eq "$(run_path_block '/fixture/home/opt/bin:/usr/bin')" \
+    "/fixture/home/.local/bin:/fixture/home/opt/bin:/usr/bin" \
+    "only the missing dir is prepended"
+
+# A neighbouring dir that merely shares a prefix must not read as "present".
+assert_eq "$(run_path_block '/fixture/home/opt/bin-extra:/usr/bin')" \
+    "/fixture/home/.local/bin:/fixture/home/opt/bin:/fixture/home/opt/bin-extra:/usr/bin" \
+    "substring match does not count as present"
+
+# The block must precede the first consumer of an installed tool: the gff
+# early-export probes `command -v gff`, and gff lives in ~/opt/bin.
+PATH_BLOCK_LINE="$(grep -n '^# --- Self-sufficient PATH' "$INSTALL" | head -1 | cut -d: -f1)"
+GFF_PROBE_LINE="$(grep -n 'command -v gff' "$INSTALL" | head -1 | cut -d: -f1)"
+assert_eq "$([ -n "$PATH_BLOCK_LINE" ] && [ -n "$GFF_PROBE_LINE" ] && \
+    [ "$PATH_BLOCK_LINE" -lt "$GFF_PROBE_LINE" ] && echo before || echo after)" \
+    "before" "PATH block runs before the gff early-export probe"
+
 _test_report

--- a/opt/scripts/system/install_snowflake_cli.sh
+++ b/opt/scripts/system/install_snowflake_cli.sh
@@ -15,6 +15,17 @@
 # Safe to re-run: exits early when `snow` is already resolvable.
 set -e
 
+# pipx installs into ~/.local/bin; brew into its own prefix (already on PATH on
+# macOS). Put ~/.local/bin on PATH for the rest of this script so both the
+# early-exit probe and the post-install verification below reflect reality —
+# install.sh run from a NON-login shell (`fleet update` over ssh) does not get
+# ~/.local/bin from ~/.profile, which is why a correctly-installed `snow`
+# reported "not resolvable after install".
+case ":${PATH}:" in
+    *":${HOME}/.local/bin:"*) ;;
+    *) PATH="${HOME}/.local/bin:${PATH}"; export PATH ;;
+esac
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
@@ -67,4 +78,5 @@ if command -v snow >/dev/null 2>&1 && snow --version >/dev/null 2>&1; then
 else
     echo -e "${RED}install_snowflake_cli: snow not resolvable after install — is ~/.local/bin on PATH?${NC}"
     echo -e "${RED}                       (open a new shell or run 'pipx ensurepath' and retry)${NC}"
+    exit 1
 fi

--- a/opt/scripts/system/install_yq.sh
+++ b/opt/scripts/system/install_yq.sh
@@ -16,6 +16,17 @@ set -e
 YQ_VERSION="${YQ_VERSION:-4.44.6}"
 INSTALL_DIR="${HOME}/opt/bin"
 
+# Put the install dir on PATH for the rest of this script. Without it, both the
+# "already installed" probe and the post-install verification below ask a PATH
+# that may not contain ~/opt/bin at all — which is exactly what happens when
+# install.sh runs from a NON-login shell (`fleet update` over ssh): yq gets
+# written correctly, then reports "not resolvable after install", and the
+# downstream yq consumers (sync-plugins, install_ai_teams) fail outright.
+case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *) PATH="${INSTALL_DIR}:${PATH}"; export PATH ;;
+esac
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
@@ -54,9 +65,17 @@ echo -e "${BLUE}Installing yq ${YQ_VERSION} (${YQ_OS}/${YQ_ARCH}) to ${INSTALL_D
 curl -fsSL "$URL" -o "${INSTALL_DIR}/yq"
 chmod +x "${INSTALL_DIR}/yq"
 
+# Verify the binary we just wrote actually runs, THEN that PATH resolves to it.
+# Separating the two makes the failure message name the real problem instead of
+# blaming PATH for a corrupt download (or vice versa).
+if ! "${INSTALL_DIR}/yq" --version >/dev/null 2>&1; then
+    echo -e "${RED}install_yq: ${INSTALL_DIR}/yq was written but does not run (corrupt download?).${NC}"
+    exit 1
+fi
 if command -v yq >/dev/null 2>&1 && yq --version >/dev/null 2>&1; then
     echo -e "${GREEN}yq installed: $(yq --version 2>&1 | head -1)${NC}"
 else
-    echo -e "${RED}install_yq: yq not resolvable after install — is ${INSTALL_DIR} on PATH?${NC}"
-    echo -e "${RED}            (binary written to ${INSTALL_DIR}/yq)${NC}"
+    echo -e "${RED}install_yq: yq works at ${INSTALL_DIR}/yq but PATH does not resolve it.${NC}"
+    echo -e "${RED}            Add ${INSTALL_DIR} to PATH (see opt/profiles/.profile).${NC}"
+    exit 1
 fi

--- a/sdk/gsl/README.md
+++ b/sdk/gsl/README.md
@@ -375,4 +375,4 @@ bash scripts/check-deps.sh
 `scripts/check-deps.sh` enforces two gates:
 
 1. **os/exec seam** — only `internal/git`, `internal/mcp`, and `internal/gh` may import `"os/exec"`. All subprocess work must go through those three runner interfaces so the logic stays testable with fakes.
-2. **License gate** — `go-licenses check ./...` must find no GPL / AGPL / LGPL / forbidden licenses in the dependency tree (skipped with a warning when `go-licenses` is absent; enforced when `GSL_STRICT_CHECK=1`).
+2. **License gate** — `go-licenses check ./...` must find no GPL / AGPL / LGPL / forbidden licenses in the dependency tree (skipped with a warning when `go-licenses` is absent **or not runnable under the active Go toolchain** — e.g. a goenv shim left over from a different Go version; enforced when `GSL_STRICT_CHECK=1`).

--- a/sdk/gsl/scripts/check-deps.sh
+++ b/sdk/gsl/scripts/check-deps.sh
@@ -15,8 +15,9 @@
 #      construction/execution there.
 #   3. License gate — go-licenses check ./... must find no GPL/AGPL/LGPL
 #      (restricted) or forbidden license anywhere in the dependency tree.
-#      Skipped with a warning when go-licenses is absent, UNLESS
-#      GSL_STRICT_CHECK=1 (set in CI), in which case its absence is a failure.
+#      Skipped with a warning when go-licenses is absent OR not runnable under
+#      the active Go toolchain (a goenv shim for another version), UNLESS
+#      GSL_STRICT_CHECK=1 (set in CI), in which case that is a failure.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -67,7 +68,17 @@ else
 fi
 
 echo "== license check: no GPL/AGPL/LGPL/forbidden in the dependency tree =="
-if command -v go-licenses >/dev/null 2>&1; then
+# Presence probe, NOT `command -v`. Under a version manager (goenv/asdf) a SHIM
+# exists on PATH for every binary ever installed under ANY toolchain version, so
+# `command -v go-licenses` succeeds even when the tool is absent from the ACTIVE
+# version. Invoking the shim then exits 127 with:
+#     goenv: 'go-licenses' command not found
+#     The 'go-licenses' command exists in these Go versions: 1.26.3
+# The old `command -v` guard took that 127 as "check ./... returned non-zero" and
+# reported "a disallowed license is present" — a false FAIL that aborted
+# install.sh (exit 1) on every host whose go-licenses lived under a different go
+# version than the repo-pinned .go-version. Probe that it actually RUNS.
+if command -v go-licenses >/dev/null 2>&1 && go-licenses --help >/dev/null 2>&1; then
   # restricted = GPL/AGPL/LGPL family; forbidden = unlicensed / commercial.
   if go-licenses check ./... --disallowed_types=forbidden,restricted; then
     echo "OK: all dependency licenses are permissive."
@@ -76,11 +87,12 @@ if command -v go-licenses >/dev/null 2>&1; then
     fail=1
   fi
 elif [ "${GSL_STRICT_CHECK:-0}" = "1" ]; then
-  echo "FAIL: go-licenses not installed (required in strict/CI mode)."
+  echo "FAIL: go-licenses not installed or not runnable under the active Go toolchain (required in strict/CI mode)."
   echo "  install: go install github.com/google/go-licenses@latest"
+  echo "  (under goenv, install it for the version pinned by .go-version, then: goenv rehash)"
   fail=1
 else
-  echo "SKIP: go-licenses not installed; skipping license gate."
+  echo "SKIP: go-licenses not installed or not runnable under the active Go toolchain; skipping license gate."
   echo "  (set GSL_STRICT_CHECK=1, or 'go install github.com/google/go-licenses@latest', to enforce)"
 fi
 

--- a/sdk/gsl/scripts/check-deps_test.sh
+++ b/sdk/gsl/scripts/check-deps_test.sh
@@ -42,6 +42,43 @@ trap - EXIT
 # 3) Clean again after cleanup.
 assert_exit 0 "clean again after probe removed" env -u GSL_STRICT_CHECK bash "$CHECK"
 
+# 4) A goenv-style go-licenses SHIM that resolves on PATH but exits 127 must be
+#    treated as ABSENT, not as a license violation. This is the ashyumi
+#    regression: go-licenses installed under go 1.26.3 while .go-version pins
+#    1.26.1, so `command -v go-licenses` succeeded, the shim exited 127, and the
+#    gate reported "a disallowed license is present" — aborting install.sh.
+SHIMDIR="$(mktemp -d)"
+shim_cleanup() { rm -rf "$SHIMDIR"; }
+trap shim_cleanup EXIT
+cat >"$SHIMDIR/go-licenses" <<'SHIM'
+#!/usr/bin/env bash
+echo "goenv: 'go-licenses' command not found" >&2
+echo "" >&2
+echo "The 'go-licenses' command exists in these Go versions:" >&2
+echo "  1.26.3" >&2
+exit 127
+SHIM
+chmod +x "$SHIMDIR/go-licenses"
+
+assert_exit 0 "unrunnable go-licenses shim skips the gate (non-strict)" \
+  env -u GSL_STRICT_CHECK PATH="$SHIMDIR:$PATH" bash "$CHECK"
+
+# 5) ...and in strict/CI mode it FAILS as "not installed", not as a bad license.
+assert_exit 1 "unrunnable go-licenses shim fails strict mode" \
+  env GSL_STRICT_CHECK=1 PATH="$SHIMDIR:$PATH" bash "$CHECK"
+
+# 6) The strict failure must name the TOOL, never claim a disallowed license.
+shim_out="$(env GSL_STRICT_CHECK=1 PATH="$SHIMDIR:$PATH" bash "$CHECK" 2>&1 || true)"
+if printf '%s' "$shim_out" | grep -q "go-licenses not installed or not runnable" \
+   && ! printf '%s' "$shim_out" | grep -q "disallowed (copyleft/forbidden) license is present"; then
+  echo "ok   - shim failure is diagnosed as a missing tool, not a bad license"; pass=$((pass + 1))
+else
+  echo "FAIL - shim failure misdiagnosed:"; printf '%s\n' "$shim_out" | sed 's/^/       /'; fail=$((fail + 1))
+fi
+
+shim_cleanup
+trap - EXIT
+
 echo "----"
 echo "check-deps_test: $pass passed, $fail failed"
 [ "$fail" = "0" ]

--- a/sdk/gss/scripts/check-deps.sh
+++ b/sdk/gss/scripts/check-deps.sh
@@ -9,8 +9,9 @@
 #      the composition root (wiring) and is intentionally exempt.
 #   2. License gate — go-licenses check ./... must find no GPL/AGPL/LGPL
 #      (restricted) or forbidden license anywhere in the dependency tree.
-#      Skipped with a warning when go-licenses is absent, UNLESS
-#      GSS_STRICT_CHECK=1 (set in CI), in which case its absence is a failure.
+#      Skipped with a warning when go-licenses is absent OR not runnable under
+#      the active Go toolchain (a goenv shim for another version), UNLESS
+#      GSS_STRICT_CHECK=1 (set in CI), in which case that is a failure.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -34,7 +35,17 @@ else
 fi
 
 echo "== license check: no GPL/AGPL/LGPL/forbidden in the dependency tree =="
-if command -v go-licenses >/dev/null 2>&1; then
+# Presence probe, NOT `command -v`. Under a version manager (goenv/asdf) a SHIM
+# exists on PATH for every binary ever installed under ANY toolchain version, so
+# `command -v go-licenses` succeeds even when the tool is absent from the ACTIVE
+# version. Invoking the shim then exits 127 with:
+#     goenv: 'go-licenses' command not found
+#     The 'go-licenses' command exists in these Go versions: 1.26.3
+# The old `command -v` guard took that 127 as "check ./... returned non-zero" and
+# reported "a disallowed license is present" — a false FAIL that aborted
+# install.sh (exit 1) on every host whose go-licenses lived under a different go
+# version than the repo-pinned .go-version. Probe that it actually RUNS.
+if command -v go-licenses >/dev/null 2>&1 && go-licenses --help >/dev/null 2>&1; then
   # restricted = GPL/AGPL/LGPL family; forbidden = unlicensed / commercial.
   if go-licenses check ./... --disallowed_types=forbidden,restricted; then
     echo "OK: all dependency licenses are permissive."
@@ -43,11 +54,12 @@ if command -v go-licenses >/dev/null 2>&1; then
     fail=1
   fi
 elif [ "${GSS_STRICT_CHECK:-0}" = "1" ]; then
-  echo "FAIL: go-licenses not installed (required in strict/CI mode)."
+  echo "FAIL: go-licenses not installed or not runnable under the active Go toolchain (required in strict/CI mode)."
   echo "  install: go install github.com/google/go-licenses@latest"
+  echo "  (under goenv, install it for the version pinned by .go-version, then: goenv rehash)"
   fail=1
 else
-  echo "SKIP: go-licenses not installed; skipping license gate."
+  echo "SKIP: go-licenses not installed or not runnable under the active Go toolchain; skipping license gate."
   echo "  (set GSS_STRICT_CHECK=1, or 'go install github.com/google/go-licenses@latest', to enforce)"
 fi
 

--- a/sdk/gss/scripts/check-deps_test.sh
+++ b/sdk/gss/scripts/check-deps_test.sh
@@ -42,6 +42,43 @@ trap - EXIT
 # 3) Clean again after cleanup.
 assert_exit 0 "clean again after probe removed" env -u GSS_STRICT_CHECK bash "$CHECK"
 
+# 4) A goenv-style go-licenses SHIM that resolves on PATH but exits 127 must be
+#    treated as ABSENT, not as a license violation. This is the ashyumi
+#    regression: go-licenses installed under go 1.26.3 while .go-version pins
+#    1.26.1, so `command -v go-licenses` succeeded, the shim exited 127, and the
+#    gate reported "a disallowed license is present" — aborting install.sh.
+SHIMDIR="$(mktemp -d)"
+shim_cleanup() { rm -rf "$SHIMDIR"; }
+trap shim_cleanup EXIT
+cat >"$SHIMDIR/go-licenses" <<'SHIM'
+#!/usr/bin/env bash
+echo "goenv: 'go-licenses' command not found" >&2
+echo "" >&2
+echo "The 'go-licenses' command exists in these Go versions:" >&2
+echo "  1.26.3" >&2
+exit 127
+SHIM
+chmod +x "$SHIMDIR/go-licenses"
+
+assert_exit 0 "unrunnable go-licenses shim skips the gate (non-strict)" \
+  env -u GSS_STRICT_CHECK PATH="$SHIMDIR:$PATH" bash "$CHECK"
+
+# 5) ...and in strict/CI mode it FAILS as "not installed", not as a bad license.
+assert_exit 1 "unrunnable go-licenses shim fails strict mode" \
+  env GSS_STRICT_CHECK=1 PATH="$SHIMDIR:$PATH" bash "$CHECK"
+
+# 6) The strict failure must name the TOOL, never claim a disallowed license.
+shim_out="$(env GSS_STRICT_CHECK=1 PATH="$SHIMDIR:$PATH" bash "$CHECK" 2>&1 || true)"
+if printf '%s' "$shim_out" | grep -q "go-licenses not installed or not runnable" \
+   && ! printf '%s' "$shim_out" | grep -q "disallowed (copyleft/forbidden) license is present"; then
+  echo "ok   - shim failure is diagnosed as a missing tool, not a bad license"; pass=$((pass + 1))
+else
+  echo "FAIL - shim failure misdiagnosed:"; printf '%s\n' "$shim_out" | sed 's/^/       /'; fail=$((fail + 1))
+fi
+
+shim_cleanup
+trap - EXIT
+
 echo "----"
 echo "check-deps_test: $pass passed, $fail failed"
 [ "$fail" = "0" ]


### PR DESCRIPTION
## What

Fixes the two independent bugs that made `fleet update <host>` abort with `install.sh` exit 1. Neither was the problem its own output named.

**1. False license-gate FAIL — the fatal one.** `sdk/gsl/scripts/check-deps.sh` and `sdk/gss/scripts/check-deps.sh` guarded the license gate with `command -v go-licenses`. Under goenv a **shim exists on PATH for every binary ever installed under any Go version**, so the probe succeeded — but invoking it under the repo-pinned `.go-version` (1.26.1, while `go-licenses` lived under 1.26.3) exits **127**:

```
goenv: 'go-licenses' command not found
The 'go-licenses' command exists in these Go versions:
  1.26.3
```

The script read that 127 as "check returned non-zero" and printed `FAIL: a disallowed (copyleft/forbidden) license is present in the dep tree` — a pure misdiagnosis that aborted the install. Both modules now probe that the tool actually **runs**, and strict/CI mode fails naming the **tool**, never a phantom license.

`gss` hit the identical false FAIL and survived only because `install.sh` ignores its exit status; `gsl` checks it, which is why the run died there.

**2. Non-login PATH.** `install.sh` writes into `~/opt/bin` (yq, sops, kubectl, every `sdk/` binary) and `~/.local/bin` (pipx CLIs), then immediately **consumes** them — but those dirs reach `PATH` only via `~/.profile`, a **login-shell** file. `fleet update` runs `ssh -t <host> "... ./install.sh"`, a non-login shell, so nothing it installed resolved:

```
install_yq: yq not resolvable after install — is ~/opt/bin on PATH?
sync-plugins: 'yq' not found. Install it via opt/scripts/system/install_yq.sh
install_ai_teams: yq is required (run install_yq.sh)
install_snowflake_cli: snow not resolvable after install
```

`install.sh` now fixes its own `PATH` (dedup-safe, ahead of the `command -v gff` probe, which had the same latent bug). `install_yq.sh` and `install_snowflake_cli.sh` are hardened standalone too, and now exit non-zero instead of printing a red error and returning success. `install_yq.sh` also separates "binary does not run" from "PATH does not resolve it", so the message names the real fault.

## Why

A fleet host could not be updated at all. Worse, both failures reported the wrong cause: an operator reading the log would have gone hunting for a copyleft dependency that does not exist, and would have concluded `yq` failed to install when it had installed correctly. The gates were fine — their **presence checks** were wrong.

## Impact

- `fleet update <host>` completes on a host whose `go-licenses` sits under a different Go version than `.go-version` pins.
- `sync-plugins` and `install_ai_teams` get a working `yq` under `fleet update`, instead of being skipped with `WARNING: ... continuing`.
- The license gate still **fails hard** on a genuinely banned dependency — only the missing/unrunnable-tool path changed.
- CI is unaffected: `teams-eval.yml` already appends `~/opt/bin` to `GITHUB_PATH`, and `install_yq.sh` now resolves internally, so that step still exits 0.
- No Go source changed.

## Testing

Reproduced and fixed against the exact condition from the failing run (this host has the same 1.26.1/1.26.3 split):

| Check | Before | After |
| :--- | :--- | :--- |
| `sdk/gsl` check-deps under `.go-version` 1.26.1 | exit 1, `FAIL: a disallowed ... license is present` | exit 0, `SKIP: go-licenses not installed or not runnable` |
| `install_yq.sh` under `PATH=/usr/local/bin:/usr/bin:/bin` | `yq not resolvable after install` | resolves, exit 0 |

New regression cases:

- 3 per module in `check-deps_test.sh` — drive a fake 127-exiting goenv-style `go-licenses` shim, asserting it skips non-strict, fails strict, and is diagnosed as a **missing tool**, never as a bad license.
- 5 in `install_test.sh` — execute the PATH block **extracted verbatim from the shipped `install.sh`** (not re-implemented), covering a bare non-login PATH, no duplicate accumulation across repeated fleet runs, partial configuration, prefix-collision (`opt/bin-extra`), and ordering before the `gff` probe.

Gates:

| Gate | Result |
| :--- | :--- |
| `make shell-test` | 30 passed, 0 failed |
| `install_test.sh` | 19 PASS / 0 FAIL |
| `sdk/gsl` + `sdk/gss` check-deps self-tests | 6/6 each |
| `make lint-shell` | exit 0 |
| `make lint-portability` | exit 0 (Tier 1: 0, Tier 2: 0) |

Pre-existing MD060 findings in `sdk/gsl/README.md:352` are untouched and predate this change.

## Out of scope

The same run logged `WARN: global: user.name is not set` / `user.email is not set` and a `gh` token missing the `user` scope. Those are host state, not a repo bug — `git_identity_doctor.sh` is reporting correctly. Fix on the host with `git config --global user.name/user.email` and `gh auth refresh -h github.com -s user`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYRs5Yq2QYFkL4EHfa1sLX