### PR TITLE
fix(scripts): strip agy's PATH append from ~/.zprofile too

### DIFF
--- a/opt/scripts/system/strip-agy-rc-appends.sh
+++ b/opt/scripts/system/strip-agy-rc-appends.sh
@@ -8,7 +8,7 @@
 #     # Added by Antigravity CLI installer
 #     export PATH="/home/<user>/.local/bin:$PATH"
 #
-# On our hosts ~/.zshrc, ~/.bashrc and ~/.profile are SYMLINKS into the
+# On our hosts ~/.zshrc, ~/.zprofile, ~/.bashrc and ~/.profile are SYMLINKS into the
 # dotfiles repo, so the append lands in the repo working tree with a
 # hardcoded, machine-specific $HOME — unportable and never committable. The
 # repo profiles already export ~/.local/bin portably (opt/profiles/.profile
@@ -25,7 +25,7 @@ set -u
 MARKER='# Added by Antigravity CLI installer'
 stripped=0
 
-for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile"; do
+for rc in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.bashrc" "$HOME/.profile"; do
     [ -L "$rc" ] || continue
     grep -qF "$MARKER" "$rc" 2>/dev/null || continue
     echo "  Stripping agy's PATH append from repo-managed $(basename "$rc")..."

--- a/opt/scripts/system/strip-agy-rc-appends_test.sh
+++ b/opt/scripts/system/strip-agy-rc-appends_test.sh
@@ -26,6 +26,17 @@ export PATH="/home/someuser/.local/bin:$PATH"
 RC
 ln -s "$H/repo/.zshrc" "$H/.zshrc"
 
+# Repo-managed .zprofile: zsh LOGIN shells read this, and agy appends here too.
+cat > "$H/repo/.zprofile" <<'RC'
+# repo zprofile content
+[ -f "$HOME/.profile" ] && emulate sh -c '. "$HOME/.profile"'
+
+
+# Added by Antigravity CLI installer
+export PATH="/home/someuser/.local/bin:$PATH"
+RC
+ln -s "$H/repo/.zprofile" "$H/.zprofile"
+
 # Host-owned REAL rc with the same append: must be left alone.
 cat > "$H/.bashrc" <<'RC'
 # host-owned bashrc
@@ -48,6 +59,11 @@ assert_in_subshell "no dangling blank lines at EOF" \
     "[ \"\$(tail -c 6 '$H/repo/.zshrc')\" = 'true' ] || [ \"\$(tail -n1 '$H/repo/.zshrc')\" = 'true' ]"
 assert_in_subshell ".zshrc is still a symlink (not replaced by a file)" "[ -L '$H/.zshrc' ]"
 
+assert_grep_negative "append removed from symlinked .zprofile target" \
+    'Added by Antigravity CLI installer' "$H/repo/.zprofile"
+assert_grep "unrelated content preserved in .zprofile" 'repo zprofile content' "$H/repo/.zprofile"
+assert_in_subshell ".zprofile is still a symlink (not replaced by a file)" "[ -L '$H/.zprofile' ]"
+
 assert_grep "host-owned real .bashrc keeps its append" \
     'Added by Antigravity CLI installer' "$H/.bashrc"
 
@@ -55,7 +71,9 @@ assert_eq "$(cat "$H/repo/.profile")" "$before_clean" "clean symlinked rc left b
 
 # Idempotency: second run changes nothing further.
 after_first="$(cat "$H/repo/.zshrc")"
+after_first_zp="$(cat "$H/repo/.zprofile")"
 env HOME="$H" bash "$STRIP" >/dev/null
 assert_eq "$(cat "$H/repo/.zshrc")" "$after_first" "second run is a no-op"
+assert_eq "$(cat "$H/repo/.zprofile")" "$after_first_zp" "second run is a no-op for .zprofile"
 
 _test_report


### PR DESCRIPTION
Follow-up hardening for `strip-agy-rc-appends.sh`.

## What

Adds `$HOME/.zprofile` to the rc list that `opt/scripts/system/strip-agy-rc-appends.sh` scans, and extends the test driver to cover it.

## Why

The Antigravity CLI bootstrapper (`agy install`, and every self-update) appends this block to each rc file it finds:

```sh
# Added by Antigravity CLI installer
export PATH="/home/<user>/.local/bin:$PATH"
```

On our hosts `~/.zprofile` is a **symlink into the repo** (`opt/profiles/.zprofile`), so that append lands directly in the working tree as a dirty, hardcoded-`$HOME`, never-committable diff.

`strip-agy-rc-appends.sh` exists precisely to guard against this — but its list (`~/.zshrc`, `~/.bashrc`, `~/.profile`) **predates `~/.zprofile` becoming a symlink**, leaving that one file unguarded. This was caught in the wild: `opt/profiles/.zprofile` showed up modified in `git status`.

## Impact

- No behaviour change for users. The stripped block is **pure redundancy**: `opt/profiles/.profile` (lines 93-94) already exports `${HOME}/.local/bin` portably, and `.zprofile` delegates to `.profile` under `sh` emulation.
- Verified post-strip on a live host: `~/.local/bin` is still on `PATH` in a login zsh, and `agy` still resolves to `/home/<user>/.local/bin/agy`.
- Host-owned **real** (non-symlink) rc files remain untouched, as before — there the block may be the only thing putting agy on PATH.
- Runs automatically at the end of `antigravity_install.sh`; safe to rerun any time (idempotent).

## Testing

- `opt/scripts/system/strip-agy-rc-appends_test.sh` — **PASS=12 FAIL=0**. New cases: symlinked `.zprofile` fixture, append removed, unrelated content preserved, still a symlink (not replaced by a regular file), and second-run-is-a-no-op idempotency.
- `make lint-shell` — exit 0 (strict; any shellcheck warning is a hard failure).
- `make lint-portability` — Tier 1: 0, Tier 2: 0 across 160 scanned files.
- Ran the fixed script against the real dirty working tree; `opt/profiles/.zprofile` returned to a clean diff.