### PR TITLE
sdk-lint-cleanup: golangci

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -35,6 +35,7 @@ merge_protections:
     success_conditions:
       - check-success = Build and Integration Test
       - check-success = Lint (go + shell + markdown + actions)
+      - check-success = Go Lint (golangci-lint)
       - check-success = Validate teams source + routing artifacts
       - check-success = binary-level e2e tests
       - check-success = unit tests + coverage gate

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -152,6 +152,39 @@ jobs:
         continue-on-error: true
         run: make lint-shell
 
+  go-lint:
+    name: Go Lint (golangci-lint)
+    runs-on: ubuntu-latest
+    # A hang must die in minutes, not burn the 6-hour default (PR #182 lesson).
+    timeout-minutes: 15
+    # Dedicated Go check, STRICT — no continue-on-error. golangci-lint also
+    # runs inside the `lint` job's `make lint` step, but that job is warn-only
+    # across every linter, which is why a 212-finding Go backlog sat on main
+    # under a green "Lint" check for months. This job isolates the Go signal
+    # under its own required context so a regression is a hard failure.
+    #
+    # It is strict because the Go backlog is at ZERO (all six sdk/ modules),
+    # which is the condition the `lint` job's comment names for dropping the
+    # warn-only flag "per linter as each category reaches zero". Shell and
+    # markdown are not there yet, so `make lint` itself stays warn-only.
+    #
+    # Do NOT add a paths filter: a required check that is skipped never
+    # reports, and the merge queue then waits on it forever (docs/mergify.md).
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache-dependency-path: |
+            sdk/**/*.sum
+      - name: Install golangci-lint
+        run: |
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Run make lint-go
+        run: make lint-go
+
   unit-tests:
     name: Run Unit Tests
     needs: lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,10 +6,12 @@
 # Pinned tool version (CI must match, see .github/workflows/docker-image.yml):
 #   golangci-lint v2.0.2 (latest stable line as of January 2026)
 #
-# This repo contains FOUR separate Go modules: sdk/gss, sdk/tmux-mgr, sdk/gsl,
-# sdk/wol. golangci-lint v2 auto-discovers each module when invoked from its
-# directory, so we keep this config free of repo-root path assumptions and
-# rely on the Makefile's `lint-go` target to iterate per-module.
+# This repo contains SIX separate Go modules: sdk/fleet, sdk/gff, sdk/gsl,
+# sdk/gss, sdk/tmux-mgr, sdk/wol. golangci-lint v2 auto-discovers each module
+# when invoked from its directory, so we keep this config free of repo-root
+# path assumptions and rely on the Makefile's `lint-go` target to iterate
+# per-module (that target lints ALL modules before failing — do not reintroduce
+# an early `|| exit 1`, which silently masked five modules for months).
 
 version: "2"
 
@@ -27,6 +29,24 @@ linters:
     - ineffassign   # detect dead assignments
     - staticcheck   # broad correctness + simplification ruleset
     - unused        # unused variables / functions / types
+
+  settings:
+    errcheck:
+      # Writes to a cobra command's own writer (cmd.OutOrStdout() /
+      # ErrOrStderr()) cannot be meaningfully recovered from: the command is
+      # already producing its final output, and there is nowhere left to report
+      # a failed write to. The Go stdlib takes the same position — fmt.Print*
+      # returns an error essentially nobody checks. Excluding the family here,
+      # once, keeps the 105 such call sites free of `_, _ =` noise so the
+      # remaining errcheck findings are all genuine unchecked-error bugs
+      # (Close, Run, Setenv, MkdirAll, WriteFile, ...) that DO deserve review.
+      #
+      # This is a deliberate narrowing of errcheck, not a backlog suppression:
+      # every other unchecked error in the tree is still a hard finding.
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
 
   exclusions:
     # Standard auto-generated and vendored paths.

--- a/Makefile
+++ b/Makefile
@@ -120,12 +120,20 @@ lint-go: ## Lint Go modules (gofmt + golangci-lint, per-module)
 			echo "$$unformatted"; \
 			exit 1; \
 		fi
-	@for d in sdk/*; do \
+	@# Lint EVERY module before failing. The previous `|| exit 1` bailed on the
+	@# first failing module, and `sdk/*` globs alphabetically — so `sdk/fleet`
+	@# masked the findings of all five other modules from CI for months.
+	@failed=''; \
+	for d in sdk/*; do \
 		if [ -f "$$d/go.mod" ]; then \
 			echo "==> golangci-lint run ($$d)"; \
-			(cd "$$d" && golangci-lint run ./...) || exit 1; \
+			(cd "$$d" && golangci-lint run ./...) || failed="$$failed $$d"; \
 		fi; \
-	done
+	done; \
+	if [ -n "$$failed" ]; then \
+		echo "golangci-lint failed in:$$failed"; \
+		exit 1; \
+	fi
 
 .PHONY: lint-shell
 lint-shell: ## Lint shell scripts with shellcheck

--- a/docs/mergify.md
+++ b/docs/mergify.md
@@ -95,6 +95,32 @@ fire: re-run `make ruleset-snapshot` and commit the diff if settings changed,
 and note the bypass in the PR. Bypass is deliberate friction — never part of
 the routine flow.
 
+## Pending: promote `Go Lint (golangci-lint)` to a ruleset-required check
+
+The `go-lint` job (`.github/workflows/docker-image.yml`) is STRICT — it runs
+`make lint-go` with no `continue-on-error` — and is listed in
+`.mergify.yml`'s `merge_protections`. It is **not yet in the GitHub ruleset's
+native required-check list**, which is still the real enforcer (see Rollout
+state below), so a Go regression currently fails that job without blocking a
+merge.
+
+Order matters, and it is the reverse of the obvious one:
+
+1. **Merge the PR that adds the job first.** Adding the context to the ruleset
+   beforehand would make every open PR wait on a check that cannot report —
+   their branches predate the job — which is the "waiting for queue
+   conditions" deadlock described above.
+2. Then add `Go Lint (golangci-lint)` to the ruleset's required checks.
+3. Then `make ruleset-snapshot` and commit the resulting
+   `.github/rulesets/main.json` diff.
+
+Why this check exists separately from the `lint` job: `make lint` is
+warn-only across every linter, so a 212-finding Go backlog accumulated on
+`main` under a permanently green "Lint" check. The Go category is now at zero
+across all six `sdk/` modules, which is the condition the `lint` job names for
+going strict "per linter as each category reaches zero". Shell (~90) and
+markdown (~979) are not there yet, so `make lint` itself stays warn-only.
+
 ## Rollout state
 
 `merge_protections` currently runs alongside the ruleset's native required

--- a/sdk/fleet/cmd/keys_test.go
+++ b/sdk/fleet/cmd/keys_test.go
@@ -200,7 +200,7 @@ func TestRemoveKeyCommandHandlesRemovingTheLastKey(t *testing.T) {
 func TestRemoveKeyCommandKeepsOtherKeys(t *testing.T) {
 	dir := t.TempDir()
 	ak := filepath.Join(dir, "authorized_keys")
-	os.WriteFile(ak, []byte("ssh-ed25519 AAA me@box\nssh-ed25519 ZZZ ci@runner\n"), 0o600)
+	mustWriteFile(t, ak, []byte("ssh-ed25519 AAA me@box\nssh-ed25519 ZZZ ci@runner\n"), 0o600)
 	if out, err := exec.Command("bash", "-c", removeKeyCmd(ak, "ssh-ed25519 ZZZ ci@runner")).CombinedOutput(); err != nil {
 		t.Fatalf("%v\n%s", err, out)
 	}

--- a/sdk/fleet/cmd/membership_test.go
+++ b/sdk/fleet/cmd/membership_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/sshconf"
 )
 
+// mustWriteFile writes a test fixture and fails the test if it cannot. An
+// unchecked fixture write lets the assertions below run against a file that
+// was never created, turning a setup failure into a confusing assertion error.
+func mustWriteFile(t *testing.T, path string, data []byte, perm os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, data, perm); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
+	}
+}
+
 // Adopting a host that is ALREADY in ~/.ssh/config must not require re-typing
 // its connection details — that was the whole friction. resolveAdd marks the
 // existing block in place and keeps its directives.
@@ -100,7 +110,7 @@ func TestWriteConfigTakesBackupFirst(t *testing.T) {
 func TestWriteConfigKeepsOwnerOnlyPermissions(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "config")
-	os.WriteFile(p, []byte("Host a\n"), 0o600)
+	mustWriteFile(t, p, []byte("Host a\n"), 0o600)
 	if err := writeConfig(p, "Host a\n    HostName 1\n"); err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +124,7 @@ func TestDryRunWritesNothing(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "config")
 	orig := "Host beta\n    HostName 10.0.0.2\n"
-	os.WriteFile(p, []byte(orig), 0o600)
+	mustWriteFile(t, p, []byte(orig), 0o600)
 
 	var sb strings.Builder
 	if err := applyConfig(&sb, p, "Host beta\n    HostName 10.0.0.9\n", true); err != nil {

--- a/sdk/fleet/cmd/status.go
+++ b/sdk/fleet/cmd/status.go
@@ -440,6 +440,3 @@ func init() {
 	statusCmd.Flags().StringVar(&flagRef, "ref", "origin/main", "baseline git ref")
 	rootCmd.AddCommand(statusCmd)
 }
-
-// drift0 renders a row's install age.
-func drift0(now time.Time, r Row) string { return drift.FormatAge(now, r.Age) }

--- a/sdk/fleet/cmd/status_test.go
+++ b/sdk/fleet/cmd/status_test.go
@@ -22,7 +22,7 @@ func TestRenderTableIsWorstFirst(t *testing.T) {
 	}
 	out := renderTable(rows, testNow)
 	iDead, iStale, iGood := strings.Index(out, "dead"), strings.Index(out, "stale"), strings.Index(out, "good")
-	if !(iDead < iStale && iStale < iGood) {
+	if iDead >= iStale || iStale >= iGood {
 		t.Fatalf("rows not worst-first:\n%s", out)
 	}
 	if !strings.Contains(out, "behind 24") {

--- a/sdk/fleet/cmd/tui_cmds.go
+++ b/sdk/fleet/cmd/tui_cmds.go
@@ -128,16 +128,6 @@ func (a answers) remembered() bool {
 	return a.sudoSecret != "" || a.windows != "" || a.gemini != ""
 }
 
-// summary is what the confirm strip prints. It is the compensating control for
-// answers that outlive their wave: the operator sees exactly what is about to
-// be applied, every time. The credential appears ONLY as a length mask.
-func (a answers) summary() string {
-	parts := []string{"sudo " + maskOrNone(a.secretLen())}
-	parts = append(parts, "windows "+orUnset(a.windows))
-	parts = append(parts, "gemini "+orUnset(a.gemini))
-	return strings.Join(parts, " · ")
-}
-
 func maskOrNone(n int) string {
 	if n == 0 {
 		return "(none)"

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -766,14 +765,4 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return route(m, msg)
 	}
 	return m, nil
-}
-
-// sortedAliases is used by tests and the help overlay for stable ordering.
-func sortedAliases(set map[string]bool) []string {
-	out := make([]string, 0, len(set))
-	for a := range set {
-		out = append(out, a)
-	}
-	sort.Strings(out)
-	return out
 }

--- a/sdk/fleet/cmd/tui_view.go
+++ b/sdk/fleet/cmd/tui_view.go
@@ -192,9 +192,9 @@ func (m tuiModel) logView() string {
 	start := m.logStart(h)
 	for i := start; i < len(m.logs) && i < start+h; i++ {
 		e := m.logs[i]
-		body.WriteString(fmt.Sprintf("%s %s\n",
+		fmt.Fprintf(&body, "%s %s\n",
 			m.hostStyle(e.alias).Render(fmt.Sprintf("%-14s│", trunc(e.alias, 14))),
-			trunc(e.line, m.logWidth()-18)))
+			trunc(e.line, m.logWidth()-18))
 	}
 	return th.panel.Width(m.panelWidth()).Render(strings.TrimRight(body.String(), "\n"))
 }
@@ -309,7 +309,7 @@ func (m tuiModel) rowView(i int) string {
 	// long one, so a 30-character hostname silently pushed the row past the
 	// terminal edge regardless of width.
 	name := truncate(r.Alias, aliasColWidth)
-	alias := name
+	var alias string
 	if m.matches(r) {
 		alias = th.match.Render(name)
 		alias += strings.Repeat(" ", max0(aliasColWidth-lipgloss.Width(name)))
@@ -538,7 +538,7 @@ func (m tuiModel) helpView() string {
 	var b strings.Builder
 	b.WriteString(th.header.Render("❓ keys") + "\n\n")
 	for _, k := range keyHelp {
-		b.WriteString(fmt.Sprintf("  %s %-18s %s\n", k.icon, k.keys, th.dim.Render(k.what)))
+		fmt.Fprintf(&b, "  %s %-18s %s\n", k.icon, k.keys, th.dim.Render(k.what))
 	}
 	b.WriteString("\n" + th.dim.Render("any key to close"))
 	return th.panel.Width(m.panelWidth()).Render(strings.TrimRight(b.String(), "\n"))

--- a/sdk/gff/cmd/paths_test.go
+++ b/sdk/gff/cmd/paths_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -31,10 +30,8 @@ func TestPathsDefault(t *testing.T) {
 
 func TestPathsDefaultWithXDGDataHome(t *testing.T) {
 	tmpdir := t.TempDir()
-	oldXDG := os.Getenv("XDG_DATA_HOME")
-	defer os.Setenv("XDG_DATA_HOME", oldXDG)
-
-	os.Setenv("XDG_DATA_HOME", tmpdir)
+	// t.Setenv restores the previous value when the test finishes.
+	t.Setenv("XDG_DATA_HOME", tmpdir)
 
 	p, err := paths.Default()
 	require.NoError(t, err)

--- a/sdk/gff/cmd/read_test.go
+++ b/sdk/gff/cmd/read_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -443,11 +442,11 @@ func TestGetSourceRegisteredName(t *testing.T) {
 		[]byte(boolFeatYAML), 0o644))
 
 	// Write sources.yaml pointing at that namespace.
-	sourcesYAML := fmt.Sprintf(`sources:
+	sourcesYAML := `sources:
   - namespace: com.example.test
     url: https://github.com/example/test
     commit: abc1234
-`)
+`
 	registryFile := filepath.Join(dir, "sources.yaml")
 	require.NoError(t, os.WriteFile(registryFile, []byte(sourcesYAML), 0o644))
 

--- a/sdk/gff/cmd/tui.go
+++ b/sdk/gff/cmd/tui.go
@@ -37,13 +37,13 @@ func runTUI(_ *cobra.Command, _ []string) error {
 
 	m := tui.NewModel(items, r.P)
 	m.Explain = r.Explain
-	if reg := (&registry.Registry{P: r.P}); reg != nil {
-		if srcs, err := reg.Sources(); err == nil {
-			for _, s := range srcs {
-				m.Sources = append(m.Sources, tui.SourceInfo{
-					Namespace: s.GetNamespace(), URL: s.GetUrl(), Commit: s.GetCommit(),
-				})
-			}
+	// &T{...} is never nil, so the old `reg != nil` guard was dead code.
+	reg := &registry.Registry{P: r.P}
+	if srcs, err := reg.Sources(); err == nil {
+		for _, s := range srcs {
+			m.Sources = append(m.Sources, tui.SourceInfo{
+				Namespace: s.GetNamespace(), URL: s.GetUrl(), Commit: s.GetCommit(),
+			})
 		}
 	}
 	p := tea.NewProgram(m, tea.WithAltScreen())

--- a/sdk/gff/internal/overrides/overrides_test.go
+++ b/sdk/gff/internal/overrides/overrides_test.go
@@ -200,7 +200,8 @@ func TestWriteFileAtomicErrorOnUnwritableDir(t *testing.T) {
 	if err := os.Chmod(rodir, 0o444); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(rodir, 0o755) // cleanup
+	// Restore write permission so t.TempDir cleanup can remove the dir.
+	defer func() { _ = os.Chmod(rodir, 0o755) }()
 
 	path := filepath.Join(rodir, "file.yaml")
 	if err := WriteFileAtomic(path, []byte("test\n"), 0o644); err == nil {
@@ -355,7 +356,7 @@ func TestWriteFileAtomicTempWriteError(t *testing.T) {
 	if err := os.Chmod(rodir, 0o444); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(rodir, 0o755)
+	defer func() { _ = os.Chmod(rodir, 0o755) }()
 
 	path := filepath.Join(rodir, "file.yaml")
 	if err := WriteFileAtomic(path, []byte("test\n"), 0o644); err == nil {
@@ -409,7 +410,7 @@ func TestMarshalDeterministic(t *testing.T) {
 		}
 	}
 
-	if !(aaa_pos < mmm_pos && mmm_pos < zzz_pos) {
+	if aaa_pos >= mmm_pos || mmm_pos >= zzz_pos {
 		t.Errorf("keys not in alphabetical order: aaa@%d, mmm@%d, zzz@%d", aaa_pos, mmm_pos, zzz_pos)
 	}
 }

--- a/sdk/gff/internal/tui/keyspace_test.go
+++ b/sdk/gff/internal/tui/keyspace_test.go
@@ -31,7 +31,7 @@ func TestRealTerminalSpaceTogglesBool(t *testing.T) {
 	var m tea.Model = tui.NewModel(items, p)
 	m = press(m, tea.KeyMsg{Type: tea.KeyEnter}) // expand area
 	m = press(m, tea.KeyMsg{Type: tea.KeyDown})  // onto install.ai.claude
-	m = press(m, tea.KeyMsg{Type: tea.KeySpace}) // REAL spacebar
+	press(m, tea.KeyMsg{Type: tea.KeySpace})     // REAL spacebar; asserted via the file it writes
 
 	data, err := os.ReadFile(p.UserOverride)
 	require.NoError(t, err, "real-terminal KeySpace must write the user override")
@@ -58,7 +58,7 @@ func TestRealTerminalSpaceDrivesPicker(t *testing.T) {
 
 	m = press(m, tea.KeyMsg{Type: tea.KeyDown})  // second option
 	m = press(m, tea.KeyMsg{Type: tea.KeySpace}) // REAL spacebar toggles entry
-	m = press(m, tea.KeyMsg{Type: tea.KeyEnter}) // confirm
+	press(m, tea.KeyMsg{Type: tea.KeyEnter})     // confirm; asserted via the file it writes
 
 	data, err := os.ReadFile(p.UserOverride)
 	require.NoError(t, err, "picker confirm after KeySpace toggle must write the override")

--- a/sdk/gff/internal/tui/model.go
+++ b/sdk/gff/internal/tui/model.go
@@ -3,7 +3,6 @@
 package tui
 
 import (
-	"io"
 	"sort"
 	"strings"
 
@@ -62,7 +61,6 @@ type pickerEntry struct {
 type Model struct {
 	items    []resolve.Resolved
 	p        paths.Paths
-	w        io.Writer // used by tests to capture output (nil = unused)
 	width    int
 	height   int
 	cursor   int             // index into m.rows (the rendered row list)

--- a/sdk/gff/internal/tui/view.go
+++ b/sdk/gff/internal/tui/view.go
@@ -249,16 +249,6 @@ func (m *Model) multiNS() bool {
 	return false
 }
 
-// anyExpanded reports whether any area is currently expanded.
-func (m *Model) anyExpanded() bool {
-	for _, v := range m.expanded {
-		if v {
-			return true
-		}
-	}
-	return false
-}
-
 // viewHelp is the ?/h overlay: about + version, the key legend for the view
 // it was opened from, and the full sources story (registry + discovered).
 func (m *Model) viewHelp() string {

--- a/sdk/gsl/cmd/config.go
+++ b/sdk/gsl/cmd/config.go
@@ -238,7 +238,7 @@ func listStyles(cfg config.Config) error {
 		if _, ok := builtins[name]; !ok {
 			label = "user"
 		}
-		sb.WriteString(fmt.Sprintf("%s%-16s (%s)\n", marker, name, label))
+		fmt.Fprintf(&sb, "%s%-16s (%s)\n", marker, name, label)
 	}
 	fmt.Print(sb.String())
 	return nil

--- a/sdk/gsl/cmd/render_test.go
+++ b/sdk/gsl/cmd/render_test.go
@@ -39,7 +39,7 @@ func captureStdout(t *testing.T, f func()) string {
 
 	f()
 
-	w.Close()
+	_ = w.Close()
 	var buf bytes.Buffer
 	io.Copy(&buf, r) //nolint:errcheck
 	return buf.String()
@@ -56,7 +56,7 @@ func TestRenderCmd_EmptyStdin(t *testing.T) {
 		origStdin := os.Stdin
 		f, _ := os.Open(os.DevNull)
 		os.Stdin = f
-		defer func() { os.Stdin = origStdin; f.Close() }()
+		defer func() { os.Stdin = origStdin; _ = f.Close() }()
 
 		out := captureStdout(t, func() {
 			cmd := renderCmd
@@ -81,11 +81,11 @@ func TestRenderCmd_WithPayload_ProducesLine(t *testing.T) {
 		// Redirect stdin to the payload.
 		r, w, _ := os.Pipe()
 		fmt.Fprint(w, payload)
-		w.Close()
+		_ = w.Close()
 
 		origStdin := os.Stdin
 		os.Stdin = r
-		defer func() { os.Stdin = origStdin; r.Close() }()
+		defer func() { os.Stdin = origStdin; _ = r.Close() }()
 
 		out := captureStdout(t, func() {
 			if err := runRender(renderCmd, nil); err != nil {
@@ -110,7 +110,7 @@ func TestRenderCmd_MasterDisabled(t *testing.T) {
 		origStdin := os.Stdin
 		f, _ := os.Open(os.DevNull)
 		os.Stdin = f
-		defer func() { os.Stdin = origStdin; f.Close() }()
+		defer func() { os.Stdin = origStdin; _ = f.Close() }()
 
 		out := captureStdout(t, func() {
 			if err := runRender(renderCmd, nil); err != nil {
@@ -129,11 +129,11 @@ func TestRenderCmd_BadJSON(t *testing.T) {
 	withTempConfig(t, cfg, func() {
 		r, w, _ := os.Pipe()
 		fmt.Fprint(w, `{invalid json`)
-		w.Close()
+		_ = w.Close()
 
 		origStdin := os.Stdin
 		os.Stdin = r
-		defer func() { os.Stdin = origStdin; r.Close() }()
+		defer func() { os.Stdin = origStdin; _ = r.Close() }()
 
 		// Must not return an error (degrade gracefully).
 		captureStdout(t, func() {
@@ -157,11 +157,11 @@ func TestRenderCmd_BadJSON_LogsStructuredEvent(t *testing.T) {
 	withTempConfig(t, cfg, func() {
 		r, w, _ := os.Pipe()
 		fmt.Fprint(w, `{invalid json`)
-		w.Close()
+		_ = w.Close()
 
 		origStdin := os.Stdin
 		os.Stdin = r
-		defer func() { os.Stdin = origStdin; r.Close() }()
+		defer func() { os.Stdin = origStdin; _ = r.Close() }()
 
 		captureStdout(t, func() {
 			if err := runRender(renderCmd, nil); err != nil {
@@ -197,7 +197,7 @@ func TestRenderCmd_MalformedConfig_FallsBackToDefaults(t *testing.T) {
 	origStdin := os.Stdin
 	f, _ := os.Open(os.DevNull)
 	os.Stdin = f
-	defer func() { os.Stdin = origStdin; f.Close() }()
+	defer func() { os.Stdin = origStdin; _ = f.Close() }()
 
 	// Capture stderr to assert a warning is emitted.
 	origStderr := os.Stderr
@@ -211,7 +211,7 @@ func TestRenderCmd_MalformedConfig_FallsBackToDefaults(t *testing.T) {
 		}
 	})
 
-	wErr.Close()
+	_ = wErr.Close()
 	os.Stderr = origStderr
 	var errBuf bytes.Buffer
 	io.Copy(&errBuf, rErr) //nolint:errcheck

--- a/sdk/gsl/cmd/statusline_test.go
+++ b/sdk/gsl/cmd/statusline_test.go
@@ -159,14 +159,14 @@ func fitOutput(t *testing.T, styleName string, columns int, payloadJSON string) 
 	if payloadJSON == "" {
 		origStdin := os.Stdin
 		f, _ := os.Open(os.DevNull)
-		t.Cleanup(func() { os.Stdin = origStdin; f.Close() })
+		t.Cleanup(func() { os.Stdin = origStdin; _ = f.Close() })
 		os.Stdin = f
 	} else {
 		r, w, _ := os.Pipe()
 		fmt.Fprint(w, payloadJSON)
-		w.Close()
+		_ = w.Close()
 		origStdin := os.Stdin
-		t.Cleanup(func() { os.Stdin = origStdin; r.Close() })
+		t.Cleanup(func() { os.Stdin = origStdin; _ = r.Close() })
 		os.Stdin = r
 	}
 

--- a/sdk/gsl/internal/config/priority_test.go
+++ b/sdk/gsl/internal/config/priority_test.go
@@ -11,10 +11,9 @@ import (
 
 func TestDefaultSegmentPriority_Order(t *testing.T) {
 	// The drop order the fit loop relies on: time goes first, repo goes last.
-	if !(DefaultSegmentPriority("time") <
-		DefaultSegmentPriority("ai") &&
-		DefaultSegmentPriority("ai") < DefaultSegmentPriority("dirgit") &&
-		DefaultSegmentPriority("dirgit") < DefaultSegmentPriority("repo")) {
+	if DefaultSegmentPriority("time") >= DefaultSegmentPriority("ai") ||
+		DefaultSegmentPriority("ai") >= DefaultSegmentPriority("dirgit") ||
+		DefaultSegmentPriority("dirgit") >= DefaultSegmentPriority("repo") {
 		t.Errorf("want time < ai < dirgit < repo, got time=%d ai=%d dirgit=%d repo=%d",
 			DefaultSegmentPriority("time"), DefaultSegmentPriority("ai"),
 			DefaultSegmentPriority("dirgit"), DefaultSegmentPriority("repo"))

--- a/sdk/gsl/internal/gh/fake/runner_test.go
+++ b/sdk/gsl/internal/gh/fake/runner_test.go
@@ -36,8 +36,8 @@ func TestFakeRunnerScript(t *testing.T) {
 
 func TestFakeRunnerRecordsCalls(t *testing.T) {
 	r := &fake.Runner{}
-	r.Run(context.Background(), "pr", "view")
-	r.Run(context.Background(), "repo", "view")
+	_, _ = r.Run(context.Background(), "pr", "view")
+	_, _ = r.Run(context.Background(), "repo", "view")
 	if r.CallCount() != 2 {
 		t.Errorf("CallCount = %d; want 2", r.CallCount())
 	}
@@ -45,7 +45,7 @@ func TestFakeRunnerRecordsCalls(t *testing.T) {
 
 func TestFakeRunnerReset(t *testing.T) {
 	r := &fake.Runner{}
-	r.Run(context.Background(), "pr", "view")
+	_, _ = r.Run(context.Background(), "pr", "view")
 	r.Reset()
 	if r.CallCount() != 0 {
 		t.Errorf("after Reset, CallCount = %d; want 0", r.CallCount())

--- a/sdk/gsl/internal/gh/pr_test.go
+++ b/sdk/gsl/internal/gh/pr_test.go
@@ -50,21 +50,6 @@ func writeFreshCache(t *testing.T, _ string, branch string, info gh.PRInfo) {
 	}
 }
 
-// replaceAll is a minimal strings.ReplaceAll stand-in using stdlib only.
-func replaceAll(s, old, new string) string {
-	out := make([]byte, 0, len(s))
-	for i := 0; i < len(s); {
-		if i+len(old) <= len(s) && s[i:i+len(old)] == old {
-			out = append(out, new...)
-			i += len(old)
-		} else {
-			out = append(out, s[i])
-			i++
-		}
-	}
-	return string(out)
-}
-
 // --- Tests ---
 
 // TestPROpenState verifies that a successful gh pr view response is parsed

--- a/sdk/gsl/internal/git/fake/runner_test.go
+++ b/sdk/gsl/internal/git/fake/runner_test.go
@@ -50,8 +50,8 @@ func TestFakeRunnerScriptFIFO(t *testing.T) {
 
 func TestFakeRunnerRecordsCalls(t *testing.T) {
 	r := &fake.Runner{}
-	r.Run(context.Background(), "status", "--porcelain")
-	r.Run(context.Background(), "rev-parse", "--short", "HEAD")
+	_, _ = r.Run(context.Background(), "status", "--porcelain")
+	_, _ = r.Run(context.Background(), "rev-parse", "--short", "HEAD")
 
 	if r.CallCount() != 2 {
 		t.Errorf("CallCount = %d; want 2", r.CallCount())
@@ -68,7 +68,7 @@ func TestFakeRunnerReset(t *testing.T) {
 	r := &fake.Runner{
 		Script: []fake.Response{{Stdout: []byte("data")}},
 	}
-	r.Run(context.Background(), "status")
+	_, _ = r.Run(context.Background(), "status")
 
 	r.Reset()
 	if r.CallCount() != 0 {

--- a/sdk/gsl/internal/mcp/fake/runner_test.go
+++ b/sdk/gsl/internal/mcp/fake/runner_test.go
@@ -36,8 +36,8 @@ func TestFakeRunnerScript(t *testing.T) {
 
 func TestFakeRunnerRecordsCalls(t *testing.T) {
 	r := &fake.Runner{}
-	r.Run(context.Background(), "mcp", "list")
-	r.Run(context.Background(), "mcp", "status")
+	_, _ = r.Run(context.Background(), "mcp", "list")
+	_, _ = r.Run(context.Background(), "mcp", "status")
 	if r.CallCount() != 2 {
 		t.Errorf("CallCount = %d; want 2", r.CallCount())
 	}
@@ -45,7 +45,7 @@ func TestFakeRunnerRecordsCalls(t *testing.T) {
 
 func TestFakeRunnerReset(t *testing.T) {
 	r := &fake.Runner{}
-	r.Run(context.Background(), "mcp", "list")
+	_, _ = r.Run(context.Background(), "mcp", "list")
 	r.Reset()
 	if r.CallCount() != 0 {
 		t.Errorf("after Reset, CallCount = %d; want 0", r.CallCount())

--- a/sdk/gsl/internal/preview/model.go
+++ b/sdk/gsl/internal/preview/model.go
@@ -155,8 +155,8 @@ func (m Model) View() string {
 	var sb strings.Builder
 
 	sb.WriteString("gsl preview  [s] cycle style  [f] cycle fixture  [1-4] toggle segments  [q] quit\n")
-	sb.WriteString(fmt.Sprintf("style: %-12s  fixture: %s\n", m.currentStyleName(), m.fixtureName))
-	sb.WriteString(fmt.Sprintf("segments: %s\n", m.segmentBadges()))
+	fmt.Fprintf(&sb, "style: %-12s  fixture: %s\n", m.currentStyleName(), m.fixtureName)
+	fmt.Fprintf(&sb, "segments: %s\n", m.segmentBadges())
 	sb.WriteString("─────────────────────────────────────────────────────\n")
 	sb.WriteString(m.renderLine())
 	sb.WriteString("\n")
@@ -208,6 +208,13 @@ func (m Model) renderLine() string {
 	// Use the known window width when available; fall back to $COLUMNS then 80.
 	cols := m.windowWidth
 	if cols <= 0 {
+		// term.Columns is deprecated in favour of cmd.resolveColumns (spec F1),
+		// but its deprecation note names internal/preview as the one caller it
+		// is deliberately preserved for: this is the pre-WindowSizeMsg first
+		// frame, and preview cannot import package cmd. Rewiring preview onto
+		// the F1 resolver is a behaviour change, not a lint fix, so it stays
+		// out of this cleanup.
+		//nolint:staticcheck // SA1019: sanctioned caller, see term.Columns doc
 		cols = term.Columns(nil) // nil source → $COLUMNS then 80
 	}
 

--- a/sdk/gsl/internal/render/render.go
+++ b/sdk/gsl/internal/render/render.go
@@ -26,7 +26,7 @@ func segmentTypeName(s Segment) string {
 		return "unknown"
 	}
 	t := reflect.TypeOf(s)
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	if name := t.Name(); name != "" {

--- a/sdk/gsl/internal/render/truncate_test.go
+++ b/sdk/gsl/internal/render/truncate_test.go
@@ -86,7 +86,7 @@ func TestTruncateText_DoesNotSplitZWJCluster(t *testing.T) {
 		if hasWoman && !hasWhole {
 			t.Fatalf("cols=%d: truncateText split the ZWJ cluster: %q", cols, got)
 		}
-		if strings.HasSuffix(got, "‍") {
+		if strings.HasSuffix(got, "\u200d") {
 			t.Fatalf("cols=%d: truncateText left a dangling ZWJ: %q", cols, got)
 		}
 	}

--- a/sdk/gsl/internal/repo/registry.go
+++ b/sdk/gsl/internal/repo/registry.go
@@ -99,12 +99,9 @@ func LoadRegistry(path string) (*Registry, error) {
 	for _, rf := range raw.Features {
 		f := Feature{Name: rf.Name, Workers: make([]Worker, 0, len(rf.Workers))}
 		for _, rw := range rf.Workers {
-			f.Workers = append(f.Workers, Worker{
-				Branch:   rw.Branch,
-				Worktree: rw.Worktree,
-				PRUrl:    rw.PRUrl,
-				PRState:  rw.PRState,
-			})
+			// rawWorker and Worker have identical fields; the conversion keeps
+			// them in lockstep (adding a field to only one is a compile error).
+			f.Workers = append(f.Workers, Worker(rw))
 		}
 		reg.Features = append(reg.Features, f)
 	}

--- a/sdk/gsl/internal/style/resolve.go
+++ b/sdk/gsl/internal/style/resolve.go
@@ -277,11 +277,10 @@ func Resolve(w io.Writer, styleName string, userStyles map[string]Style, forceAS
 	}
 
 	// ── 2. Deep-merge user override (if any) ─────────────────────────────────
+	// An unknown style name with no user entry needs no merge: base is already
+	// powerline from the fallback above.
 	if user, ok := userStyles[styleName]; ok {
 		base = mergeInto(base, user)
-	} else if !found {
-		// Unknown style name AND no user entry → base is already powerline;
-		// nothing extra to merge.
 	}
 
 	// Special case: brand-new style name (not a built-in) with a user entry.

--- a/sdk/gsl/internal/style/style_test.go
+++ b/sdk/gsl/internal/style/style_test.go
@@ -771,12 +771,14 @@ func TestResolveConfig_AutoPalette_EmptyName_NoMerge(t *testing.T) {
 	sNoAuto := style.ResolveConfig(&buf, "powerline", nil, false, "")
 	sWithDark := style.ResolveConfig(&buf, "powerline", nil, false, "dark")
 
-	// Both should have the same segment keys (dark palette matches builtins).
+	// The "dark" auto-palette intentionally matches the builtins, so every
+	// segment colour must agree. This used to be an empty if body that asserted
+	// nothing beyond "did not panic"; making it a real comparison is what the
+	// surrounding comment always claimed it was doing.
 	for _, key := range style.SegmentColorKeys() {
 		if sNoAuto.Theme[key] != sWithDark.Theme[key] {
-			// The "dark" palette intentionally matches the builtins. But even if
-			// it didn't, the empty-name path must not crash.
-			// Just assert no panic.
+			t.Errorf("segment %q: auto-palette %q must match the builtin, got %q vs %q",
+				key, "dark", sNoAuto.Theme[key], sWithDark.Theme[key])
 		}
 	}
 }

--- a/sdk/gsl/internal/theme/settings.go
+++ b/sdk/gsl/internal/theme/settings.go
@@ -196,7 +196,8 @@ func readSettingsFile(home, path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("theme: open %s: %w", path, err)
 	}
-	defer f.Close()
+	// Read-only handle: a Close failure cannot affect the bytes already read.
+	defer func() { _ = f.Close() }()
 
 	data, err := io.ReadAll(io.LimitReader(f, maxSettingsBytes+1))
 	if err != nil {

--- a/sdk/gss/cmd/status_test.go
+++ b/sdk/gss/cmd/status_test.go
@@ -7,20 +7,28 @@ import (
 	"testing"
 )
 
-func TestIsDirty(t *testing.T) {
-	// Create a temporary directory
-	tempDir, err := os.MkdirTemp("", "gss-test-*")
+// mustGit runs a git command in dir and fails the test if it does not succeed.
+// These setup commands used to run unchecked, so a failed `git init` or
+// `git config` surfaced later as a confusing assertion failure about
+// dirtiness rather than a clear setup error.
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("setup: git %v: %v\n%s", args, err, out)
 	}
-	defer os.RemoveAll(tempDir)
+}
+
+func TestIsDirty(t *testing.T) {
+	// t.TempDir cleans itself up when the test finishes.
+	tempDir := t.TempDir()
 
 	// Initialize a git repo
-	exec.Command("git", "-C", tempDir, "init").Run()
+	mustGit(t, tempDir, "init")
 	// Configure git for the temp repo to avoid failures due to missing global config
-	exec.Command("git", "-C", tempDir, "config", "user.email", "test@example.com").Run()
-	exec.Command("git", "-C", tempDir, "config", "user.name", "Test User").Run()
-	exec.Command("git", "-C", tempDir, "config", "commit.gpgsign", "false").Run()
+	mustGit(t, tempDir, "config", "user.email", "test@example.com")
+	mustGit(t, tempDir, "config", "user.name", "Test User")
+	mustGit(t, tempDir, "config", "commit.gpgsign", "false")
 
 	// Case 1: Clean repo (initially empty)
 	if isDirty(tempDir) {
@@ -40,7 +48,7 @@ func TestIsDirty(t *testing.T) {
 	}
 
 	// Case 3: Clean repo again (staged and committed)
-	exec.Command("git", "-C", tempDir, "add", ".").Run()
+	mustGit(t, tempDir, "add", ".")
 	if err := exec.Command("git", "-C", tempDir, "commit", "-m", "test").Run(); err != nil {
 		out, _ := exec.Command("git", "-C", tempDir, "status").CombinedOutput()
 		t.Fatalf("Failed to commit: %v. Status:\n%s", err, string(out))

--- a/sdk/gss/internal/feature/auto.go
+++ b/sdk/gss/internal/feature/auto.go
@@ -165,8 +165,11 @@ func (s *Service) appendAutoLog(worktree, reason string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
-	_, _ = f.WriteString(fmt.Sprintf("\n## Auto-checkpoint log\n- %s %s\n", s.now(), reason))
+	// Best-effort diagnostic: this helper reports nothing to its caller (which
+	// is already returning an error of its own), so a failure to write or close
+	// the log is discarded explicitly rather than silently.
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "\n## Auto-checkpoint log\n- %s %s\n", s.now(), reason)
 }
 
 // splitPorcelain partitions `git status --porcelain` lines into tracked

--- a/sdk/gss/internal/registry/lock.go
+++ b/sdk/gss/internal/registry/lock.go
@@ -109,7 +109,9 @@ func (s *Store) writeLocked(reg Registry) error {
 		return fmt.Errorf("registry: create temp: %w", err)
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName) // no-op after a successful rename
+	// No-op after a successful rename; nothing to report if the temp file is
+	// already gone.
+	defer func() { _ = os.Remove(tmpName) }()
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
 		return fmt.Errorf("registry: write temp: %w", err)

--- a/sdk/tmux-mgr/cmd/agent.go
+++ b/sdk/tmux-mgr/cmd/agent.go
@@ -15,7 +15,9 @@ import (
 )
 
 func runAgent(cmd *cobra.Command, args []string) {
-	cmd.Help()
+	// Bare `tmux-mgr agent` just prints usage; a failed write to the help
+	// stream has nowhere left to be reported.
+	_ = cmd.Help()
 }
 
 func runAgentStart(cmd *cobra.Command, args []string) error {
@@ -277,7 +279,11 @@ func runAntigravityLoop(task, agyPath, requestedModel string) error {
 
 		runErr := c.Run()
 		if logFile != nil {
-			logFile.Close()
+			// A failed Close truncates the agent transcript, which is the whole
+			// point of the log — say so rather than dropping it.
+			if err := logFile.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: closing agent log: %v\n", err)
+			}
 		}
 
 		if runErr == nil {
@@ -330,7 +336,9 @@ func runClaudeLoop(task, claudePath, model string) error {
 
 	runErr := c.Run()
 	if logFile != nil {
-		logFile.Close()
+		if err := logFile.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: closing agent log: %v\n", err)
+		}
 	}
 
 	if runErr != nil {
@@ -480,14 +488,16 @@ func init() {
 	agentCmd.AddCommand(cleanupCmd)
 
 	startCmd.Flags().StringP("task-description", "d", "", "A natural language description of the agent's task.")
-	startCmd.MarkFlagRequired("task-description")
+	// Cannot fail: the flag is registered on the line above.
+	_ = startCmd.MarkFlagRequired("task-description")
 	startCmd.Flags().String("feature", "", "gss feature to add the worker to (default: the agent name; auto-created)")
 	startCmd.Flags().String("purpose", "", "gss worker purpose (default: the agent name)")
 
 	cleanupCmd.Flags().Bool("force", false, "Forward --force to `gss feature done` (remove despite dirty/dependents/open PR)")
 
 	executeCmd.Flags().StringP("task-description", "d", "", "The task description for the agent.")
-	executeCmd.MarkFlagRequired("task-description")
+	// Cannot fail: the flag is registered on the line above.
+	_ = executeCmd.MarkFlagRequired("task-description")
 
 	listCmd.Flags().BoolP("all", "a", false, "Show sessions from every repo (and global sessions). Default scopes to current repo.")
 }

--- a/sdk/tmux-mgr/cmd/alias.go
+++ b/sdk/tmux-mgr/cmd/alias.go
@@ -28,7 +28,10 @@ alias tmux-start='tmux-mgr session new antigravity -a'
 `
 			home, _ := os.UserHomeDir()
 			configDir := filepath.Join(home, ".config", "tmux-mgr")
-			os.MkdirAll(configDir, 0755)
+			if err := os.MkdirAll(configDir, 0755); err != nil {
+				fmt.Printf("Error creating %s: %v\n", configDir, err)
+				return
+			}
 
 			aliasFile := filepath.Join(configDir, "aliases.sh")
 			err := os.WriteFile(aliasFile, []byte(aliases), 0644)
@@ -41,12 +44,19 @@ alias tmux-start='tmux-mgr session new antigravity -a'
 
 			// Generate completions
 			completionDir := filepath.Join(configDir, "completions")
-			os.MkdirAll(completionDir, 0755)
+			if err := os.MkdirAll(completionDir, 0755); err != nil {
+				fmt.Printf("Error creating %s: %v\n", completionDir, err)
+				return
+			}
 
 			bashComp := filepath.Join(completionDir, "tmux-mgr.bash")
-			rootCmd.GenBashCompletionFile(bashComp)
+			if err := rootCmd.GenBashCompletionFile(bashComp); err != nil {
+				fmt.Printf("Error writing bash completions: %v\n", err)
+			}
 			zshComp := filepath.Join(completionDir, "tmux-mgr.zsh")
-			rootCmd.GenZshCompletionFile(zshComp)
+			if err := rootCmd.GenZshCompletionFile(zshComp); err != nil {
+				fmt.Printf("Error writing zsh completions: %v\n", err)
+			}
 
 			// Update aliases file to include completions and alias completions
 			completionSource := `
@@ -66,9 +76,19 @@ if command -v compdef >/dev/null 2>&1; then
 fi
 `
 
-			f, _ := os.OpenFile(aliasFile, os.O_APPEND|os.O_WRONLY, 0644)
-			f.WriteString(completionSource)
-			f.Close()
+			// The error here used to be discarded and f used unconditionally: if
+			// OpenFile failed, f was nil and f.WriteString panicked.
+			cf, err := os.OpenFile(aliasFile, os.O_APPEND|os.O_WRONLY, 0644)
+			if err != nil {
+				fmt.Printf("Error appending completions to %s: %v\n", aliasFile, err)
+				return
+			}
+			if _, err := cf.WriteString(completionSource); err != nil {
+				fmt.Printf("Error writing completions to %s: %v\n", aliasFile, err)
+			}
+			if err := cf.Close(); err != nil {
+				fmt.Printf("Error closing %s: %v\n", aliasFile, err)
+			}
 
 			sourceLine := "\n# Added by tmux-mgr\n[ -f ${HOME}/.config/tmux-mgr/aliases.sh ] && source ${HOME}/.config/tmux-mgr/aliases.sh\n"
 
@@ -80,8 +100,12 @@ fi
 					if !contains(string(content), "tmux-mgr/aliases.sh") {
 						f, err := os.OpenFile(cfgPath, os.O_APPEND|os.O_WRONLY, 0644)
 						if err == nil {
-							f.WriteString(sourceLine)
-							f.Close()
+							if _, err := f.WriteString(sourceLine); err != nil {
+								fmt.Printf("Error updating %s: %v\n", cfg, err)
+							}
+							if err := f.Close(); err != nil {
+								fmt.Printf("Error closing %s: %v\n", cfg, err)
+							}
 							fmt.Printf("Updated %s to source aliases\n", cfg)
 						}
 					} else {

--- a/sdk/tmux-mgr/cmd/desktop.go
+++ b/sdk/tmux-mgr/cmd/desktop.go
@@ -21,7 +21,9 @@ func init() {
 			if args[0] == "switch" && len(args) > 1 {
 				target = args[1]
 			}
-			Tmgr.Run("select-window", "-t", target)
+			if !runTmux("select-window", "-t", target) {
+				return
+			}
 			log.Printf("Switched to window %s", target)
 		},
 	})

--- a/sdk/tmux-mgr/cmd/migrate.go
+++ b/sdk/tmux-mgr/cmd/migrate.go
@@ -255,8 +255,12 @@ func appendMigrateLog(summary string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	// This file is written, so a failed Close can lose buffered data. Report it
+	// when the write itself succeeded rather than deferring it away.
 	_, err = fmt.Fprintf(f, "=== %s ===\n%s\n", time.Now().UTC().Format(time.RFC3339), summary)
+	if cerr := f.Close(); err == nil {
+		err = cerr
+	}
 	return err
 }
 

--- a/sdk/tmux-mgr/cmd/root.go
+++ b/sdk/tmux-mgr/cmd/root.go
@@ -30,7 +30,9 @@ var rootCmd = &cobra.Command{
 func init() {
 	home, _ := os.UserHomeDir()
 	logDir := filepath.Join(home, ".config", "tmux-mgr")
-	os.MkdirAll(logDir, 0755)
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		fmt.Printf("Error creating log dir %s: %v\n", logDir, err)
+	}
 
 	f, err := os.OpenFile(filepath.Join(logDir, "tmux-mgr.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -54,6 +56,7 @@ func Execute() {
 // CloseLog closes the log file.
 func CloseLog() {
 	if LogFile != nil {
-		LogFile.Close()
+		// Shutdown path: there is no longer anywhere to report a Close failure.
+		_ = LogFile.Close()
 	}
 }

--- a/sdk/tmux-mgr/cmd/session.go
+++ b/sdk/tmux-mgr/cmd/session.go
@@ -67,7 +67,9 @@ func init() {
 		Use:   "detach",
 		Short: "Detach from the current tmux session",
 		Run: func(cmd *cobra.Command, args []string) {
-			Tmgr.Run("detach-client")
+			if !runTmux("detach-client") {
+				return
+			}
 			log.Printf("Detached from session")
 		},
 	})

--- a/sdk/tmux-mgr/cmd/window.go
+++ b/sdk/tmux-mgr/cmd/window.go
@@ -11,6 +11,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// runTmux runs a tmux command and logs the failure if there is one, reporting
+// whether it succeeded. The call sites below used to discard the error and then
+// print a past-tense success line regardless — "Moved focus left" even when tmux
+// had refused the request. Callers now skip that line when this returns false.
+func runTmux(args ...string) bool {
+	if _, err := Tmgr.Run(args...); err != nil {
+		log.Printf("tmux %s: %v", strings.Join(args, " "), err)
+		return false
+	}
+	return true
+}
+
 var windowCmd = &cobra.Command{
 	Use:   "window",
 	Short: "Manage tmux windows and panes",
@@ -37,7 +49,9 @@ func init() {
 				fmt.Println("Invalid direction. Use left|right|up|down")
 				return
 			}
-			Tmgr.Run("select-pane", tmuxArg)
+			if !runTmux("select-pane", tmuxArg) {
+				return
+			}
 			log.Printf("Moved focus %s", dir)
 		},
 	})
@@ -66,7 +80,9 @@ func init() {
 				fmt.Fprintln(os.Stderr, "Error:", err)
 				os.Exit(1)
 			}
-			Tmgr.Run("split-window", tmuxArg, "-t", target)
+			if !runTmux("split-window", tmuxArg, "-t", target) {
+				return
+			}
 			log.Printf("Split window %s", dir)
 		},
 	})
@@ -81,7 +97,9 @@ func init() {
 			if len(args) > 0 {
 				tmuxArgs = append(tmuxArgs, "-n", args[0])
 			}
-			Tmgr.Run(tmuxArgs...)
+			if !runTmux(tmuxArgs...) {
+				return
+			}
 			log.Printf("Created new window")
 		},
 	})
@@ -90,7 +108,9 @@ func init() {
 		Use:   "kill",
 		Short: "Kill the current tmux pane",
 		Run: func(cmd *cobra.Command, args []string) {
-			Tmgr.Run("kill-pane")
+			if !runTmux("kill-pane") {
+				return
+			}
 			log.Printf("Killed current pane")
 		},
 	})
@@ -115,7 +135,9 @@ func init() {
 				fmt.Println("Invalid direction. Use left|right|up|down")
 				return
 			}
-			Tmgr.Run("swap-pane", tmuxArg)
+			if !runTmux("swap-pane", tmuxArg) {
+				return
+			}
 			log.Printf("Swapped pane %s", dir)
 		},
 	})
@@ -126,7 +148,9 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
-			Tmgr.Run("rename-window", name)
+			if !runTmux("rename-window", name) {
+				return
+			}
 			log.Printf("Renamed window to %s", name)
 		},
 	})
@@ -137,8 +161,9 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			title := args[0]
-			// Ensure pane titles are visible
-			Tmgr.Run("set", "-g", "pane-border-status", "top")
+			// Ensure pane titles are visible. Cosmetic: SetPaneTitle below is the
+			// operation that actually has to succeed, and it reports its own error.
+			runTmux("set", "-g", "pane-border-status", "top")
 			err := Tmgr.SetPaneTitle(title)
 			if err != nil {
 				log.Printf("Error renaming pane to %s: %v", title, err)
@@ -174,11 +199,15 @@ func init() {
 
 				if dir == "width" || dir == "horizontal" || strings.HasSuffix(dir, "%") {
 					newW := (width * v) / 100
-					Tmgr.Run("resize-pane", "-x", strconv.Itoa(newW))
+					if !runTmux("resize-pane", "-x", strconv.Itoa(newW)) {
+						return
+					}
 					log.Printf("Resized width to %d (%d%%)", newW, v)
 				} else if dir == "height" || dir == "vertical" {
 					newH := (height * v) / 100
-					Tmgr.Run("resize-pane", "-y", strconv.Itoa(newH))
+					if !runTmux("resize-pane", "-y", strconv.Itoa(newH)) {
+						return
+					}
 					log.Printf("Resized height to %d (%d%%)", newH, v)
 				}
 				return
@@ -198,7 +227,9 @@ func init() {
 				fmt.Println("Invalid direction. Use left|right|up|down or width/height with %")
 				return
 			}
-			Tmgr.Run("resize-pane", tmuxArg, val)
+			if !runTmux("resize-pane", tmuxArg, val) {
+				return
+			}
 			log.Printf("Resized %s by %s", dir, val)
 		},
 	})

--- a/sdk/tmux-mgr/pkg/agent/definition.go
+++ b/sdk/tmux-mgr/pkg/agent/definition.go
@@ -81,7 +81,8 @@ func parseDefinitionFile(path string) (*Definition, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open agent definition %s: %w", path, err)
 	}
-	defer f.Close()
+	// Read-only handle: a Close failure cannot affect the bytes already read.
+	defer func() { _ = f.Close() }()
 
 	def := &Definition{
 		SourcePath: path,

--- a/sdk/tmux-mgr/pkg/tmux/pane.go
+++ b/sdk/tmux-mgr/pkg/tmux/pane.go
@@ -39,8 +39,9 @@ func AnchorPane(title string) (string, error) {
 	if err := exec.Command("tmux", "set-environment", "-g", "TMUX_MGR_ROOT_PANE", paneID).Run(); err != nil {
 		return "", fmt.Errorf("failed to save anchor to tmux environment: %w", err)
 	}
-	exec.Command("tmux", "set", "-g", "pane-border-status", "top").Run()
-	exec.Command("tmux", "select-pane", "-t", paneID, "-T", title).Run()
+	// Cosmetic: the anchor above is the operation that had to succeed.
+	_ = exec.Command("tmux", "set", "-g", "pane-border-status", "top").Run()
+	_ = exec.Command("tmux", "select-pane", "-t", paneID, "-T", title).Run()
 	return paneID, nil
 }
 
@@ -63,7 +64,8 @@ func AdoptPane() (string, error) {
 	if err := exec.Command("tmux", "set-environment", "-g", "TMUX_MGR_ROOT_PANE", paneID).Run(); err != nil {
 		return "", fmt.Errorf("failed to save anchor to tmux environment: %w", err)
 	}
-	exec.Command("tmux", "set", "-g", "pane-border-status", "top").Run()
-	exec.Command("tmux", "select-pane", "-t", paneID, "-T", "root").Run()
+	// Cosmetic: the anchor above is the operation that had to succeed.
+	_ = exec.Command("tmux", "set", "-g", "pane-border-status", "top").Run()
+	_ = exec.Command("tmux", "select-pane", "-t", paneID, "-T", "root").Run()
 	return paneID, nil
 }

--- a/sdk/tmux-mgr/pkg/tmux/pane_test.go
+++ b/sdk/tmux-mgr/pkg/tmux/pane_test.go
@@ -18,7 +18,9 @@ func TestRootPaneID_fromEnv(t *testing.T) {
 }
 
 func TestRootPaneID_noEnv_noAnchor(t *testing.T) {
-	os.Unsetenv("TMUX_PANE")
+	if err := os.Unsetenv("TMUX_PANE"); err != nil {
+		t.Fatalf("unset TMUX_PANE: %v", err)
+	}
 	// When there is no tmux server (CI), show-environment will also fail.
 	_, err := RootPaneID()
 	if err == nil {
@@ -30,7 +32,9 @@ func TestRootPaneID_noEnv_noAnchor(t *testing.T) {
 }
 
 func TestAnchorPane_noEnv(t *testing.T) {
-	os.Unsetenv("TMUX_PANE")
+	if err := os.Unsetenv("TMUX_PANE"); err != nil {
+		t.Fatalf("unset TMUX_PANE: %v", err)
+	}
 	_, err := AnchorPane("")
 	if err == nil {
 		t.Fatal("expected error when TMUX_PANE is unset")

--- a/sdk/tmux-mgr/pkg/tmux/tmux.go
+++ b/sdk/tmux-mgr/pkg/tmux/tmux.go
@@ -109,10 +109,18 @@ func (m *Manager) RestoreLayout(name string) error {
 		return fmt.Errorf("error unmarshaling layout: %w", err)
 	}
 
+	// This function returns an error, so a step that fails must not be swallowed
+	// and then reported as "Layout restored".
 	for _, win := range layout.Windows {
-		m.Run("select-window", "-t", strconv.Itoa(win.Index))
-		m.Run("select-layout", win.Layout)
-		m.Run("rename-window", "-t", strconv.Itoa(win.Index), win.Name)
+		for _, step := range [][]string{
+			{"select-window", "-t", strconv.Itoa(win.Index)},
+			{"select-layout", win.Layout},
+			{"rename-window", "-t", strconv.Itoa(win.Index), win.Name},
+		} {
+			if _, err := m.Run(step...); err != nil {
+				return fmt.Errorf("restore layout %s: tmux %s: %w", name, strings.Join(step, " "), err)
+			}
+		}
 	}
 
 	log.Printf("Layout %s restored", name)
@@ -171,8 +179,10 @@ func CreatePane(sessionID, worktreePath, command, symbol, label string) (string,
 		label = sessionID
 	}
 	styledTitle := fmt.Sprintf("#[bg=colour33,fg=white,bold] %s %s #[default]", symbol, label)
-	exec.Command("tmux", "select-pane", "-t", paneID, "-T", styledTitle).Run()
-	exec.Command("tmux", "set-option", "-w", "-t", paneID, "pane-border-status", "top").Run()
+	// Cosmetic pane decoration: the pane already exists and is returned below,
+	// so a styling failure must not fail pane creation.
+	_ = exec.Command("tmux", "select-pane", "-t", paneID, "-T", styledTitle).Run()
+	_ = exec.Command("tmux", "set-option", "-w", "-t", paneID, "pane-border-status", "top").Run()
 
 	fmt.Printf("Created tmux pane: %s\n", paneID)
 	return paneID, nil

--- a/sdk/wol/cmd/root.go
+++ b/sdk/wol/cmd/root.go
@@ -27,7 +27,9 @@ var rootCmd = &cobra.Command{
 			if len(args) > 0 {
 				macAddr = args[0]
 			} else {
-				cmd.Help()
+				// Usage text on the way out; a failed write to the help
+				// stream has nowhere left to be reported.
+				_ = cmd.Help()
 				os.Exit(1)
 			}
 		}
@@ -68,7 +70,9 @@ var rootCmd = &cobra.Command{
 			fmt.Printf("Error creating UDP connection: %v\n", err)
 			os.Exit(1)
 		}
-		defer conn.Close()
+		// Datagram socket: Close reports no delivery information, and the
+		// Write below is what actually needs checking.
+		defer func() { _ = conn.Close() }()
 
 		_, err = conn.Write(packet)
 		if err != nil {


### PR DESCRIPTION
Unmask the lint-go loop, retire the fmt.Fprint* class via errcheck config, fix all real findings in six modules

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **sdk-lint-cleanup**.

- **#234 — edward-raigosa/golangci (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
