### PR TITLE
fix(gsl): point gnome-terminal at the Nerd Font, and cover U+23F4/U+23F5

### DIFF
--- a/opt/profiles/packages.tsv
+++ b/opt/profiles/packages.tsv
@@ -69,6 +69,16 @@ watch                -
 -                    fontconfig
 -                    curl
 
+# Symbol-font fallback for codepoints the Nerd Font does not carry. MesloLGS NF
+# covers the powerline separators (U+E0Bx) and the Nerd Font PUA icons (U+F0xx),
+# but its cmap stops short of Miscellaneous Technical: U+23F4/U+23F5 (the
+# media-control triangles Claude Code's own status footer renders) fall in NO
+# font shipped with Ubuntu, so they show as tofu on an otherwise-correct setup.
+# Symbola covers U+2190-2426 and carries no PUA range, so it complements the
+# Nerd Font as a fontconfig fallback rather than shadowing it. macOS ships
+# Apple Symbols with the same coverage, hence '-' in the BREW column.
+-                    fonts-symbola
+
 # Kubernetes toolchain. apt has no kind package at all, and kubectl/helm need
 # third-party apt repos that lag upstream — so Linux/WSL gets the official
 # release binaries via opt/scripts/system/install_k8s_tools.sh (wired into

--- a/sdk/gsl/scripts/install_nerd_font_linux.sh
+++ b/sdk/gsl/scripts/install_nerd_font_linux.sh
@@ -68,6 +68,49 @@ fi
 
 echo "Verify: fc-list | grep -i MesloLGS"
 
+# ── Point gnome-terminal at the font ─────────────────────────────────────────
+# Installing the font is not enough: gnome-terminal defaults to use-system-font,
+# i.e. the GNOME monospace font (Ubuntu Sans Mono), which has no Nerd Font PUA
+# glyphs — so gsl's powerline separators and icons render as tofu on a machine
+# where the font IS correctly installed. check-font-glyphs.sh validates the font
+# FILE, so it passes and never catches this. Symmetric with the WSL branch below,
+# which installs on the Windows host precisely so Windows Terminal can render it.
+#
+# Only touches the DEFAULT profile, only when it is still on the system font, so
+# a deliberate font choice is never overwritten.
+configure_gnome_terminal_font() {
+  command -v gsettings >/dev/null 2>&1 || return 0
+  [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ] || return 0
+  [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -w "${XDG_RUNTIME_DIR}" ] || return 0
+
+  # The Profile schema is RELOCATABLE; `gsettings list-schemas` omits those
+  # entirely, so it must be looked up with list-relocatable-schemas.
+  gsettings list-relocatable-schemas 2>/dev/null |
+    grep -qx 'org.gnome.Terminal.Legacy.Profile' || return 0
+
+  _prof="$(gsettings get org.gnome.Terminal.ProfilesList default 2>/dev/null | tr -d "'")"
+  [ -n "$_prof" ] || return 0
+  _key="org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/:${_prof}/"
+
+  # Respect an explicit user font choice.
+  if [ "$(gsettings get "$_key" use-system-font 2>/dev/null)" != "true" ]; then
+    echo "gnome-terminal already uses a custom font; leaving it alone."
+    return 0
+  fi
+
+  # Carry over the size already in effect so only the glyphs change, not layout.
+  _size="$(gsettings get org.gnome.desktop.interface monospace-font-name 2>/dev/null |
+    tr -d "'" | awk '{print $NF}')"
+  case "$_size" in ''|*[!0-9]*) _size=12 ;; esac
+
+  gsettings set "$_key" use-system-font false 2>/dev/null &&
+    gsettings set "$_key" font "MesloLGS Nerd Font ${_size}" 2>/dev/null &&
+    echo "Set gnome-terminal font to 'MesloLGS Nerd Font ${_size}'." ||
+    echo "WARNING: could not set the gnome-terminal font."
+}
+
+configure_gnome_terminal_font
+
 # ── WSL: also install on the Windows host for Windows Terminal ───────────────
 # Windows Terminal renders WSL sessions using the host font stack; the font
 # must exist on Windows even when gsl runs in the Linux layer.

--- a/sdk/gsl/scripts/install_nerd_font_linux_test.sh
+++ b/sdk/gsl/scripts/install_nerd_font_linux_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Self-test for install_nerd_font_linux.sh — specifically the gnome-terminal
+# font wiring. Drives the REAL script with a stubbed toolchain (fc-list reports
+# the font already present, so the download path is skipped) and a stub
+# gsettings backed by a state table, so the assertions cover the actual
+# decision logic without touching the host's dconf or the network.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALLER="$SCRIPT_DIR/install_nerd_font_linux.sh"
+pass=0
+fail=0
+
+ok()   { echo "ok   - $1"; pass=$((pass + 1)); }
+notok(){ echo "FAIL - $1"; fail=$((fail + 1)); }
+
+assert_contains() { # desc file needle
+  if grep -qF -- "$3" "$2"; then ok "$1"; else notok "$1 (missing: $3)"; fi
+}
+assert_absent() { # desc file needle
+  if grep -qF -- "$3" "$2"; then notok "$1 (unexpectedly present: $3)"; else ok "$1"; fi
+}
+
+H="$(mktemp -d)"
+trap 'rm -rf "$H"' EXIT
+mkdir -p "$H/bin" "$H/run"
+
+for t in curl unzip fc-cache; do printf '#!/bin/sh\nexit 0\n' > "$H/bin/$t"; done
+printf '#!/bin/sh\necho "/f/MesloLGSNerdFont-Regular.ttf: MesloLGS Nerd Font:style=Regular"\n' > "$H/bin/fc-list"
+
+cat > "$H/bin/gsettings" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  # Real gsettings splits these: list-schemas omits RELOCATABLE schemas, which
+  # is the trap the installer has to avoid for the Profile schema.
+  list-schemas)             printf 'org.gnome.desktop.interface\n'; exit 0 ;;
+  list-relocatable-schemas) cat "$GS_RELOC"; exit 0 ;;
+  get)
+    v="$(awk -F'\t' -v s="$2" -v k="$3" '$1==s && $2==k {print $3}' "$GS_STATE")"
+    [ -n "$v" ] || exit 1
+    printf '%s\n' "$v"; exit 0 ;;
+  set)
+    printf '%s %s %s\n' "$2" "$3" "$4" >> "$GS_SETLOG"
+    tmp="$(mktemp)"
+    awk -F'\t' -v s="$2" -v k="$3" '!($1==s && $2==k)' "$GS_STATE" > "$tmp"
+    printf '%s\t%s\t%s\n' "$2" "$3" "$4" >> "$tmp"
+    mv "$tmp" "$GS_STATE"; exit 0 ;;
+esac
+exit 1
+STUB
+chmod +x "$H"/bin/*
+
+PROF="b1dcc9dd-0000-0000-0000-000000000000"
+PKEY="org.gnome.Terminal.Legacy.Profile:/org/gnome/terminal/legacy/profiles:/:${PROF}/"
+
+seed() { # $1 = use-system-font, $2 = "with-profile"|"no-profile"
+  : > "$H/setlog"
+  {
+    printf 'org.gnome.Terminal.ProfilesList\tdefault\t%s\n' "'${PROF}'"
+    printf 'org.gnome.desktop.interface\tmonospace-font-name\t%s\n' "'Ubuntu Sans Mono 13'"
+    printf '%s\tuse-system-font\t%s\n' "$PKEY" "$1"
+    printf '%s\tfont\t%s\n' "$PKEY" "'Monospace 12'"
+  } > "$H/state"
+  if [ "$2" = "with-profile" ]; then
+    printf 'org.gnome.Terminal.Legacy.Profile\norg.gnome.Terminal.Legacy.Keybindings\n' > "$H/reloc"
+  else
+    : > "$H/reloc"
+  fi
+}
+
+run() { # extra env assignments as args
+  env PATH="$H/bin:/usr/bin:/bin" HOME="$H" \
+      GS_STATE="$H/state" GS_SETLOG="$H/setlog" GS_RELOC="$H/reloc" \
+      DBUS_SESSION_BUS_ADDRESS="unix:path=$H/run/bus" XDG_RUNTIME_DIR="$H/run" \
+      "$@" bash "$INSTALLER" > "$H/out" 2>&1
+}
+
+# --- happy path: system font in use -> switch to the Nerd Font ----------------
+seed "true" with-profile
+if run; then ok "installer exits clean"; else notok "installer exits clean"; fi
+assert_contains "skips the download when the font is already installed" \
+  "$H/out" "already installed"
+assert_contains "sets use-system-font false" "$H/setlog" "use-system-font false"
+assert_contains "carries over the size already in effect (13)" \
+  "$H/setlog" "font MesloLGS Nerd Font 13"
+
+# --- respects an explicit user font choice ------------------------------------
+seed "false" with-profile
+run
+assert_absent "leaves a custom font alone" "$H/setlog" "use-system-font"
+assert_contains "says why it left the font alone" "$H/out" "already uses a custom font"
+
+# --- guards --------------------------------------------------------------------
+seed "true" no-profile
+run
+assert_absent "no gnome-terminal Profile schema: writes nothing" "$H/setlog" "use-system-font"
+
+seed "true" with-profile
+run DBUS_SESSION_BUS_ADDRESS=
+assert_absent "no session bus: writes nothing" "$H/setlog" "use-system-font"
+
+seed "true" with-profile
+run XDG_RUNTIME_DIR="$H/run/nope"
+assert_absent "unwritable runtime dir: writes nothing" "$H/setlog" "use-system-font"
+
+echo "----"
+echo "install_nerd_font_linux_test: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/sdk/gsl/skill/SKILL.md
+++ b/sdk/gsl/skill/SKILL.md
@@ -153,11 +153,13 @@ Run `sync-skills --build` to rebuild the binary and refresh all skill links.
 | OS | Installer | Notes |
 |----|-----------|-------|
 | macOS | `sdk/gsl/scripts/install_nerd_font_macos.sh` | Writes an iTerm2 Dynamic Profile (`gsl-nerd-font`) |
-| Linux/WSL | `sdk/gsl/scripts/install_nerd_font_linux.sh` | Also invokes Windows installer from WSL for Windows Terminal |
+| Linux/WSL | `sdk/gsl/scripts/install_nerd_font_linux.sh` | Points gnome-terminal's default profile at the font (only when it is still on the system font); also invokes the Windows installer from WSL for Windows Terminal |
 | Windows | `sdk/gsl/scripts/install_nerd_font_windows.ps1` | Called by `setup-apps.ps1 → Install-NerdFont`; touchless (`-NonInteractive -ExecutionPolicy Bypass`) |
 
 After install, `sdk/gsl/scripts/check-font-glyphs.sh` proves the installed font
-covers all 17 PUA codepoints gsl emits. Run it manually to verify:
+covers all 17 PUA codepoints gsl emits. Note it validates the font *file*, not
+the terminal's font *selection* — a terminal still pointed at a non-Nerd font
+renders tofu even though this check passes. Run it manually to verify:
 
 ```bash
 bash sdk/gsl/scripts/check-font-glyphs.sh


### PR DESCRIPTION
## What

Two font fixes that together make gsl's status line render correctly on a fresh GNOME install.

**1. Point gnome-terminal at the Nerd Font** (`sdk/gsl/scripts/install_nerd_font_linux.sh`)

Installing the font was never enough on GNOME. gnome-terminal defaults to `use-system-font`, i.e. the GNOME monospace font (Ubuntu Sans Mono), which carries no Nerd Font glyphs — so the powerline separators and icons rendered as tofu on machines where the installer had *correctly* installed MesloLGS NF.

**2. Add `fonts-symbola` to `packages.tsv`**

MesloLGS NF's cmap stops short of Miscellaneous Technical, so `U+23F4`/`U+23F5` are covered by **no font shipped with Ubuntu** and show as tofu regardless of the terminal font.

## Why

Every other platform already closed the install→configure loop. Only native Linux/GNOME installed a font and then never pointed a terminal at it:

| Platform | Installs font | Configures the terminal |
|---|---|---|
| macOS | yes | yes — writes an iTerm2 Dynamic Profile |
| WSL | yes, **and on the Windows host** | yes — so Windows Terminal can render it |
| Linux / GNOME | yes | **no** ← the gap |

`check-font-glyphs.sh` could not catch this: it validates that the font **file** covers the 17 PUA codepoints, which passes regardless of which font the terminal is actually using. That is now called out in `SKILL.md` so the gap is not re-derived later.

## Evidence

Font-coverage claims were verified against the actual cmaps with `fc-query`, not assumed:

```
MesloLGS NF ranges near 23xx : ... 2373-237a, 237d      <- no 23F5
fc-list ':charset=23F5'      : 0 fonts on a stock Ubuntu 24.04 + this repo
Symbola range containing it  : 2190-2426                <- covers 23F4/23F5
Symbola vs powerline U+E0B0  : not covered              <- complements, does not shadow
```

That last row is the point of choosing Symbola: it fills the Miscellaneous Technical gap without carrying a PUA range that could shadow the Nerd Font in fontconfig's fallback order.

## Design notes

**Non-destructive.** `configure_gnome_terminal_font()` only touches the **default** profile, and only when it is still on the system font — a deliberate user font choice is preserved and reported. It carries over the size already in effect, so only the glyphs change, not the layout.

**Relocatable schemas.** `org.gnome.Terminal.Legacy.Profile` is relocatable, and `gsettings list-schemas` omits relocatable schemas entirely; it must be looked up via `list-relocatable-schemas` or the check always reports the schema absent. (Same trap hit in [#247](https://github.com/sfc-gh-eraigosa/dotfiles/pull/247).)

**Headless-safe.** Guarded on a writable GNOME session, so it is a no-op in CI, docker, plain SSH and on non-GNOME desktops. No new gff flag — this rides the existing `install.fonts.nerd-font`.

## Impact

Independent of [#247](https://github.com/sfc-gh-eraigosa/dotfiles/pull/247); branched off `main` and can merge in either order.

`fonts-symbola` is `-` in the BREW column: macOS ships Apple Symbols with the same coverage.

## Testing

New `sdk/gsl/scripts/install_nerd_font_linux_test.sh` drives the **real** installer with a stubbed toolchain (stub `fc-list` reports the font present so the download path is skipped; stub `gsettings` is backed by a state table modelling the real `list-schemas` / `list-relocatable-schemas` split):

```
9/9    switches the font when the system font is in use
       carries over the in-effect size (13)
       preserves an explicitly-chosen custom font
       writes nothing with no Profile schema / no session bus / unwritable XDG_RUNTIME_DIR
EXIT=0 make lint-shell        (strict: warnings are hard CI failures)
EXIT=0 make lint-portability  (Tier 1: 0, Tier 2: 0)
```

**Not verified:** `make lint-markdown` — `markdownlint-cli2` is not installed locally. Leaving that to CI.