### PR TITLE
fix(bashrc): guard openclaw completion behind command -v

### DIFF
--- a/opt/profiles/.bashrc
+++ b/opt/profiles/.bashrc
@@ -264,7 +264,7 @@ fi
 [ -f "$HOME/.openclaw.sh" ] && source "$HOME/.openclaw.sh"
 
 # OpenClaw Completion
-source <(openclaw completion --shell bash)
+command -v openclaw >/dev/null && source <(openclaw completion --shell bash)
 
 # tmux aliases
 # Added by tmux-mgr


### PR DESCRIPTION
## What

Guards the OpenClaw bash completion behind a `command -v` check in `opt/profiles/.bashrc`.

```diff
-source <(openclaw completion --shell bash)
+command -v openclaw >/dev/null && source <(openclaw completion --shell bash)
```

## Why

The line ran `openclaw completion --shell bash` unconditionally. On any host where `openclaw` isn't installed, every bash shell printed `openclaw: command not found` while sourcing `.bashrc`. Hit on a fresh DGX Spark provision.

`.zshrc` already handles this correctly via a lazy-load wrapper that checks `command -v` before sourcing — the bash side just never got the same treatment.

## Impact

- Hosts **without** openclaw: error gone, shell startup clean.
- Hosts **with** openclaw: unchanged, completion still loads.

Guarded rather than removed, since these profiles are shared across machines.

## Testing

- `bash -lc true` on a host without openclaw — no error, clean startup.
- Verified `.bashrc:264` (`~/.openclaw.sh`) was already `-f` guarded and needed no change.