### PR TITLE
fix(fleet): distinguish a refused credential from an unreachable host

### DIFF
--- a/sdk/fleet/AGENTS.md
+++ b/sdk/fleet/AGENTS.md
@@ -37,6 +37,7 @@ facts. `opt/scripts/system/install-stamp.sh` now records the second one; this to
 | `internal/sshconf` | parse **and edit** `~/.ssh/config` (the only inventory) |
 | `internal/stamp` | parse the install stamp |
 | `internal/drift` | classify drift + format age (`now` injected — never `time.Now()`) |
+| `internal/sshfail` | read ssh's stderr to tell a refused *connection* from a refused *credential* |
 | `internal/keys` | authorized_keys diff (reports removals, never applies them) |
 | `internal/reach` | the wake ladder: rung order, peer ranking, provenance (pure; every impure edge injected via `Deps`) |
 | `cmd/answers_store.go` | the non-secret prompt preferences on disk (`0600`); the on-disk type has no credential field |
@@ -59,6 +60,21 @@ without opening a socket.
 - **A dirty clone is skipped** unless `--force`, which *preserves* work in a rescue worktree
   (`git add -A` onto a branch — **not** `stash@{0}`, which silently drops untracked files).
 - **Failures are named per host** and reflected in the exit code; never swallowed.
+- **`unreachable` means the network, never the keys.** A probe that CONNECTED and was
+  then refused — unknown or changed host key, no accepted credential — classifies as
+  `auth-failed`, not `unreachable`. Every probe runs `BatchMode=yes`, so an unknown host
+  key fails *instantly* and used to look exactly like a dead machine; the cost was a real
+  investigation aimed at the network for a one-line `known_hosts` gap. The evidence is
+  ssh's stderr, which `(*exec.Cmd).Output()` already captures. A failure with no stderr
+  to read stays `unreachable` — `internal/sshfail` never invents a diagnosis. Pinned by
+  `TestAuthFailureReportsAuthFailedNotUnreachable` and
+  `TestFailureWithNoEvidenceStaysUnreachable`.
+- **An answering host is never woken, and never relays.** The ladder rouses machines
+  asleep at layer 2; a host that refused us is awake, so waking it spends a full budget
+  (~12s) per host per run to fix nothing. It is equally never ranked as a live relay
+  peer — we cannot run a command through a hop that refuses us. Pinned by
+  `TestWakeLadderNeverFiresForAnAuthFailure` and
+  `TestAuthFailedHostIsNeverOfferedAsALiveRelayPeer`.
 - **TUI in-flight ownership**: a host is in exactly one of `pending` / `updating` /
   `waking` / resolved. Refresh skips hosts an async path owns; every completion
   re-polls its host. Two async paths must never own one row.
@@ -135,6 +151,12 @@ without opening a socket.
   feature branch to prove the stamp before it merges.
 - A stamp that exists but won't parse reports `unknown (corrupt stamp)` — deliberately
   distinct from never-installed.
+- `auth-failed (host key unverified)` almost always means the alias was never accepted
+  into `~/.ssh/known_hosts` — common right after `ssh-find` rewrites a `Hostname`, since
+  the *new* address is an unknown host to ssh. Fix on the workstation:
+  `ssh-keyscan -H <alias> >> ~/.ssh/known_hosts` after checking the fingerprint.
+  `auth-failed (host key CHANGED)` is NOT routine — it is the MITM warning, and the row
+  is orange rather than red precisely so it is not mistaken for a dead host.
 - **A host that needs waking every run is not healthy — it is power-saving.** The `woke via
   <peer>` note exists to keep that visible instead of smoothing it away. The permanent cure
   is on the host, not in fleet: a Wi-Fi NIC with `power_save on` sleeps through the

--- a/sdk/fleet/cmd/status.go
+++ b/sdk/fleet/cmd/status.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/reach"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/runner"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/sshconf"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/sshfail"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/stamp"
 	"github.com/spf13/cobra"
 )
@@ -127,7 +128,16 @@ func probeHost(h sshconf.Host, r runner.Runner, base Baseliner) Row {
 func probeHostWake(h sshconf.Host, peers func() []reach.Peer, r runner.Runner, base Baseliner, w waker) Row {
 	row := Row{Alias: h.Alias}
 	out, err := r.Run(h.Alias, probeCmd)
-	if err != nil && w != nil {
+
+	// A host that answered SSH and then refused us is not asleep, so the
+	// ladder has nothing to fix: running it would spend a full wake budget
+	// per host, every run, on ICMP and relay hops that cannot help.
+	authFailed := sshfail.Classify(err) == sshfail.Auth
+	if authFailed {
+		row.Note = sshfail.Note(err)
+	}
+
+	if err != nil && w != nil && !authFailed {
 		var ps []reach.Peer
 		if peers != nil {
 			ps = peers()
@@ -141,7 +151,7 @@ func probeHostWake(h sshconf.Host, peers func() []reach.Peer, r runner.Runner, b
 	}
 	stampText, liveBranch := splitProbe(out)
 	row.Branch = normalizeBranch(liveBranch)
-	in := drift.Input{Reachable: err == nil, Baseline: base.Head()}
+	in := drift.Input{Reachable: err == nil, AuthFailed: authFailed, Baseline: base.Head()}
 	if err == nil {
 		s, perr := stamp.Parse(stampText)
 		switch {
@@ -187,7 +197,11 @@ func collectWake(hosts []sshconf.Host, r runner.Runner, base Baseliner, now time
 			defer wg.Done()
 			peers := func() []reach.Peer { return track.peersFor(h.Alias, hosts) }
 			rows[i] = probeHostWake(h, peers, r, base, w)
-			if rows[i].Class != string(drift.Unreachable) {
+			// Only a host that actually ANSWERED may serve as a relay. One
+			// that refused us is reachable at the IP layer yet cannot run a
+			// command, so ranking it live would send a straggler's ladder
+			// through a hop guaranteed to fail.
+			if c := rows[i].Class; c != string(drift.Unreachable) && c != string(drift.AuthFailed) {
 				track.markUp(h.Alias)
 			}
 		}(i, h)
@@ -242,10 +256,11 @@ func short(sha string) string {
 
 var severity = map[string]int{
 	string(drift.Unreachable): 0,
-	string(drift.Divergent):   1,
-	string(drift.Unknown):     2,
-	string(drift.Behind):      3,
-	string(drift.UpToDate):    4,
+	string(drift.AuthFailed):  1,
+	string(drift.Divergent):   2,
+	string(drift.Unknown):     3,
+	string(drift.Behind):      4,
+	string(drift.UpToDate):    5,
 }
 
 func statusLabel(r Row) string {

--- a/sdk/fleet/cmd/status_auth_test.go
+++ b/sdk/fleet/cmd/status_auth_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/drift"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/reach"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/runner"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/sshconf"
+)
+
+// sshErr reproduces what runner.Exec.Run really returns when ssh fails: a
+// *exec.ExitError carrying the process's stderr. Hand-building the struct
+// would leave ProcessState nil and test a shape production never emits.
+func sshErr(t *testing.T, stderr string) error {
+	t.Helper()
+	_, err := exec.Command("sh", "-c", `printf '%s' "$1" >&2; exit 255`, "sh", stderr).Output()
+	if err == nil {
+		t.Fatal("setup: wanted a failing command")
+	}
+	return err
+}
+
+const hostKeyFail = "Host key verification failed.\r\n"
+
+// The whole bug: BatchMode means an unknown host key fails instantly, which
+// looked exactly like a dead machine and sent a real investigation to the
+// network layer. The host was up the entire time.
+func TestAuthFailureReportsAuthFailedNotUnreachable(t *testing.T) {
+	cur := strings.Repeat("a", 40)
+	r := runner.Fake{Err: map[string]error{"blocked": sshErr(t, hostKeyFail)}}
+	base := fakeBaseline{head: cur, ancestor: map[string]bool{cur: true}}
+
+	row := probeHost(sshconf.Host{Alias: "blocked"}, r, base)
+
+	if row.Class != string(drift.AuthFailed) {
+		t.Fatalf("Class = %q, want %q", row.Class, drift.AuthFailed)
+	}
+	if !strings.Contains(row.Note, "host key unverified") {
+		t.Fatalf("Note = %q, want it to name the fault", row.Note)
+	}
+}
+
+// A failure with no stderr to read (every fake runner that predates this
+// change) must classify exactly as it always did.
+func TestFailureWithNoEvidenceStaysUnreachable(t *testing.T) {
+	cur := strings.Repeat("a", 40)
+	r := runner.Fake{Err: map[string]error{"dead": runner.ErrFake}}
+	base := fakeBaseline{head: cur, ancestor: map[string]bool{cur: true}}
+
+	row := probeHost(sshconf.Host{Alias: "dead"}, r, base)
+
+	if row.Class != string(drift.Unreachable) {
+		t.Fatalf("Class = %q, want %q", row.Class, drift.Unreachable)
+	}
+}
+
+// The ladder exists to rouse hosts asleep at layer 2. A host that answered SSH
+// is not asleep, so waking it is pure waste — a full budget (~12s) of ICMP and
+// relay hops per host, every run, to fix nothing.
+func TestWakeLadderNeverFiresForAnAuthFailure(t *testing.T) {
+	cur := strings.Repeat("a", 40)
+	r := runner.Fake{Err: map[string]error{"blocked": sshErr(t, hostKeyFail)}}
+	base := fakeBaseline{head: cur, ancestor: map[string]bool{cur: true}}
+
+	var mu sync.Mutex
+	var woken []string
+	w := func(h sshconf.Host, _ []reach.Peer) reach.Result {
+		mu.Lock()
+		defer mu.Unlock()
+		woken = append(woken, h.Alias)
+		return reach.Result{}
+	}
+
+	collectWake([]sshconf.Host{{Alias: "blocked"}}, r, base, testNow, w)
+
+	if len(woken) != 0 {
+		t.Fatalf("ladder fired for %v; an answering host must never be woken", woken)
+	}
+}
+
+// We cannot run a command on a host that refuses us, so it must never be
+// ranked as a live relay candidate. Marking it up would send a straggler's
+// ladder through a hop that is guaranteed to fail.
+func TestAuthFailedHostIsNeverOfferedAsALiveRelayPeer(t *testing.T) {
+	cur := strings.Repeat("a", 40)
+	r := runner.Fake{Err: map[string]error{
+		"blocked": sshErr(t, hostKeyFail),
+		"asleep":  runner.ErrFake,
+	}}
+	base := fakeBaseline{head: cur, ancestor: map[string]bool{cur: true}}
+
+	var mu sync.Mutex
+	var seen []reach.Peer
+	w := func(h sshconf.Host, peers []reach.Peer) reach.Result {
+		mu.Lock()
+		defer mu.Unlock()
+		if h.Alias == "asleep" {
+			seen = peers
+		}
+		return reach.Result{}
+	}
+
+	collectWake([]sshconf.Host{{Alias: "blocked"}, {Alias: "asleep"}}, r, base, testNow, w)
+
+	for _, p := range seen {
+		if p.Alias == "blocked" && p.Reachable {
+			t.Fatal("a host that refused us was offered as a reachable relay peer")
+		}
+	}
+}

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -596,9 +596,12 @@ func (m tuiModel) peersFor(target string) []reach.Peer {
 			name = r.Alias
 		}
 		out = append(out, reach.Peer{
-			Alias:     r.Alias,
-			HostName:  name,
-			Reachable: !m.pending[r.Alias] && r.Class != string(drift.Unreachable) && r.Class != "polling",
+			Alias:    r.Alias,
+			HostName: name,
+			// A host that refused us cannot run a relayed command, so it is
+			// no more usable as a hop than an unreachable one.
+			Reachable: !m.pending[r.Alias] && r.Class != string(drift.Unreachable) &&
+				r.Class != string(drift.AuthFailed) && r.Class != "polling",
 		})
 	}
 	return out

--- a/sdk/fleet/cmd/tui_view.go
+++ b/sdk/fleet/cmd/tui_view.go
@@ -70,7 +70,11 @@ func newTheme() theme {
 			string(drift.Divergent):   lipgloss.NewStyle().Foreground(c("5")),
 			string(drift.Unknown):     lipgloss.NewStyle().Faint(true),
 			string(drift.Unreachable): lipgloss.NewStyle().Foreground(c("1")).Bold(true),
-			"polling":                 lipgloss.NewStyle().Faint(true),
+			// Orange, not the unreachable red: the machine is UP. The colour
+			// difference is the whole point — it says "look at your keys, not
+			// at the network".
+			string(drift.AuthFailed): lipgloss.NewStyle().Foreground(c("208")).Bold(true),
+			"polling":                lipgloss.NewStyle().Faint(true),
 		},
 	}
 }

--- a/sdk/fleet/internal/drift/drift.go
+++ b/sdk/fleet/internal/drift/drift.go
@@ -18,13 +18,21 @@ const (
 	Divergent   Class = "ahead/divergent"
 	Unknown     Class = "unknown"
 	Unreachable Class = "unreachable"
+	// AuthFailed is a host that ANSWERED and then refused us — an unknown or
+	// changed host key, or no accepted credential. It is deliberately not
+	// Unreachable: the machine is up and listening, and the fix is local
+	// (known_hosts, a key) rather than on the network.
+	AuthFailed Class = "auth-failed"
 )
 
 // Input is everything known about one host after the SSH probe.
 type Input struct {
 	Reachable, HaveStamp, IsAncestor bool
-	Commit, Baseline                 string
-	BehindCount                      int
+	// AuthFailed qualifies a failed probe: ssh got a session and was turned
+	// away. Meaningless when Reachable is true.
+	AuthFailed       bool
+	Commit, Baseline string
+	BehindCount      int
 }
 
 type Result struct {
@@ -35,8 +43,16 @@ type Result struct {
 // Classify decides a host's state. Order matters: an unreachable host is
 // never reported as up-to-date, and a host with no stamp is Unknown rather
 // than assumed current — silence is not success.
+//
+// AuthFailed is tested before Unreachable because it is strictly more
+// specific: both mean "no answer to work with", but only one tells the
+// operator the machine is alive and the fix is local. It is deliberately
+// checked only when the probe failed, so a stale flag can never mask a host
+// that actually answered.
 func Classify(in Input) Result {
 	switch {
+	case !in.Reachable && in.AuthFailed:
+		return Result{Class: AuthFailed}
 	case !in.Reachable:
 		return Result{Class: Unreachable}
 	case !in.HaveStamp:

--- a/sdk/fleet/internal/drift/drift_test.go
+++ b/sdk/fleet/internal/drift/drift_test.go
@@ -72,3 +72,27 @@ func TestFormatAgeZeroTimeIsUnknown(t *testing.T) {
 		t.Fatalf("zero time should render %q, got %q", "-", got)
 	}
 }
+
+// A host that answered SSH and then refused us is NOT unreachable. Reporting
+// it as such is what sends an operator to the network layer to debug a trust
+// problem on a machine that is up and listening.
+func TestClassifyAuthFailureIsNotUnreachable(t *testing.T) {
+	got := Classify(Input{Reachable: false, AuthFailed: true})
+	if got.Class != AuthFailed {
+		t.Fatalf("Classify = %q, want %q", got.Class, AuthFailed)
+	}
+	if got.Class == Unreachable {
+		t.Fatal("an auth failure must never render as unreachable")
+	}
+}
+
+// AuthFailed is strictly more specific than "no reply", so it outranks it —
+// but it must never outrank a host that actually answered, or a successful
+// probe carrying a stale flag would hide a real classification.
+func TestClassifyAuthFailureNeverMasksASuccessfulProbe(t *testing.T) {
+	got := Classify(Input{Reachable: true, AuthFailed: true, HaveStamp: true,
+		Commit: "aaa", Baseline: "aaa", IsAncestor: true})
+	if got.Class != UpToDate {
+		t.Fatalf("a host that answered must classify on its stamp, got %q", got.Class)
+	}
+}

--- a/sdk/fleet/internal/sshfail/sshfail.go
+++ b/sdk/fleet/internal/sshfail/sshfail.go
@@ -1,0 +1,87 @@
+// Package sshfail tells apart the two ways an SSH probe fails, because they
+// send an operator to different machines.
+//
+// A probe that never reached the host (refused, timed out, unresolvable) is a
+// network fact. A probe that CONNECTED and was then refused on trust or
+// credentials is not: the host is up, listening, and answering. Collapsing the
+// second into "unreachable" is what sent a real investigation to the network
+// layer for what was a one-line known_hosts gap — fleet runs every probe with
+// BatchMode=yes, so an unknown host key cannot prompt and fails instantly,
+// looking exactly like a dead machine.
+//
+// The evidence is ssh's stderr, which (*exec.Cmd).Output() already captures
+// into *exec.ExitError. Nothing here opens a socket.
+package sshfail
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+)
+
+// Kind is what the failure actually was.
+type Kind string
+
+const (
+	// Unknown is the honest answer when there is no stderr to read — every
+	// fake runner in the unit tests lands here, and callers must treat it
+	// exactly as they treated a failure before this package existed.
+	Unknown Kind = "unknown"
+	// Network means the session never got established.
+	Network Kind = "network"
+	// Auth means ssh connected and we were turned away.
+	Auth Kind = "auth"
+)
+
+// markers maps a stderr signature to its kind and operator-facing note.
+//
+// Order matters: a CHANGED host key prints the "Host key verification failed"
+// line as well, so the more specific — and far more alarming — signature has
+// to be tested first or a possible MITM would render as a routine unknown key.
+var markers = []struct {
+	sig, note string
+	kind      Kind
+}{
+	{"REMOTE HOST IDENTIFICATION HAS CHANGED", "host key CHANGED", Auth},
+	{"Host key verification failed", "host key unverified", Auth},
+	{"Permission denied", "permission denied", Auth},
+	{"Too many authentication failures", "permission denied", Auth},
+	{"Connection refused", "", Network},
+	{"Connection timed out", "", Network},
+	{"Connection closed by", "", Network},
+	{"No route to host", "", Network},
+	{"Network is unreachable", "", Network},
+	{"Could not resolve hostname", "", Network},
+	{"Operation timed out", "", Network},
+}
+
+// match is the single scan both exported functions share, so a signature can
+// never classify one way and annotate another.
+func match(err error) (Kind, string) {
+	s := stderrOf(err)
+	if s == "" {
+		return Unknown, ""
+	}
+	for _, m := range markers {
+		if strings.Contains(s, m.sig) {
+			return m.kind, m.note
+		}
+	}
+	return Unknown, ""
+}
+
+// stderrOf recovers what the ssh process wrote. A plain error carries none.
+func stderrOf(err error) string {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return string(ee.Stderr)
+	}
+	return ""
+}
+
+// Classify reports which layer failed. A nil error is Unknown, never a verdict.
+func Classify(err error) Kind { k, _ := match(err); return k }
+
+// Note is the short qualifier for the row: which auth fault, since the fixes
+// differ (ssh-keygen -R versus authorizing a key).
+func Note(err error) string { _, n := match(err); return n }

--- a/sdk/fleet/internal/sshfail/sshfail_test.go
+++ b/sdk/fleet/internal/sshfail/sshfail_test.go
@@ -1,0 +1,73 @@
+package sshfail
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+// realExitError produces the EXACT error shape runner.Exec.Run returns: a
+// *exec.ExitError whose Stderr was captured by (*exec.Cmd).Output(). Building
+// one by hand would leave ProcessState nil and test a shape the runner never
+// actually emits.
+func realExitError(t *testing.T, stderr string) error {
+	t.Helper()
+	_, err := exec.Command("sh", "-c", `printf '%s' "$1" >&2; exit 255`, "sh", stderr).Output()
+	if err == nil {
+		t.Fatal("setup: wanted a failing command, got success")
+	}
+	return err
+}
+
+// The whole point of the package: ssh answering and then REFUSING us is not
+// the same fact as ssh never getting through, and an operator sent to the
+// network layer for a trust problem debugs the wrong machine.
+func TestClassifySeparatesRefusedTrustFromNoConnection(t *testing.T) {
+	for _, tc := range []struct {
+		name, stderr string
+		want         Kind
+	}{
+		{"unknown host key under BatchMode", "Host key verification failed.", Auth},
+		{"host key changed", "@@@@@@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @@@@@@", Auth},
+		{"no usable credential", "wenlock@host: Permission denied (publickey).", Auth},
+		{"nothing listening", "ssh: connect to host h port 22: Connection refused", Network},
+		{"host down", "ssh: connect to host h port 22: Connection timed out", Network},
+		{"no route", "ssh: connect to host h port 22: No route to host", Network},
+		{"name does not resolve", "ssh: Could not resolve hostname h: Name or service not known", Network},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Classify(realExitError(t, tc.stderr)); got != tc.want {
+				t.Fatalf("Classify(%q) = %q, want %q", tc.stderr, got, tc.want)
+			}
+		})
+	}
+}
+
+// A fake runner in a unit test returns a plain error with no stderr at all.
+// Guessing Auth there would invent a diagnosis from nothing; the honest answer
+// is Unknown, which callers treat exactly as they treated every failure before.
+func TestClassifyDoesNotInventADiagnosis(t *testing.T) {
+	if got := Classify(errors.New("boom")); got != Unknown {
+		t.Fatalf("plain error = %q, want %q", got, Unknown)
+	}
+	if got := Classify(nil); got != Unknown {
+		t.Fatalf("nil error = %q, want %q", got, Unknown)
+	}
+}
+
+// The class says "auth-failed"; the note says WHICH kind, because the two have
+// completely different fixes: one is ssh-keygen -R, the other is a key.
+func TestNoteNamesTheActualFault(t *testing.T) {
+	for _, tc := range []struct{ stderr, want string }{
+		{"Host key verification failed.", "host key unverified"},
+		{"@@@@@@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @@@@@@", "host key CHANGED"},
+		{"wenlock@host: Permission denied (publickey).", "permission denied"},
+	} {
+		if got := Note(realExitError(t, tc.stderr)); got != tc.want {
+			t.Fatalf("Note(%q) = %q, want %q", tc.stderr, got, tc.want)
+		}
+	}
+	if got := Note(errors.New("boom")); got != "" {
+		t.Fatalf("Note(plain error) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## What

`fleet status` reported a live, listening host as `unreachable`. This adds a new
`auth-failed` class so a refused *credential* is never confused with a refused
*connection*.

- **New `internal/sshfail`** — reads ssh's stderr (already captured by
  `(*exec.Cmd).Output()` into `*exec.ExitError`) and classifies the failure as
  `Auth`, `Network`, or `Unknown`. Nothing here opens a socket.
- **New `drift` class `auth-failed`**, tested before `Unreachable` because it is
  strictly more specific, and only when the probe actually failed — so a stale
  flag can never mask a host that answered.
- **The wake ladder no longer fires** at a host that is demonstrably awake.
- **An auth-failed host is never ranked as a live relay peer** (headless and TUI).
- **TUI renders it orange, not the unreachable red**, and the note names the fault.

## Why

Every probe runs `BatchMode=yes`, so an unknown host key cannot prompt and fails
*instantly* — indistinguishable from a dead machine. The cost is real: an
investigation went to the network layer for what was a one-line `known_hosts`
gap on a host that was up the whole time.

The wake ladder made it worse. `internal/reach` exists for hosts asleep at layer
2; against a host that is answering it spends a full budget (~12s) per host per
run on ICMP and relay hops that cannot possibly help.

`host key CHANGED` is the MITM warning. Rendering it as `unreachable` hid a
security signal behind a routine-looking dead row.

## Impact

- A new value appears in the STATUS column and `--json`: `auth-failed`.
- Severity order gains it at rank 1, just after `unreachable`; `exitCode` is
  unchanged (still non-zero for anything not `up-to-date`).
- **No behaviour change without evidence**: a failure with no stderr to read
  stays `unreachable`. `sshfail` never invents a diagnosis, so every existing
  fake-runner test keeps its original meaning.

## Testing

- TDD throughout — each cycle's RED was observed before implementing. The
  headline failure was `Class = "unreachable", want "auth-failed"`.
- Tests build **genuine** `*exec.ExitError`s from a real failing process rather
  than hand-stuffing the struct, so they exercise the shape production emits.
- `go test -race ./...` green across all 8 packages; `go vet` clean; `gofmt` clean.
- Coverage: `internal/sshfail` 93.3%, `internal/drift` 100%.
- **End-to-end on real hardware**: removed the alias's `known_hosts` entry to
  recreate the original bug, then ran both binaries against the identical state.

  | binary | STATUS |
  | :-- | :-- |
  | before | `unreachable` |
  | after | `auth-failed (host key unverified)` |