### PR TITLE
feat(install): macOS-style Super+C/V in gnome-terminal, and fix the zsh handoff

### DIFF
--- a/.github/gff/features.yaml
+++ b/.github/gff/features.yaml
@@ -25,6 +25,10 @@ sets:
       - path: install.shell.default-zsh
         description: Runs the chsh block that sets zsh as the default login shell.
         boolDefault: true
+      # --- desktop (1) ---
+      - path: install.desktop.gnome-keys
+        description: Runs gnome-desktop-defaults.sh, which binds macOS-style Super+C/Super+V copy-paste in gnome-terminal and frees Super+V from the GNOME message tray. No-ops off a GNOME session.
+        boolDefault: true
       # --- pkg (2) ---
       - path: install.pkg.common-core
         description: Runs the pkg-install block that installs the curated common-core packages plus the legacy yum path.

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ unset _ip_prev _ip_arg
 #   - CONFIG / SKILL / SYMLINK / any repo-content step -> _IP_CONFIG_FLAGS. Runs
 #     in the per-commit config layer; omitting it BAKES the step into the cached
 #     deps layer, so later edits to it stop taking effect per commit (a bug).
-_IP_CONFIG_FLAGS="INSTALL_SHELL_PROFILES INSTALL_SHELL_DEFAULT_ZSH INSTALL_AI_SKILLS INSTALL_AI_ANTIGRAVITY INSTALL_AI_CLAUDE INSTALL_TOOLS_GIT_ALIASES INSTALL_SDK_GSS INSTALL_SDK_TMUX_MGR INSTALL_SDK_WOL INSTALL_SDK_GSL INSTALL_SDK_GFF"
+_IP_CONFIG_FLAGS="INSTALL_SHELL_PROFILES INSTALL_SHELL_DEFAULT_ZSH INSTALL_DESKTOP_GNOME_KEYS INSTALL_AI_SKILLS INSTALL_AI_ANTIGRAVITY INSTALL_AI_CLAUDE INSTALL_TOOLS_GIT_ALIASES INSTALL_SDK_GSS INSTALL_SDK_TMUX_MGR INSTALL_SDK_WOL INSTALL_SDK_GSL INSTALL_SDK_GFF"
 _IP_DEPS_FLAGS="INSTALL_PKG_COMMON_CORE INSTALL_PKG_BREWFILE INSTALL_TOOLS_SOPS INSTALL_TOOLS_YQ INSTALL_TOOLS_K8S INSTALL_TOOLS_SNOWFLAKE INSTALL_TOOLS_DOCKER INSTALL_RUNTIME_GOENV INSTALL_RUNTIME_PYENV INSTALL_RUNTIME_RBENV INSTALL_RUNTIME_NVM"
 apply_install_phase() {
   case "$INSTALL_PHASE" in
@@ -212,6 +212,16 @@ for file in ".profile" ".zprofile" ".zshenv" ".zshrc" ".bash_logout" ".bashrc"; 
 done
 else gff_skip_msg install.shell.profiles; fi
 
+# GNOME desktop defaults — macOS-style Super+C/Super+V copy/paste for
+# gnome-terminal, the Linux counterpart to the Cmd-key mapping macos.ahk applies
+# on Windows. Self-guarding: a no-op off a writable GNOME session (CI, docker,
+# WSL, plain SSH, macOS), so this is safe to run unconditionally.
+if gff_on install.desktop.gnome-keys; then
+if [ -x "${BASE_DIR}/opt/scripts/system/gnome-desktop-defaults.sh" ]; then
+  "${BASE_DIR}/opt/scripts/system/gnome-desktop-defaults.sh" || echo "WARNING: GNOME desktop defaults reported problems; continuing."
+fi
+else gff_skip_msg install.desktop.gnome-keys; fi
+
 # Shared skill sync — links every SKILL.md into BOTH ~/.gemini/config/skills
 # (Antigravity) and ~/.claude/skills (Claude). Single source of truth for both
 # assistants.
@@ -272,10 +282,36 @@ else
   if gff_on install.shell.default-zsh; then
   ZSH_PATH="$(command -v zsh || true)"
   if [ -n "$ZSH_PATH" ]; then
-    if [ "$SHELL" != "$ZSH_PATH" ]; then
+    # Compare against the PASSWD entry, not $SHELL. $SHELL is frozen at login,
+    # so after a chsh it stays stale for the life of the session — testing it
+    # re-runs `sudo chsh` on every install until the user logs out.
+    # (macOS has no getent; fall back to $SHELL there.)
+    if command -v getent &> /dev/null; then
+      CURRENT_LOGIN_SHELL="$(getent passwd "${USER:-$(id -un)}" | cut -d: -f7)"
+    else
+      CURRENT_LOGIN_SHELL="$SHELL"
+    fi
+    if [ "$CURRENT_LOGIN_SHELL" != "$ZSH_PATH" ]; then
       echo "Changing default shell to zsh ($ZSH_PATH)..."
       # ${USER:-$(id -un)} so chsh still gets a real name in non-login/root shells.
       sudo chsh -s "$ZSH_PATH" "${USER:-$(id -un)}" || echo "WARNING: could not change default shell to zsh."
+    fi
+
+    # chsh only rewrites /etc/passwd. The running session keeps the old $SHELL,
+    # and VTE/gnome-terminal prefers $SHELL OVER the passwd entry — so every new
+    # terminal keeps opening the previous shell until the next logout. Push the
+    # new value into the systemd user manager and the D-Bus activation env so
+    # D-Bus-activated terminals (gnome-terminal-server) pick it up on their next
+    # start. Best-effort: absent on macOS and in containers.
+    if [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+      if command -v systemctl &> /dev/null; then
+        systemctl --user set-environment "SHELL=${ZSH_PATH}" 2>/dev/null || true
+      fi
+      # Pass the VALUE explicitly. A bare `--systemd SHELL` re-reads $SHELL from
+      # THIS process — still the OLD shell — and silently clobbers the line above.
+      if command -v dbus-update-activation-environment &> /dev/null; then
+        dbus-update-activation-environment --systemd "SHELL=${ZSH_PATH}" 2>/dev/null || true
+      fi
     fi
   else
     echo "WARNING: zsh is not installed; leaving the default shell unchanged."

--- a/opt/scripts/system/AGENTS.md
+++ b/opt/scripts/system/AGENTS.md
@@ -23,6 +23,7 @@ This directory contains scripts for configuring the operating system, environmen
 - `google-cli-setup.sh`: Installs/updates gcloud, the Antigravity CLI (only when absent — `antigravity_install.sh` owns the install), and the `gws` Workspace CLI; `status` subcommand reports their health.
 - `setup_jtop.sh`: Installs and configures jetson-stats (jtop) for NVIDIA Jetson devices.
 - `terminal-theme.sh`: Configures terminal colors and themes.
+- `gnome-desktop-defaults.sh`: Applies GNOME desktop defaults — macOS-style `Super+C`/`Super+V` copy-paste in gnome-terminal (Super is the Linux Cmd analogue, so `Ctrl+C` stays SIGINT), and frees `Super+V` from the GNOME message tray so it can't swallow the paste. The Linux counterpart to the Cmd-key mapping `opt/Desktop/Apps/scripts/macos.ahk` applies on Windows. Idempotent, hand-runnable, and a no-op off a writable GNOME session (CI, docker, WSL, plain SSH, macOS). Gated by `install.desktop.gnome-keys`.
 - `perf-toggle.sh`: Toggles system performance modes (e.g., on Jetson).
 - `enable-vmx.sh`: Helper to check/enable virtualization support.
 - `coco_install.sh`: Installer for the COCO dataset tools or similar.

--- a/opt/scripts/system/gnome-desktop-defaults.sh
+++ b/opt/scripts/system/gnome-desktop-defaults.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# GNOME desktop defaults — the Linux counterpart to the macOS-style hotkeys that
+# opt/Desktop/Apps/scripts/macos.ahk provides on Windows.
+#
+# WHY <Super> AND NOT <Control>: on macOS, Terminal.app copies with Cmd+C, and
+# Super is the Linux analogue of Cmd — so <Super>c/<Super>v deliver the same
+# muscle memory while leaving Ctrl+C as SIGINT. Binding Ctrl+C to copy would
+# break interrupts outright: gnome-terminal consumes a matched accelerator
+# unconditionally and has no copy-if-selection-else-pass-through mode (Ptyxis
+# and kitty have one; VTE 0.76 / gnome-terminal 3.52 do not).
+#
+# Idempotent and safe to re-run by hand:
+#   ~/opt/scripts/system/gnome-desktop-defaults.sh
+# No-ops on anything that is not a live GNOME session (CI, docker, WSL, plain
+# SSH, macOS), so install.sh stays safe headless.
+
+set -o nounset
+
+GT_KEYS="org.gnome.Terminal.Legacy.Keybindings:/org/gnome/terminal/legacy/keybindings/"
+
+# A GNOME session we can actually write settings into. Without a session bus or
+# a writable XDG_RUNTIME_DIR, dconf has nowhere to persist and `gsettings set`
+# degrades to a silent no-op — better to skip loudly than to pretend it worked.
+gnome_session_available() {
+	command -v gsettings > /dev/null 2>&1 || return 1
+	[ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ] || return 1
+	[ -n "${XDG_RUNTIME_DIR:-}" ] && [ -w "${XDG_RUNTIME_DIR}" ] || return 1
+	case "${XDG_CURRENT_DESKTOP:-}" in
+		*GNOME*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+# gset SCHEMA[:PATH] KEY VALUE — idempotent, never fatal. Reads first so a
+# re-run touches nothing, and so a missing key exits 0 instead of failing.
+gset() {
+	_gs_have="$(gsettings get "$1" "$2" 2> /dev/null)" || return 0
+	[ "$_gs_have" = "$3" ] && return 0
+	gsettings set "$1" "$2" "$3" 2> /dev/null ||
+		echo "WARNING: could not set $1 $2"
+}
+
+apply_terminal_copy_paste() {
+	# gnome-terminal may not be installed (Ptyxis-only or headless GNOME).
+	# NOTE: the Keybindings schema is RELOCATABLE (it is bound to a dconf path),
+	# and `gsettings list-schemas` omits relocatable schemas entirely — it must
+	# be looked up with list-relocatable-schemas or this always reports "absent".
+	if ! gsettings list-relocatable-schemas 2> /dev/null |
+		grep -qx 'org.gnome.Terminal.Legacy.Keybindings'; then
+		echo "gnome-terminal keybinding schema absent; skipping copy/paste binds."
+		return 0
+	fi
+	gset "$GT_KEYS" copy "'<Super>c'"
+	gset "$GT_KEYS" paste "'<Super>v'"
+}
+
+free_super_v() {
+	# GNOME binds <Super>v to the message tray, which would swallow the paste
+	# before gnome-terminal ever sees it. <Super>m stays as the tray toggle, so
+	# nothing is lost. Only rewrite when <Super>v is actually still bound, to
+	# avoid stomping a deliberate user customization on a re-run.
+	_tray="$(gsettings get org.gnome.shell.keybindings toggle-message-tray 2> /dev/null)" || return 0
+	case "$_tray" in
+		*"<Super>v"*)
+			gset org.gnome.shell.keybindings toggle-message-tray "['<Super>m']"
+			;;
+	esac
+}
+
+if gnome_session_available; then
+	echo "Applying GNOME desktop defaults (macOS-style Super+C / Super+V)..."
+	apply_terminal_copy_paste
+	free_super_v
+else
+	echo "Not a writable GNOME session; skipping GNOME desktop defaults."
+fi

--- a/opt/scripts/system/gnome-desktop-defaults_test.sh
+++ b/opt/scripts/system/gnome-desktop-defaults_test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Test driver for gnome-desktop-defaults.sh — macOS-style Super+C/Super+V binds
+# for gnome-terminal. Drives a stub `gsettings` on PATH so the assertions cover
+# the real decision logic without touching the host's dconf.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=/dev/null
+. "$REPO_ROOT/ai/_test_helpers.sh"
+
+DEFAULTS="$SCRIPT_DIR/gnome-desktop-defaults.sh"
+
+H="$(mktemp -d)"
+trap 'rm -rf "$H"' EXIT
+mkdir -p "$H/bin" "$H/run"
+
+GT="org.gnome.Terminal.Legacy.Keybindings:/org/gnome/terminal/legacy/keybindings/"
+
+# Stub gsettings: STATE is a "schema<TAB>key<TAB>value" table, SETLOG records
+# every `set` so we can assert on writes (and on their absence).
+cat > "$H/bin/gsettings" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  # Real gsettings splits these: list-schemas omits relocatable schemas, which
+  # is exactly the trap gnome-desktop-defaults.sh has to avoid.
+  list-schemas) cat "$GS_SCHEMAS"; exit 0 ;;
+  list-relocatable-schemas) cat "$GS_RELOC"; exit 0 ;;
+  get)
+    line="$(awk -F'\t' -v s="$2" -v k="$3" '$1==s && $2==k {print $3}' "$GS_STATE")"
+    [ -n "$line" ] || exit 1
+    printf '%s\n' "$line"; exit 0 ;;
+  set)
+    printf '%s %s %s\n' "$2" "$3" "$4" >> "$GS_SETLOG"
+    tmp="$(mktemp)"
+    awk -F'\t' -v s="$2" -v k="$3" '!($1==s && $2==k)' "$GS_STATE" > "$tmp"
+    printf '%s\t%s\t%s\n' "$2" "$3" "$4" >> "$tmp"
+    mv "$tmp" "$GS_STATE"; exit 0 ;;
+esac
+exit 1
+STUB
+chmod +x "$H/bin/gsettings"
+
+reset_state() { # $1 = tray value, $2 = "with-gt" | "no-gt"
+  : > "$H/setlog"
+  {
+    printf 'org.gnome.shell.keybindings\ttoggle-message-tray\t%s\n' "$1"
+    printf '%s\tcopy\t%s\n'  "$GT" "'<Control><Shift>c'"
+    printf '%s\tpaste\t%s\n' "$GT" "'<Control><Shift>v'"
+  } > "$H/state"
+  printf 'org.gnome.shell.keybindings\n' > "$H/schemas"
+  if [ "$2" = "with-gt" ]; then
+    printf 'org.gnome.Terminal.Legacy.Keybindings\norg.gnome.Terminal.Legacy.Profile\n' > "$H/reloc"
+  else
+    : > "$H/reloc"
+  fi
+}
+
+# run_gnome [extra env assignments...] — a fully-formed writable GNOME session
+run_gnome() {
+  env PATH="$H/bin:$PATH" \
+      GS_STATE="$H/state" GS_SETLOG="$H/setlog" GS_SCHEMAS="$H/schemas" GS_RELOC="$H/reloc" \
+      XDG_CURRENT_DESKTOP="ubuntu:GNOME" \
+      DBUS_SESSION_BUS_ADDRESS="unix:path=$H/run/bus" \
+      XDG_RUNTIME_DIR="$H/run" \
+      "$@" bash "$DEFAULTS"
+}
+
+# --- guards: must no-op off a real session -----------------------------------
+reset_state "['<Super>v', '<Super>m']" with-gt
+out="$(env PATH="$H/bin:$PATH" GS_STATE="$H/state" GS_SETLOG="$H/setlog" \
+       GS_SCHEMAS="$H/schemas" GS_RELOC="$H/reloc" XDG_CURRENT_DESKTOP="ubuntu:GNOME" \
+       XDG_RUNTIME_DIR="$H/run" DBUS_SESSION_BUS_ADDRESS= \
+       bash "$DEFAULTS" 2>&1)"
+assert_eq "$?" "0" "no session bus: exits clean"
+case "$out" in *"skipping GNOME desktop defaults"*) r=0 ;; *) r=1 ;; esac
+assert_eq "$r" "0" "no session bus: reports the skip"
+assert_eq "$(wc -l < "$H/setlog" | tr -d ' ')" "0" "no session bus: writes nothing"
+
+reset_state "['<Super>v', '<Super>m']" with-gt
+run_gnome XDG_CURRENT_DESKTOP="KDE" > /dev/null 2>&1
+assert_eq "$(wc -l < "$H/setlog" | tr -d ' ')" "0" "non-GNOME desktop: writes nothing"
+
+reset_state "['<Super>v', '<Super>m']" with-gt
+run_gnome XDG_RUNTIME_DIR="$H/run/does-not-exist" > /dev/null 2>&1
+assert_eq "$(wc -l < "$H/setlog" | tr -d ' ')" "0" "unwritable runtime dir: writes nothing"
+
+# --- happy path ---------------------------------------------------------------
+reset_state "['<Super>v', '<Super>m']" with-gt
+assert_exit_code 0 "applies cleanly on a GNOME session" run_gnome
+assert_grep "binds copy to Super+C"  "copy '<Super>c'"  "$H/setlog"
+assert_grep "binds paste to Super+V" "paste '<Super>v'" "$H/setlog"
+assert_grep "frees Super+V from the message tray" \
+    "toggle-message-tray \['<Super>m'\]" "$H/setlog"
+assert_grep_negative "leaves Ctrl+C alone (SIGINT preserved)" \
+    "<Control>c" "$H/setlog"
+
+# --- idempotency ---------------------------------------------------------------
+: > "$H/setlog"
+run_gnome > /dev/null 2>&1
+assert_eq "$(wc -l < "$H/setlog" | tr -d ' ')" "0" "second run is a no-op"
+
+# --- gnome-terminal absent ------------------------------------------------------
+reset_state "['<Super>v', '<Super>m']" no-gt
+out="$(run_gnome 2>&1)"
+assert_exit_code 0 "no gnome-terminal schema: still exits clean" run_gnome
+assert_grep_negative "no gnome-terminal schema: binds no copy key" \
+    "copy" "$H/setlog"
+assert_grep "no gnome-terminal schema: still frees the tray key" \
+    "toggle-message-tray" "$H/setlog"
+
+# --- respects a user who already customized the tray ----------------------------
+reset_state "['<Super>m']" with-gt
+run_gnome > /dev/null 2>&1
+assert_grep_negative "tray already free of Super+V: not rewritten" \
+    "toggle-message-tray" "$H/setlog"
+
+_test_report


### PR DESCRIPTION
## What

**New — `opt/scripts/system/gnome-desktop-defaults.sh`** (gated by `install.desktop.gnome-keys`)

Binds gnome-terminal copy/paste to `<Super>c` / `<Super>v` and frees `<Super>v` from the GNOME message tray (`<Super>m` remains the tray toggle). Idempotent, hand-runnable, and a no-op off a writable GNOME session — CI, docker, WSL, plain SSH and macOS all skip cleanly.

**Fixed — the zsh default-shell handoff in `install.sh`**

- `chsh` only rewrites `/etc/passwd`, but VTE/gnome-terminal prefers `$SHELL` **over** the passwd entry. The running session keeps its login-time `$SHELL`, so every new terminal kept opening the *old* shell until the next logout. Now pushed into the systemd user manager and the D-Bus activation environment so `gnome-terminal-server` picks it up on its next start.
- The "needs chsh?" test compared the stale session `$SHELL` instead of the passwd entry, so `sudo chsh` re-ran on every install until logout.

## Why

The repo already treats macOS muscle memory as a shipped default — `opt/Desktop/Apps/scripts/macos.ahk` maps `LWin -> Cmd` with `Cmd+C`/`Cmd+V` and ~30 more bindings on Windows. That stopped at the Windows boundary; Linux/GNOME had no equivalent, and no GNOME configuration existed anywhere in the repo (the only `gsettings` call outside Go source lives in `opt/profiles/.xsessionrc`, a vendored NVIDIA L4T file).

Hit in practice: a fresh install left gnome-terminal on `Ctrl+Shift+C` and spawning bash despite `chsh` having succeeded.

## Design notes

**Why Super and not Ctrl.** Super is the Linux analogue of Cmd, and Terminal.app copies with `Cmd+C` — so `<Super>c` gives the same muscle memory while `Ctrl+C` stays SIGINT. Binding `Ctrl+C` to copy was considered and rejected: gnome-terminal consumes a matched accelerator unconditionally and has no copy-if-selection-else-pass-through mode (Ptyxis and kitty have one; VTE 0.76 does not), so it would break interrupts outright.

**Relocatable schemas.** `gsettings list-schemas` omits relocatable schemas, and `org.gnome.Terminal.Legacy.Keybindings` is one. The first version checked the wrong list and silently skipped the binds on every real system — caught by running it live, not by the unit tests, whose stub had been modelling the two lists as one. Both the script and the stub now model the real split.

**`dbus-update-activation-environment` takes an explicit value.** A bare `--systemd SHELL` re-reads `$SHELL` from the calling process — still the *old* shell — and silently clobbers the `systemctl --user set-environment` that precedes it. Called out in a comment because it is easy to reintroduce.

## Impact

Default-on (`boolDefault: true`), consistent with every other `install.*` flag; disable with `gff set install.desktop.gnome-keys false`. Registered in `_IP_CONFIG_FLAGS` (config layer, not deps — no packages installed), per the AGENTS.md Docker-layering rule.

Users who install over SSH will skip the binds and can re-run the script by hand from a desktop session. Making it apply at every login would mean `.xsessionrc`, which is avoided here: it is a vendored NVIDIA L4T file, and GDM does not source it under Wayland.

## Testing

```
15/15  bash opt/scripts/system/gnome-desktop-defaults_test.sh
EXIT=0 make lint-shell         (strict: warnings are hard CI failures)
EXIT=0 make lint-portability   (Tier 1: 0, Tier 2: 0)
EXIT=0 gff lint
       gff get install.desktop.gnome-keys      -> true
       gff export --shell | grep DESKTOP_GNOME -> GFF_INSTALL_DESKTOP_GNOME_KEYS=true
```

Verified on a live GNOME session: clean no-op when already applied; reverting `copy` to `<Control><Shift>c` and re-running restored `<Super>c`; `env -u DBUS_SESSION_BUS_ADDRESS` skips with exit 0.

Test coverage: absent session bus, non-GNOME desktop, unwritable `XDG_RUNTIME_DIR`, happy path, `Ctrl+C` never rebound, idempotent re-run, gnome-terminal absent, and a user who already customised the tray binding.

**Not verified:** `make lint-markdown` — `markdownlint-cli2` is not installed locally. Leaving that to CI.

`make shell-test` reports 2 failing drivers (`install_ai_teams_test.sh`, `sync-plugins_test.sh`); both fail identically on a stashed clean tree, so they are pre-existing and unrelated to this change.