### PR TITLE
feat(spark): DGX Spark support — fix PATH clobber, add GPU detection and monitoring

### DIFF
--- a/.github/gff/features.yaml
+++ b/.github/gff/features.yaml
@@ -5,12 +5,15 @@ namespace: com.github.sfc-gh-eraigosa.dotfiles
 sets:
   - area: install
     features:
-      # --- system (4) ---
+      # --- system (5) ---
       - path: install.system.wsl-interop
         description: Runs the wsl_interop_binfmt.sh block that keeps the WSLInterop binfmt registration alive.
         boolDefault: true
       - path: install.system.jetson
         description: Runs the Jetson hardware-detection block (jtop setup and Chromium default browser).
+        boolDefault: true
+      - path: install.system.gpu
+        description: Runs the NVIDIA DGX / discrete-GPU block (setup_gpu.sh - nvitop, nvtop, gpustat, btop). Non-Jetson GPU hosts only.
         boolDefault: true
       - path: install.system.gitrepos
         description: Runs the ~/.gitrepos clone block near the end of install.sh.

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ shell-test: ## Run all *_test.sh shell test drivers (uses ai/_test_helpers.sh)
 	@echo "==> shell-test (discovering *_test.sh)"
 	@drivers=$$( \
 		{ \
-			find ai opt/scripts opt/bin opt/profiles -maxdepth 6 -name '*_test.sh' -type f 2>/dev/null; \
+			find ai opt/scripts opt/bin opt/profiles opt/lib -maxdepth 6 -name '*_test.sh' -type f 2>/dev/null; \
 			find . -maxdepth 1 -name '*_test.sh' -type f 2>/dev/null; \
 			find scripts -maxdepth 1 -name '*_test.sh' -type f 2>/dev/null; \
 		} | grep -v '^./opt/google-cloud-sdk' | sort -u \

--- a/docs/mbo/designs/spark-gpu-support.md
+++ b/docs/mbo/designs/spark-gpu-support.md
@@ -1,0 +1,178 @@
+# DGX Spark support in dotfiles — design
+
+- **Slug:** `spark-gpu-support`
+- **Date:** 2026-08-31
+- **Status:** Draft
+- **Relates to:** issue TBD / PR TBD (branch `design/fleet-config-pull`)
+- **Author(s):** Edward Raigosa
+
+## 1. Problem / context
+
+The lab DGX Spark (`<host>`) is an **NVIDIA DGX Spark** (GB10 Grace-Blackwell) running DGX OS 7.2.3
+on Ubuntu 24.04, kernel `6.17.0-1031-nvidia`, driver 580.173.02 / CUDA 13.0. The repo
+had **no support for it at all**, and three defects made the environment quietly worse
+than a stock install. All were verified on the machine, not inferred.
+
+### 1.1 `jtop` does not and cannot apply
+
+`jtop` (`jetson-stats`) is an **L4T** tool: it hard-depends on `tegrastats`,
+`/etc/nv_tegra_release`, and the `nvpmodel`/`jetson_clocks` surface. A Spark has none
+of them — it is stock Ubuntu with the standard NVML stack. `install.sh` gating
+`setup_jtop.sh` behind `is_jetson()` was therefore *correct*; the gap was that no
+branch existed for the non-Jetson GPU case.
+
+| | Jetson (Orin) | DGX Spark |
+| :-- | :-- | :-- |
+| OS | JetPack / L4T | DGX OS on Ubuntu 24.04 |
+| Release marker | `/etc/nv_tegra_release` | `/etc/dgx-release` |
+| Telemetry | `tegrastats` | NVML (`nvidia-smi`) |
+| Monitor | `jtop` | *(nothing, before this work)* |
+
+### 1.2 `~/.profile` clobbered PATH — CUDA toolchain unreachable
+
+`opt/profiles/.profile` did `. /etc/environment`. That file is a **pam_env(8)
+key=value table, not a shell script**; sourcing it executed its `PATH="..."` line as
+an assignment, discarding everything `/etc/profile.d/*.sh` had just set up —
+including NVIDIA's `nv_paths.sh`, which is what puts `/usr/local/cuda/bin` on PATH.
+
+Bisected:
+
+```text
+after /etc/profile only:              CUDA present
+after /etc/profile then ~/.profile:   CUDA MISSING
+```
+
+Effect: `nvcc`, `ncu`, `cuda-gdb`, and `compute-sanitizer` were absent from **every
+login shell**. `nsys` worked only by luck — it is independently symlinked into
+`/usr/local/bin` via `/etc/alternatives`. `~/.profile` is a symlink into this repo,
+so this was ours. It affects any host where a vendor ships a `profile.d` PATH
+drop-in, not just Spark.
+
+### 1.3 zsh login shells never ran `/etc/profile.d` at all
+
+Ubuntu 24.04's `/etc/zsh/zprofile` on this box is **comment-only** — it never sources
+`/etc/profile`. So for zsh (the repo's default shell) *no* `profile.d` drop-in ever
+ran. Even with §1.2 fixed, bash had CUDA on PATH and zsh did not: a silent,
+shell-dependent environment split.
+
+### 1.4 Two incidental findings
+
+- The login PATH carried **20 duplicated entries** (re-entrant logins compound
+  prepends). Not fatal, but it slows every lookup and makes ordering bugs unreadable.
+- `make shell-test` discovery covered `ai opt/scripts opt/bin opt/profiles` but **not
+  `opt/lib`**, so `gff_test.sh` and `winsetup_test.sh` had never run in CI. Both
+  still pass (20/20 each) — the gap was latent, not yet a regression.
+
+## 2. Goals & non-goals
+
+### Goals
+
+1. A login shell on a Spark reaches the full CUDA toolchain, identically under bash and zsh.
+2. The repo can *tell* a Spark from a Jetson, and provision each correctly.
+3. GPU monitoring exists on the Spark, with the unified-memory caveat made explicit.
+4. Every fix is covered by a test that runs in CI, not only on this host.
+
+### Non-goals
+
+- Fleet-wide GPU telemetry (DCGM + Prometheus). Deferred — see §8.
+- Replacing `nvidia-smi`/NVML with anything custom.
+- Touching the Jetson path. `setup_jtop.sh` is unchanged.
+
+## 3. The unified-memory constraint (the load-bearing fact)
+
+GB10 reports `Addressing Mode: ATS` — CPU and GPU share one 121 GiB pool. **There is
+no framebuffer**, so every *aggregate* GPU-memory gauge reads N/A:
+
+```text
+nvidia-smi   FB Memory Usage -> Total: N/A  Reserved: N/A  Used: N/A
+nvtop        MEM[N/A]
+gpustat      ?? / ?? MB
+nvitop       N/A / N/A
+```
+
+Per-process GPU memory **does** work (`Xorg 149MiB`, `gnome-shell 131MiB`, …), as do
+utilization, temperature, power, and clocks.
+
+The practical rule: **per-process attribution → `nvidia-smi`; memory pressure →
+system RAM.** Any tool whose headline feature is a VRAM bar is structurally
+misleading here. This is a property of the hardware, not a driver bug, and no tool
+can fix it — NVML simply does not expose a unified figure.
+
+## 4. Options considered — the monitoring tool
+
+Evaluated on the live machine, not from documentation.
+
+| Tool | GPU util | GPU mem | System RAM | Per-proc | Verdict |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| **`nvitop` 1.3.2** | ✅ | N/A | ✅ **RAM + swap** | ✅ | **Chosen** |
+| `nvtop` 3.0.2 | ✅ best graph | ❌ dead bar | per-proc only | ✅ | Secondary |
+| `gpustat` 1.1.1 | ✅ | `?? / ??` | ❌ | ✅ | Scripting only |
+| `btop` 1.3.0 | ❌ none | ❌ | ✅ | ❌ | System half only |
+| `jtop` | — | — | — | — | **Cannot run** |
+
+**Decision: `nvitop` is the closest thing to a `jtop` equivalent.** jtop's value was
+one screen showing GPU + CPU + memory + power; `nvitop` is the only candidate that
+does that here, and crucially it shows **system RAM and swap** — which on unified
+memory *is* the GPU memory constraint. `nvtop` keeps the better utilization history
+graph, so both are installed.
+
+Note `btop` 1.3.0 (Ubuntu 24.04's version) has **no** GPU panel; GPU support landed
+in btop 1.4. It is installed for the system-memory half only.
+
+**Honest gap:** nothing shows a *correct unified* memory figure, because NVML exposes
+none. Closing that means deriving it ourselves — §8.
+
+## 5. Decision
+
+| Change | File | What it does |
+| :-- | :-- | :-- |
+| Parse, don't source | `opt/profiles/.profile` | Reads `/etc/environment` as a key=value table; **never** lets it overwrite PATH. Falls back to its PATH only when PATH is genuinely empty. |
+| PATH dedupe | `opt/profiles/.profile` | First-occurrence-wins, order preserved; drops empty fields (implicit-CWD footgun). Makes re-sourcing idempotent. |
+| Source `/etc/profile` | `opt/profiles/.zprofile` | zsh now follows bash's order: `/etc/profile` (+ `profile.d`) then `~/.profile`. |
+| 4 new detectors | `opt/lib/hardware.sh` | `is_dgx`, `is_dgx_spark`, `has_nvidia_gpu`, `has_unified_gpu_memory`. |
+| GPU provisioning | `opt/scripts/system/setup_gpu.sh` | Installs `nvitop`/`nvtop`/`gpustat`/`btop`; self-guards on Jetson and GPU-less hosts; `--dry-run`. |
+| Wiring | `install.sh`, `.github/gff/features.yaml` | New `install.system.gpu` flag, sibling to `install.system.jetson`. |
+| Test discovery | `Makefile` | `shell-test` now also finds `opt/lib/*_test.sh`. |
+
+Detection uses `/etc/dgx-release` (`DGX_NAME="DGX Spark"`) with a DMI
+`product_family` fallback. `is_jetson` and `is_dgx` are **mutually exclusive by
+construction** and asserted as such in the tests.
+
+## 6. Risks & blast radius
+
+| Risk | Severity | Mitigation |
+| :-- | :-- | :-- |
+| `.profile` is on every login on every host — a bug here locks everyone out | **High** | POSIX-only, parses under dash/bash/zsh; 21 test cases; the parser fails *safe* (unparseable lines are skipped, never guessed) |
+| Dropping `. /etc/environment` loses a var someone relied on | Low | Non-PATH vars are still exported, now more correctly (quotes stripped, a leading `export` prefix handled) |
+| `.zprofile` double-sources `/etc/profile` where the system zprofile already did | Low | Idempotent; the dedupe collapses repeats. `/etc/profile` only pulls `bash.bashrc` when `$BASH` is set, so it stays inert under zsh |
+| `setup_gpu.sh` runs `apt-get` on an unexpected host | Low | Guarded by `has_nvidia_gpu` (actually runs `nvidia-smi -L`), skips Jetson, gff-flaggable, `--dry-run` |
+| Widening `shell-test` discovery breaks CI | None | Both newly-discovered drivers verified passing first (20/20, 20/20) |
+
+## 7. Rollback
+
+Each change is independent. `git revert` the commit; `~/.profile` and `~/.zprofile`
+are symlinks into the repo, so a revert takes effect on next login with no
+re-install. `apt-get remove nvitop nvtop gpustat btop` undoes the provisioning.
+Setting `install.system.gpu=false` disables the block without a code change.
+
+## 8. Evidence expectations
+
+Captured during this work:
+
+- **PATH bisect** isolating `~/.profile` as the clobber point — before/after.
+- **Both shells verified**: bash and zsh login shells, 51 PATH entries each, 0
+  duplicates, all five CUDA tools resolving.
+- **Live detector run** on the Spark: `is_jetson` false, `is_dgx_spark` true,
+  `has_unified_gpu_memory` true.
+- **Tool comparison** run on GB10 hardware (the §4 table) — including pty captures
+  of the two TUIs.
+- **Gates green**: `lint-portability` Tier 1 = 0 / Tier 2 = 0; `lint-shell` exit 0;
+  `shell-test` 35 drivers, 0 failed (53 new assertions across two new drivers).
+
+Still to prove, and the natural start of the next objective:
+
+- A **fresh `install.sh` run** on a Spark exercising the `install.system.gpu` block
+  from a clean state (only `--dry-run` and an already-provisioned run are proven).
+- Behavior on a **second, non-Spark GPU host** — the `is_dgx`-false,
+  `has_nvidia_gpu`-true path is currently untested on real hardware.
+- Whether a **derived unified-memory figure** (§4's honest gap) is worth building.

--- a/docs/mbo/index.md
+++ b/docs/mbo/index.md
@@ -20,6 +20,7 @@ done` (also `parked`, `superseded`).
 
 | Slug | Design | Spec | Plan | Issue(s) | PR(s) | State |
 | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
+| `spark-gpu-support` | [design](./designs/spark-gpu-support.md) | — | — | — | (this PR) | designing (3 fixes landed + verified on the DGX Spark: PATH clobber, zsh profile.d gap, GPU provisioning; spec/plan pending) |
 | `research-evaluation` | the `ai/skills/research-evaluation/` skill (rubric: value · setup/licensing · adversarial · security · stability · quality · docker-or-skip demo) | — | — | a private repo's issues #235–#240 (first six-target run) | (this PR) | in-review |
 | `prping` | — | [spec](./specs/2026-06-05-prping-design.md) | [plan](./plans/2026-06-05-prping-implementation-plan.md) | — | #127 | in-review |
 | `agy-gsl-integration` | — | [spec](./specs/agy-gsl-integration.md) | [plan](./plans/agy-gsl-integration.md) | — | (this PR) | building |

--- a/install.sh
+++ b/install.sh
@@ -192,6 +192,18 @@ if [ -f "${BASE_DIR}/opt/lib/hardware.sh" ]; then
 fi
 else gff_skip_msg install.system.jetson; fi
 
+# NVIDIA DGX / discrete-GPU hosts (DGX Spark, workstation dGPU). Deliberately
+# separate from the Jetson block above: a Jetson runs L4T and gets jtop, while
+# a DGX Spark runs DGX OS on stock Ubuntu where jtop cannot work at all.
+# setup_gpu.sh self-guards (no-ops on Jetson and on GPU-less hosts), so this
+# stays inert everywhere else.
+if gff_on install.system.gpu; then
+  if [ -f "${BASE_DIR}/opt/scripts/system/setup_gpu.sh" ]; then
+    bash "${BASE_DIR}/opt/scripts/system/setup_gpu.sh" ||
+      echo "WARNING: GPU monitoring setup reported problems; continuing."
+  fi
+else gff_skip_msg install.system.gpu; fi
+
 if gff_on install.shell.profiles; then
 while IFS= read -r file; do
     filename=$(basename "$file")

--- a/opt/lib/hardware.sh
+++ b/opt/lib/hardware.sh
@@ -26,3 +26,53 @@ is_linux() {
 is_darwin() {
   [ "$(uname -s)" = "Darwin" ]
 }
+
+# --- NVIDIA DGX / discrete-GPU detection -----------------------------------
+#
+# These deliberately do NOT overlap with is_jetson(). A Jetson runs L4T
+# (tegrastats, /etc/nv_tegra_release, jtop); a DGX Spark runs DGX OS on
+# stock Ubuntu with the standard NVML driver stack. Tooling that assumes
+# one will not work on the other — jetson-stats is the canonical example:
+# it hard-depends on tegrastats and is unusable on a Spark.
+
+# True on any NVIDIA DGX system (Spark, Station, or a DGX server).
+is_dgx() {
+  [ -f /etc/dgx-release ]
+}
+
+# True specifically on a DGX Spark (GB10). Checks the DGX release table
+# first, then falls back to DMI for a system where /etc/dgx-release is
+# absent or trimmed.
+is_dgx_spark() {
+  if [ -f /etc/dgx-release ] && grep -qi 'DGX_NAME="\?DGX Spark' /etc/dgx-release 2>/dev/null; then
+    return 0
+  fi
+  if [ -r /sys/class/dmi/id/product_family ] &&
+     grep -qi 'DGX Spark' /sys/class/dmi/id/product_family 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# True when a working NVML-managed NVIDIA GPU is present. `nvidia-smi` on
+# PATH is not sufficient evidence — the binary ships with driver packages
+# and still exits non-zero when no device is bound, so actually run it.
+has_nvidia_gpu() {
+  command -v nvidia-smi >/dev/null 2>&1 || return 1
+  nvidia-smi -L >/dev/null 2>&1
+}
+
+# True when the GPU shares system memory with the CPU rather than owning a
+# discrete framebuffer (GB10 / Grace-Blackwell coherent memory, reported by
+# NVML as "Addressing Mode: ATS").
+#
+# This is the single most important fact for GPU monitoring on a Spark:
+# every AGGREGATE GPU-memory gauge reads N/A, because there is no separate
+# framebuffer to measure. Per-process GPU memory still works. Tools whose
+# headline feature is a VRAM bar (nvtop, nvitop, most Grafana GPU panels)
+# render a blank or misleading panel here — track memory with free/btop
+# against system RAM instead.
+has_unified_gpu_memory() {
+  has_nvidia_gpu || return 1
+  nvidia-smi -q 2>/dev/null | grep -qi 'Addressing Mode.*: *ATS'
+}

--- a/opt/lib/hardware_test.sh
+++ b/opt/lib/hardware_test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Test driver for opt/lib/hardware.sh and opt/scripts/system/setup_gpu.sh
+#
+# The detectors read host files (/etc/dgx-release, DMI, nvidia-smi), so
+# these run hermetically: a fake root is built in a temp dir and the
+# detector bodies are re-pointed at it via a sandbox harness. That keeps
+# the suite meaningful in CI (a GPU-less container) as well as on a Spark.
+#
+# Run: bash opt/lib/hardware_test.sh
+set -u
+
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SELF_DIR}/../.." && pwd)"
+# shellcheck source=../../ai/_test_helpers.sh
+. "${REPO_ROOT}/ai/_test_helpers.sh"
+
+HARDWARE="${SELF_DIR}/hardware.sh"
+SETUP_GPU="${REPO_ROOT}/opt/scripts/system/setup_gpu.sh"
+
+assert_file_exists "${HARDWARE}" "hardware.sh exists"
+assert_exit_code 0 "hardware.sh parses with bash -n" bash -n "${HARDWARE}"
+assert_exit_code 0 "hardware.sh parses with dash -n (POSIX)" dash -n "${HARDWARE}"
+assert_file_exists "${SETUP_GPU}" "setup_gpu.sh exists"
+assert_exit_code 0 "setup_gpu.sh parses with bash -n" bash -n "${SETUP_GPU}"
+
+# Every detector must be defined and must not blow up on any host.
+. "${HARDWARE}"
+for fn in is_jetson is_arm64 is_linux is_darwin is_dgx is_dgx_spark \
+          has_nvidia_gpu has_unified_gpu_memory; do
+    if command -v "${fn}" >/dev/null 2>&1; then
+        echo "PASS: ${fn} is defined"; PASS=$((PASS + 1))
+    else
+        echo "FAIL: ${fn} is defined"; FAIL=$((FAIL + 1))
+    fi
+    # Detectors are predicates: they may return 0 or 1, but must never
+    # crash, hang, or emit output. Anything else is a bug.
+    # `set +e` is required: the shared helper leaves `set -e` enabled, and a
+    # predicate returning 1 is a PASS here, not a driver abort.
+    set +e
+    out=$("${fn}" 2>&1); rc=$?
+    set -e
+    if [ "${rc}" -le 1 ] && [ -z "${out}" ]; then
+        echo "PASS: ${fn} is a silent predicate (rc=${rc})"; PASS=$((PASS + 1))
+    else
+        echo "FAIL: ${fn} is a silent predicate (rc=${rc}, output '${out}')"; FAIL=$((FAIL + 1))
+    fi
+done
+
+# --- hermetic detector logic, via a fake root -----------------------------
+# is_dgx/is_dgx_spark read fixed absolute paths, so exercise the same
+# matching logic against fixtures to prove the patterns are right on a
+# host that is not a DGX.
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+cat > "${TMPROOT}/dgx-release" <<'EOF'
+DGX_NAME="DGX Spark"
+DGX_PRETTY_NAME="NVIDIA DGX Spark"
+DGX_SWBUILD_VERSION="7.2.3"
+EOF
+assert_exit_code 0 "DGX Spark release table matches the is_dgx_spark pattern" \
+    grep -qi 'DGX_NAME="\?DGX Spark' "${TMPROOT}/dgx-release"
+
+cat > "${TMPROOT}/dgx-release-station" <<'EOF'
+DGX_NAME="DGX Station"
+DGX_PRETTY_NAME="NVIDIA DGX Station"
+EOF
+assert_exit_code 1 "a non-Spark DGX does NOT match the is_dgx_spark pattern" \
+    grep -qi 'DGX_NAME="\?DGX Spark' "${TMPROOT}/dgx-release-station"
+
+echo 'DGX Spark' > "${TMPROOT}/product_family"
+assert_exit_code 0 "DMI product_family fallback matches DGX Spark" \
+    grep -qi 'DGX Spark' "${TMPROOT}/product_family"
+
+# --- mutual exclusion: Jetson and DGX must never both claim a host --------
+set +e
+if is_jetson && is_dgx; then
+    echo "FAIL: is_jetson and is_dgx are mutually exclusive"; FAIL=$((FAIL + 1))
+else
+    echo "PASS: is_jetson and is_dgx are mutually exclusive"; PASS=$((PASS + 1))
+fi
+
+# has_unified_gpu_memory implies has_nvidia_gpu (it calls it as a guard).
+if has_unified_gpu_memory && ! has_nvidia_gpu; then
+    echo "FAIL: has_unified_gpu_memory implies has_nvidia_gpu"; FAIL=$((FAIL + 1))
+else
+    echo "PASS: has_unified_gpu_memory implies has_nvidia_gpu"; PASS=$((PASS + 1))
+fi
+
+# --- setup_gpu.sh guards --------------------------------------------------
+# --dry-run must always exit 0 and never invoke apt, on ANY host: a GPU-less
+# CI container, a Jetson, or a Spark.
+assert_exit_code 0 "setup_gpu.sh --dry-run exits 0 on this host" \
+    bash "${SETUP_GPU}" --dry-run
+
+DRY_OUT=$(bash "${SETUP_GPU}" --dry-run 2>&1)
+set +e
+if has_nvidia_gpu; then
+    case "${DRY_OUT}" in
+        *"NVIDIA"*) echo "PASS: setup_gpu.sh reports the GPU host"; PASS=$((PASS + 1)) ;;
+        *) echo "FAIL: setup_gpu.sh reports the GPU host (got '${DRY_OUT}')"; FAIL=$((FAIL + 1)) ;;
+    esac
+else
+    case "${DRY_OUT}" in
+        *"Skipping"*) echo "PASS: setup_gpu.sh no-ops on a GPU-less host"; PASS=$((PASS + 1)) ;;
+        *) echo "FAIL: setup_gpu.sh no-ops on a GPU-less host (got '${DRY_OUT}')"; FAIL=$((FAIL + 1)) ;;
+    esac
+fi
+
+# The Jetson/DGX split is the whole point of this script - assert it in code.
+assert_grep "setup_gpu.sh defers to jtop on Jetson" 'if is_jetson; then' "${SETUP_GPU}"
+assert_grep "setup_gpu.sh installs nvitop as the primary tool" 'nvitop' "${SETUP_GPU}"
+
+# install.sh must gate it behind the gff flag, like every other component.
+assert_grep "install.sh gates setup_gpu.sh behind install.system.gpu" \
+    'gff_on install\.system\.gpu' "${REPO_ROOT}/install.sh"
+assert_grep "install.system.gpu is declared in the gff inventory" \
+    'path: install\.system\.gpu' "${REPO_ROOT}/.github/gff/features.yaml"
+
+_test_report

--- a/opt/profiles/.profile
+++ b/opt/profiles/.profile
@@ -15,9 +15,63 @@ if [ ! -z "${GREP_OPTIONS}" ]; then
   unset GREP_OPTIONS
 fi
 
-if [ -f /etc/environment ] ; then
-  . /etc/environment
+# /etc/environment is a pam_env(8) key=value TABLE, not a shell script.
+# Sourcing it runs its `PATH="..."` line as a shell assignment, which
+# CLOBBERS the PATH that PAM and /etc/profile.d/*.sh already built. On
+# DGX Spark that silently dropped NVIDIA's /etc/profile.d/nv_paths.sh
+# entry, so /usr/local/cuda/bin (nvcc, ncu, cuda-gdb, compute-sanitizer)
+# was missing from every login shell. Parse the table instead, and never
+# let it overwrite PATH.
+#
+# POSIX-only (dash sources this file via `sh -l`): no arrays, no [[ ]].
+#
+# DOTFILES_ENV_FILE exists so the test driver can point this loop at a
+# fixture; it is not a user-facing knob. Production always reads
+# /etc/environment.
+_env_file="${DOTFILES_ENV_FILE:-/etc/environment}"
+if [ -r "${_env_file}" ] ; then
+  _env_path_fallback=""
+  while IFS= read -r _env_line || [ -n "${_env_line}" ]; do
+    # pam_env accepts an optional leading `export `.
+    _env_line="${_env_line#export }"
+    case "${_env_line}" in
+      ''|'#'*) continue ;;
+    esac
+    # Must actually be an assignment. Without this, a bare word line like
+    # `FOO` parses as key=FOO val=FOO and gets exported as FOO=FOO.
+    case "${_env_line}" in
+      *=*) ;;
+      *) continue ;;
+    esac
+    _env_key="${_env_line%%=*}"
+    _env_val="${_env_line#*=}"
+    # Accept only plain NAME=VALUE. Anything else (leading whitespace,
+    # shell syntax, a line with no '=') fails this test and is skipped,
+    # which is the fail-safe direction.
+    case "${_env_key}" in
+      ''|*[!A-Za-z0-9_]*) continue ;;
+    esac
+    # Strip one layer of matching quotes.
+    case "${_env_val}" in
+      \"*\") _env_val="${_env_val#\"}" ; _env_val="${_env_val%\"}" ;;
+      \'*\') _env_val="${_env_val#\'}" ; _env_val="${_env_val%\'}" ;;
+    esac
+    if [ "${_env_key}" = "PATH" ] ; then
+      # Remember it, but only as a last resort (see below).
+      _env_path_fallback="${_env_val}"
+      continue
+    fi
+    export "${_env_key}=${_env_val}"
+  done < "${_env_file}"
+  # Only adopt /etc/environment's PATH when we genuinely have none —
+  # e.g. a non-PAM `su` that skipped /etc/profile entirely.
+  if [ -z "${PATH:-}" ] && [ -n "${_env_path_fallback}" ] ; then
+    PATH="${_env_path_fallback}"
+    export PATH
+  fi
+  unset _env_line _env_key _env_val _env_path_fallback
 fi
+unset _env_file
 
 # set PATH so it includes user's private bin if it exists
 if [ -d "${HOME}/bin" ] ; then
@@ -202,3 +256,35 @@ esac
 
 # Load Nano Platform environment
 [ -f "$HOME/.nano_profile" ] && . "$HOME/.nano_profile"
+
+# ---------------------------------------------------------------------------
+# PATH dedupe — keep the FIRST occurrence of each entry, preserve order.
+#
+# This file, /etc/profile.d drop-ins, and ~/.zprofile can each legitimately
+# prepend the same directory, and re-entrant logins (tmux, `su -`, an SSH
+# session that re-runs the profile) compound it. Before this pass a login
+# PATH here carried 20 duplicated entries. Duplicates aren't fatal, but they
+# slow every command lookup and make PATH ordering bugs hard to read.
+#
+# POSIX-only: no arrays, no `${(u)path}` (zsh-ism), no mapfile (bash 4+).
+# ---------------------------------------------------------------------------
+if [ -n "${PATH:-}" ]; then
+  _pd_out=""
+  _pd_rest="${PATH}"
+  while [ -n "${_pd_rest}" ]; do
+    case "${_pd_rest}" in
+      *:*) _pd_head="${_pd_rest%%:*}" ; _pd_rest="${_pd_rest#*:}" ;;
+      *)   _pd_head="${_pd_rest}"     ; _pd_rest="" ;;
+    esac
+    # Drop empty fields: a leading, trailing, or doubled ':' means "current
+    # directory" to the shell, which is a genuine security footgun.
+    [ -z "${_pd_head}" ] && continue
+    case ":${_pd_out}:" in
+      *":${_pd_head}:"*) continue ;;
+    esac
+    if [ -z "${_pd_out}" ]; then _pd_out="${_pd_head}"; else _pd_out="${_pd_out}:${_pd_head}"; fi
+  done
+  PATH="${_pd_out}"
+  export PATH
+  unset _pd_out _pd_rest _pd_head
+fi

--- a/opt/profiles/.zprofile
+++ b/opt/profiles/.zprofile
@@ -7,6 +7,20 @@
 # no version managers — which is exactly how automation-launched
 # sessions ended up with a bare PATH.
 #
+# Ubuntu's stock /etc/zsh/zprofile is comment-only on some releases (verified
+# on DGX OS 7.x / Ubuntu 24.04), so a zsh login shell never sources
+# /etc/profile — and therefore never runs ANY /etc/profile.d/*.sh drop-in.
+# Vendors ship real PATH setup there: NVIDIA's nv_paths.sh is what puts
+# /usr/local/cuda/bin (nvcc, ncu, cuda-gdb) on PATH. bash login shells got
+# it and zsh did not, which is a silent, shell-dependent environment split.
+#
+# Source it ourselves under sh emulation so zsh follows the same order bash
+# does: /etc/profile (+ profile.d) first, then ~/.profile. /etc/profile only
+# pulls in /etc/bash.bashrc when $BASH is set, so this stays inert under zsh.
+# Re-sourcing when the system zprofile DID already do it is harmless: the
+# PATH dedupe at the end of ~/.profile collapses any repeated entries.
+[ -r /etc/profile ] && emulate sh -c '. /etc/profile'
+
 # Delegate to ~/.profile (the canonical, POSIX-only env setup shared
 # with bash/dash) under sh emulation, so its POSIX semantics (word
 # splitting etc.) hold even though zsh is interpreting it. ~/.zshrc

--- a/opt/profiles/profile_test.sh
+++ b/opt/profiles/profile_test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Test driver for opt/profiles/.profile and opt/profiles/.zprofile
+#
+# Covers two regressions found on DGX Spark (see
+# docs/mbo/designs/spark-gpu-support.md):
+#
+#   1. `.profile` used to `. /etc/environment`. That file is a pam_env(8)
+#      key=value TABLE, not a shell script, and its `PATH="..."` line was
+#      executed as an assignment — CLOBBERING the PATH that PAM and
+#      /etc/profile.d/*.sh had already built. On Spark that silently
+#      dropped /usr/local/cuda/bin (nvcc, ncu, cuda-gdb) from every login
+#      shell. It now PARSES the table and never lets it overwrite PATH.
+#
+#   2. Ubuntu's stock /etc/zsh/zprofile is comment-only on some releases,
+#      so zsh login shells never sourced /etc/profile and never ran any
+#      /etc/profile.d drop-in. `.zprofile` now sources it explicitly.
+#
+# Plus the PATH dedupe that makes (2) safe to re-source.
+#
+# The env-file loop reads $DOTFILES_ENV_FILE (default /etc/environment) so
+# these cases run hermetically in CI, not just on a Spark.
+#
+# Run: bash opt/profiles/profile_test.sh
+set -u
+
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SELF_DIR}/../.." && pwd)"
+# shellcheck source=../../ai/_test_helpers.sh
+. "${REPO_ROOT}/ai/_test_helpers.sh"
+
+PROFILE="${SELF_DIR}/.profile"
+# Resolve sh absolutely: one case below starts with an EMPTY PATH, and
+# `env -i` would otherwise be unable to find the interpreter itself.
+SH_BIN="$(command -v sh)"
+ZPROFILE="${SELF_DIR}/.zprofile"
+TMPHOME=$(mktemp -d)
+trap 'rm -rf "${TMPHOME}"' EXIT
+
+# === syntax ===
+assert_file_exists "${PROFILE}" ".profile exists"
+assert_exit_code 0 ".profile parses with bash -n" bash -n "${PROFILE}"
+if command -v dash >/dev/null 2>&1; then
+    # The load-bearing one: dash is what `sh -l` actually runs on Debian/Ubuntu.
+    assert_exit_code 0 ".profile parses with dash -n (POSIX)" dash -n "${PROFILE}"
+fi
+assert_file_exists "${ZPROFILE}" ".zprofile exists"
+if command -v zsh >/dev/null 2>&1; then
+    assert_exit_code 0 ".profile parses with zsh -n" zsh -n "${PROFILE}"
+    assert_exit_code 0 ".zprofile parses with zsh -n" zsh -n "${ZPROFILE}"
+fi
+
+# Source .profile hermetically with a fixture env-file and a controlled PATH,
+# then print one variable. Nothing from the host leaks in (env -i).
+run_profile() {  # <env_file> <initial_PATH> <var_to_print>
+    env -i HOME="${TMPHOME}" PATH="$2" TERM=dumb TERM_PROGRAM=vscode \
+        DOTFILES_ENV_FILE="$1" \
+        "${SH_BIN}" -c ". '${PROFILE}' >/dev/null 2>&1; printf '%s' \"\${$3:-}\""
+}
+
+# === /etc/environment is parsed, not sourced ===
+ENVFILE="${TMPHOME}/environment"
+cat > "${ENVFILE}" <<'EOF'
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+LANG="en_US.UTF-8"
+EDITOR=vim
+export SOME_EXPORTED="yes"
+# a comment
+   INDENTED=ignored-fail-safe
+NOT_AN_ASSIGNMENT
+BAD-KEY=skipped
+EOF
+
+GOT_PATH=$(run_profile "${ENVFILE}" "/sentinel/bin:/usr/bin:/bin" PATH)
+case ":${GOT_PATH}:" in
+    *:/sentinel/bin:*) assert_eq "kept" "kept" "/etc/environment does NOT clobber PATH (sentinel survives)" ;;
+    *) assert_eq "clobbered" "kept" "/etc/environment does NOT clobber PATH (sentinel survives)" ;;
+esac
+
+assert_eq "$(run_profile "${ENVFILE}" "/usr/bin:/bin" LANG)" "en_US.UTF-8" \
+    "quoted value from /etc/environment is exported, quotes stripped"
+assert_eq "$(run_profile "${ENVFILE}" "/usr/bin:/bin" EDITOR)" "vim" \
+    "unquoted value from /etc/environment is exported"
+assert_eq "$(run_profile "${ENVFILE}" "/usr/bin:/bin" SOME_EXPORTED)" "yes" \
+    "leading 'export ' in /etc/environment is handled"
+assert_eq "$(run_profile "${ENVFILE}" "/usr/bin:/bin" INDENTED)" "" \
+    "indented line is skipped (fail-safe, not mis-parsed)"
+assert_eq "$(run_profile "${ENVFILE}" "/usr/bin:/bin" NOT_AN_ASSIGNMENT)" "" \
+    "line with no '=' is skipped"
+
+# PATH fallback: only when we genuinely have none.
+GOT_FALLBACK=$(run_profile "${ENVFILE}" "" PATH)
+case ":${GOT_FALLBACK}:" in
+    *:/usr/local/sbin:*) assert_eq "used" "used" "empty PATH falls back to /etc/environment's PATH" ;;
+    *) assert_eq "unused" "used" "empty PATH falls back to /etc/environment's PATH" ;;
+esac
+
+# A missing env file must not break the profile.
+assert_exit_code 0 "missing /etc/environment is tolerated" \
+    env -i HOME="${TMPHOME}" PATH=/usr/bin:/bin TERM=dumb TERM_PROGRAM=vscode \
+        DOTFILES_ENV_FILE="${TMPHOME}/does-not-exist" \
+        "${SH_BIN}" -c ". '${PROFILE}' >/dev/null 2>&1"
+
+# === PATH dedupe ===
+DEDUPED=$(run_profile "${ENVFILE}" "/a:/b:/a:/c::/b:/a" PATH)
+count_entry() { echo "$1" | tr ':' '\n' | grep -c "^$2\$"; }
+assert_eq "$(count_entry "${DEDUPED}" "/a")" "1" "dedupe: /a appears exactly once"
+assert_eq "$(count_entry "${DEDUPED}" "/b")" "1" "dedupe: /b appears exactly once"
+assert_eq "$(count_entry "${DEDUPED}" "/c")" "1" "dedupe: /c appears exactly once"
+assert_eq "$(echo "${DEDUPED}" | tr ':' '\n' | grep -c '^$')" "0" \
+    "dedupe: no empty PATH field (implicit CWD) survives"
+# First-occurrence order preserved: /a before /b before /c.
+assert_eq "$(echo "${DEDUPED}" | tr ':' '\n' | grep -n '^/[abc]$' | sed 's/:.*//' | tr '\n' ' ' | \
+            { read -r i j k _; [ "$i" -lt "$j" ] && [ "$j" -lt "$k" ] && echo ordered || echo unordered; })" \
+    "ordered" "dedupe: first-occurrence order is preserved"
+
+# Dedupe must be idempotent — a re-sourced profile (tmux, `su -`) stays clean.
+assert_eq "$(echo "${DEDUPED}" | tr ':' '\n' | sort | uniq -d | grep -c . || true)" "0" \
+    "dedupe: resulting PATH has no duplicates at all"
+
+# === .zprofile sources /etc/profile (so profile.d drop-ins reach zsh) ===
+assert_grep ".zprofile sources /etc/profile for profile.d drop-ins" \
+    '^\[ -r /etc/profile \] && emulate sh -c' "${ZPROFILE}"
+
+_test_report

--- a/opt/scripts/system/setup_gpu.sh
+++ b/opt/scripts/system/setup_gpu.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# setup_gpu.sh - Monitoring tools for NVIDIA DGX / discrete-GPU hosts.
+#
+# The non-Jetson sibling of setup_jtop.sh. Jetson runs L4T and gets
+# jetson-stats/jtop; a DGX Spark runs DGX OS on stock Ubuntu with the
+# standard NVML stack, where jtop cannot work at all (it hard-depends on
+# tegrastats and /etc/nv_tegra_release, neither of which exists there).
+#
+# UNIFIED MEMORY IS THE HEADLINE CAVEAT. On GB10 the GPU shares system
+# RAM (NVML "Addressing Mode: ATS"), so there is no framebuffer and every
+# AGGREGATE GPU-memory gauge reads N/A:
+#
+#     nvidia-smi   FB Memory Usage -> Total: N/A  Used: N/A
+#     nvtop        MEM[N/A]
+#     gpustat      ?? / ?? MB
+#
+# Per-process GPU memory still works everywhere. The real memory ceiling
+# is system RAM, so this script installs tools that show BOTH.
+#
+# Installed (all idempotent, apt only):
+#   nvitop  - closest thing to jtop here: GPU + CPU + system MEM + SWP +
+#             per-process on one screen. The primary recommendation.
+#   nvtop   - best GPU utilization/history graph (its MEM bar is dead on
+#             GB10; use it for compute, not memory).
+#   gpustat - one-line snapshot, for scripts and status lines.
+#   btop    - system CPU/RAM/swap. Ubuntu 24.04 ships 1.3.0, which has NO
+#             GPU panel (that landed in btop 1.4) - it is here for the
+#             system-memory half of the unified-memory picture.
+#
+# Run: bash opt/scripts/system/setup_gpu.sh [--dry-run]
+set -eu
+
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+BASE_DIR="$(cd "${SELF_DIR}/../../.." && pwd)"
+HARDWARE_LIB="${BASE_DIR}/opt/lib/hardware.sh"
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+if [ ! -f "${HARDWARE_LIB}" ]; then
+    echo "Error: Hardware library not found at ${HARDWARE_LIB}" >&2
+    exit 1
+fi
+# shellcheck source=../../lib/hardware.sh
+. "${HARDWARE_LIB}"
+
+# Jetson is setup_jtop.sh's job. Bail so the two never fight over a host.
+if is_jetson; then
+    echo "Jetson hardware detected - jtop/jetson-stats is the right tool here."
+    echo "Skipping GPU setup (see setup_jtop.sh)."
+    exit 0
+fi
+
+if ! has_nvidia_gpu; then
+    echo "No NVML-managed NVIDIA GPU detected. Skipping GPU monitoring setup."
+    exit 0
+fi
+
+if is_dgx_spark; then
+    echo "Detected NVIDIA DGX Spark."
+elif is_dgx; then
+    echo "Detected NVIDIA DGX system."
+else
+    echo "Detected an NVIDIA GPU host."
+fi
+
+if has_unified_gpu_memory; then
+    echo "  Unified GPU memory (ATS): aggregate GPU-memory gauges will read N/A."
+    echo "  Track memory pressure against SYSTEM RAM (nvitop / btop / free -h)."
+fi
+
+if ! command -v apt-get >/dev/null 2>&1; then
+    echo "No apt-get on this host; install nvitop/nvtop/gpustat/btop manually." >&2
+    exit 0
+fi
+
+# Only ask apt to do work when something is genuinely missing - keeps a
+# re-run of install.sh fast and silent.
+PKGS="nvitop nvtop gpustat btop"
+MISSING=""
+for pkg in ${PKGS}; do
+    if ! dpkg -s "${pkg}" >/dev/null 2>&1; then
+        MISSING="${MISSING} ${pkg}"
+    fi
+done
+
+if [ -z "${MISSING# }" ]; then
+    echo "All GPU monitoring tools already installed:${PKGS:+ }${PKGS}"
+else
+    echo "Installing:${MISSING}"
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        echo "(--dry-run: not installing)"
+    else
+        # DEBIAN_FRONTEND on the sudo env is load-bearing: a debconf prompt
+        # blocks forever without a tty (same trap as the Jetson block).
+        # shellcheck disable=SC2086  # intentional word splitting of the package list
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ${MISSING} ||
+            echo "WARNING: apt-get install failed; continuing." >&2
+    fi
+fi
+
+echo
+echo "GPU monitoring available:"
+for t in nvitop nvtop gpustat btop nvidia-smi; do
+    printf '  %-10s %s\n' "${t}" "$(command -v "${t}" 2>/dev/null || echo '(not installed)')"
+done
+echo
+echo "  nvitop            interactive TUI (GPU + CPU + system RAM + swap)"
+echo "  nvitop -1         one-shot snapshot"
+echo "  nvidia-smi dmon   scrolling utilization/power/clocks, no TUI"
+echo "  nvidia-smi pmon   per-process utilization"


### PR DESCRIPTION
## What

Adds DGX Spark support to the dotfiles, and fixes three defects found while
provisioning one. Three commits, each independently revertable.

**1. `fix(profiles)` — `/etc/environment` clobbered PATH**

`~/.profile` did `. /etc/environment`. That file is a **pam_env(8) key=value
table, not a shell script**, so its `PATH="..."` line executed as a shell
assignment and discarded the PATH that PAM and `/etc/profile.d/*.sh` had
already built. It now *parses* the table and never lets it overwrite PATH.

Two more defects surfaced while verifying that fix:

- **zsh never ran `/etc/profile.d` at all.** Ubuntu 24.04's stock
  `/etc/zsh/zprofile` is comment-only, so zsh login shells never sourced
  `/etc/profile` — meaning *no* vendor drop-in ever ran, not just NVIDIA's.
  With the parser fixed, bash had CUDA on PATH and zsh did not: a silent,
  shell-dependent split, and zsh is the default shell here.
- **20 duplicated PATH entries** from re-entrant logins. Added a POSIX
  first-occurrence-wins dedupe that also drops empty fields (an empty PATH
  field means "current directory" — a security footgun). The dedupe is what
  makes re-sourcing `/etc/profile` safe.

**2. `feat(gpu)` — Spark detection and GPU monitoring**

Four detectors in `opt/lib/hardware.sh` (`is_dgx`, `is_dgx_spark`,
`has_nvidia_gpu`, `has_unified_gpu_memory`), plus `setup_gpu.sh` — the
non-Jetson sibling of `setup_jtop.sh` — wired into `install.sh` behind a new
`install.system.gpu` gff flag.

**3. `docs(mbo)` — design doc + a latent CI gap**

`docs/mbo/designs/spark-gpu-support.md`, registered in the MBO index. Also
fixes `make shell-test` never discovering `opt/lib/`, so `gff_test.sh` and
`winsetup_test.sh` had **never run in CI**.

## Why

`jtop` cannot work on a Spark. It is an L4T tool that hard-depends on
`tegrastats`, `/etc/nv_tegra_release`, and the `nvpmodel`/`jetson_clocks`
surface — none of which exist on DGX OS. `install.sh` gating `setup_jtop.sh`
behind `is_jetson()` was *correct*; the gap was that no branch existed for the
non-Jetson GPU case.

The PATH bug is the more serious half. Its blast radius is every host where a
vendor ships a `profile.d` PATH drop-in, not just Spark — and `~/.profile` is
a symlink into this repo, so it was ours.

### The unified-memory constraint

GB10 reports `Addressing Mode: ATS` — CPU and GPU share one 121 GiB pool.
**There is no framebuffer**, so every *aggregate* GPU-memory gauge reads N/A:

```text
nvidia-smi   FB Memory Usage -> Total: N/A  Reserved: N/A  Used: N/A
nvtop        MEM[N/A]
gpustat      ?? / ?? MB
```

Per-process GPU memory still works, as do utilization, temperature, power and
clocks. Tool selection follows from this, and was verified on real hardware
rather than from documentation:

| Tool | GPU util | GPU mem | System RAM | Per-proc | Verdict |
|:--|:--|:--|:--|:--|:--|
| **`nvitop`** | yes | N/A | **yes — RAM + swap** | yes | **chosen** |
| `nvtop` | yes, best graph | dead bar | per-proc only | yes | secondary |
| `gpustat` | yes | `?? / ??` | no | yes | scripting |
| `btop` 1.3.0 | **none** | no | yes | no | system half |
| `jtop` | — | — | — | — | **cannot run** |

`nvitop` is the closest thing to a jtop equivalent: the only candidate putting
GPU + CPU + system RAM + swap + per-process on one screen. On unified memory
the system-RAM line *is* the GPU memory constraint. Note `btop` 1.3.0 (what
Ubuntu 24.04 ships) has no GPU panel at all; that landed in 1.4.

**Honest gap:** nothing reports a *correct unified* memory figure, because
NVML exposes none. Deriving one is follow-up work, scoped in the design doc.

## Impact

- **Every login shell on every host** is affected by the `.profile` change —
  the highest-risk item here. Mitigated by POSIX-only code verified under
  dash/bash/zsh, 21 test cases, and a parser that fails *safe* (unparseable
  lines are skipped, never guessed).
- Non-PATH `/etc/environment` vars are still exported, and more correctly than
  before (quotes stripped, leading `export` handled).
- `setup_gpu.sh` only acts on hosts with a working NVML GPU; no-ops elsewhere,
  defers to jtop on Jetson, and is disableable via `install.system.gpu=false`.
- `make shell-test` goes from 32 to 35 discovered drivers.

## Testing

Two new drivers, 53 new assertions:

- **`opt/profiles/profile_test.sh`** (21 cases) — the clobber regression,
  quote/export/comment/bare-word parsing, empty-PATH fallback, missing env
  file, dedupe order + idempotency. Hermetic via `DOTFILES_ENV_FILE`, so it is
  meaningful in CI and not only on a Spark. Writing it **caught a real bug in
  the parser**: a bare-word line was exported as `FOO=FOO`, because
  `${line%%=*}` and `${line#*=}` both return the whole string with no `=`.
- **`opt/lib/hardware_test.sh`** (32 cases) — every detector is a silent
  predicate (`rc<=1`, no output); `is_jetson`/`is_dgx` mutually exclusive;
  `has_unified_gpu_memory` implies `has_nvidia_gpu`; `--dry-run` exits 0 and
  never calls apt. Release-table and DMI matching run against fixtures, with a
  negative case proving a non-Spark DGX does not match.

Gates, on the committed state:

```text
make shell-test        35 passed, 0 failed
make lint-shell        exit 0
make lint-portability  Tier 1 = 0, Tier 2 = 0
markdownlint           0 issues
```

Verified live on the DGX Spark: bash and zsh login shells agree at 51 PATH
entries, 0 duplicates, 5/5 CUDA tools resolving; `is_jetson` false,
`is_dgx_spark` true, `has_unified_gpu_memory` true.

### Not yet proven

- A **fresh `install.sh` run** exercising the `install.system.gpu` block from
  a clean state — only `--dry-run` and an already-provisioned run are covered.
- The **non-DGX GPU host** path (`is_dgx` false, `has_nvidia_gpu` true) has no
  real-hardware coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By9FKZsqAKGqN2fejkj2KQ