### PR TITLE
fix(pkg): install xclip+xsel so herdr copies reach the X clipboard

### DIFF
--- a/docs/macos-keys.md
+++ b/docs/macos-keys.md
@@ -165,6 +165,20 @@ accelerator matches. Check with `dconf dump /org/gnome/terminal/legacy/keybindin
 and re-run `~/opt/scripts/system/gnome-desktop-defaults.sh`, which resets the
 stale binds.
 
+**herdr says "copied to clipboard" but `Cmd+V` pastes something older.** Not a
+keyd problem: the chord arrives as `Ctrl+Shift+V` and gnome-terminal dutifully
+pastes the X clipboard — herdr just never wrote to it. herdr's Linux clipboard
+path is `wl-copy` → `xclip` → `xsel`, and only when none of those exists does
+it fall back to the OSC 52 escape, which gnome-terminal/VTE silently drops
+([VTE #2495](https://gitlab.gnome.org/GNOME/vte/-/issues/2495),
+[herdr #2399](https://github.com/herdrdev/herdr/issues/2399)). `packages.tsv`
+installs `xclip` and `xsel` on every apt host for exactly this reason; on a
+machine provisioned before that, `sudo apt-get install xclip xsel` fixes the
+running herdr immediately (no restart — it resolves the tool per copy). On a
+Wayland session install `wl-clipboard` instead. Holding `Shift` while
+drag-selecting bypasses herdr's mouse capture and copies through gnome-terminal
+itself, if you need a one-off without installing anything.
+
 **Nothing is remapped at all.** `systemctl is-active keyd`, then
 `sudo keyd check` to validate the config. Note that keyd **rejects a trailing
 comment on a binding line** (`c = C-c  # copy`) with `invalid key or action` and

--- a/opt/bin/pkg-install_test.sh
+++ b/opt/bin/pkg-install_test.sh
@@ -152,4 +152,21 @@ case "$OUT" in
         ;;
 esac
 
+# === 7. manifest: Linux ships an X11 clipboard tool ===
+# herdr's Linux clipboard path is wl-copy -> xclip -> xsel, and only THEN the
+# OSC 52 escape -- which gnome-terminal/VTE silently drops (VTE #2495). Without
+# one of these installed every herdr mouse-copy shows a "copied" toast while the
+# clipboard keeps its old contents (herdr #2399). .tmux.conf's copy-pipe binds
+# also assume xsel. Both must stay in the APT column; macOS has pbcopy.
+MANIFEST="${REPO_ROOT}/opt/profiles/packages.tsv"
+for tool in xclip xsel; do
+    if awk '!/^[[:space:]]*(#|$)/ {print $2}' "$MANIFEST" | grep -qx "$tool"; then
+        echo "PASS: packages.tsv installs $tool on apt hosts"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: packages.tsv APT column is missing $tool (herdr/tmux clipboard)"
+        FAIL=$((FAIL + 1))
+    fi
+done
+
 _test_report

--- a/opt/profiles/packages.tsv
+++ b/opt/profiles/packages.tsv
@@ -79,6 +79,18 @@ watch                -
 # Apple Symbols with the same coverage, hence '-' in the BREW column.
 -                    fonts-symbola
 
+# X11 clipboard bridge for terminal programs. herdr's Linux clipboard path is
+# wl-copy -> xclip -> xsel and only THEN the OSC 52 escape, which gnome-terminal
+# (VTE) silently drops -- so with neither tool present every herdr mouse-copy
+# shows a "copied" toast while Cmd+V pastes the OLD clipboard (herdr #2399,
+# VTE #2495). .tmux.conf's copy-pipe binds already assume xsel. Both are tiny;
+# xclip is first in herdr's order, xsel is what tmux calls. Wayland sessions
+# want wl-clipboard instead (tracked in the dotfiles herdr clipboard issue).
+# macOS ships pbcopy/pbpaste, hence '-' in the BREW column. Guarded by
+# opt/bin/pkg-install_test.sh.
+-                    xclip
+-                    xsel
+
 # Kubernetes toolchain. apt has no kind package at all, and kubectl/helm need
 # third-party apt repos that lag upstream — so Linux/WSL gets the official
 # release binaries via opt/scripts/system/install_k8s_tools.sh (wired into

--- a/opt/scripts/system/install_ai_teams_test.sh
+++ b/opt/scripts/system/install_ai_teams_test.sh
@@ -53,8 +53,18 @@ assert_eq "deep-think -> claude opus"      "$(fmget "$CSY" '.model')"  "opus"
 assert_eq "deep-think -> claude effort hi" "$(fmget "$CSY" '.effort')" "high"
 assert_eq "fast -> claude haiku"           "$(fmget "$CWQ" '.model')"  "haiku"
 assert_eq "deep-think -> antigravity o3"   "$(yq '.model' "$ASY")"  "o3"
-assert_contains "ollama standard FROM"  "$(cat "$OGD")" "FROM qwen2.5-coder:7b"
-assert_contains "ollama num_ctx"        "$(cat "$OGD")" "PARAMETER num_ctx 8192"
+# The ollama expectations are READ FROM model-map.yaml rather than hardcoded: the
+# tiers get re-pointed as the Spark scorecard moves (13a1b90 took standard from
+# qwen2.5-coder:7b to qwen3-coder:30b and this test, still hardcoded, turned the
+# required teams-eval check red on every PR). What is under test is that the
+# emitter honours the map's standard tier, not which tag the map happens to name.
+MODEL_MAP="${HERE}/../../../ai/teams/model-map.yaml"
+MM_STD_MODEL="$(yq -r '.tiers.standard.ollama.model'   "$MODEL_MAP")"
+MM_STD_CTX="$(yq -r '.tiers.standard.ollama.num_ctx'   "$MODEL_MAP")"
+assert_contains "ollama standard FROM follows model-map (${MM_STD_MODEL})" \
+  "$(cat "$OGD")" "FROM ${MM_STD_MODEL}"
+assert_contains "ollama num_ctx follows model-map (${MM_STD_CTX})" \
+  "$(cat "$OGD")" "PARAMETER num_ctx ${MM_STD_CTX}"
 
 # --- emitter validity ------------------------------------------------------------------
 fmget "$CFE" '.name' >/dev/null 2>&1 && [ "$(fmget "$CFE" '.name')" = "web-fe" ] \


### PR DESCRIPTION
Tracks #262 (follow-ups live there).

## What

- `opt/profiles/packages.tsv`: add `xclip` and `xsel` to the APT column (BREW `-`: macOS ships `pbcopy`).
- `opt/bin/pkg-install_test.sh`: new case asserting both rows stay in the manifest.
- `docs/macos-keys.md`: troubleshooting entry for *"herdr says copied, but `Cmd+V` pastes something older"*.
- `opt/scripts/system/install_ai_teams_test.sh` (CI repair, folded in): the required **Validate teams source + routing artifacts** check went red on main when 13a1b90 re-pointed the ollama standard/think tiers to `qwen3-coder:30b` but left this test asserting `qwen2.5-coder:7b`. The test now reads the expected `FROM` / `num_ctx` from `ai/teams/model-map.yaml`'s standard tier, so the next re-tiering cannot strand it.

## Why

herdr's Linux clipboard writer (`src/platform/linux.rs`, v0.8.2) tries `wl-copy` → `xclip` → `xsel` and **only when none is installed** falls back to the OSC 52 escape. gnome-terminal 3.52 / VTE 0.76 does not implement OSC 52 ([VTE #2495](https://gitlab.gnome.org/GNOME/vte/-/issues/2495), open since 2018), so the escape is silently dropped while herdr still shows its "copied to clipboard" toast ([herdr #2399](https://github.com/herdrdev/herdr/issues/2399), closed upstream 2026-08-31 as "depends on the outer terminal").

The Spark had none of the three tools, so every herdr mouse-copy went down the OSC 52 path and `Cmd+V` (keyd → `Ctrl+Shift+V` → gnome-terminal paste) pasted whatever was in the X clipboard before. It presents as a keyd paste bug; the keyd/gsettings side was verified healthy (#259 applied, mapper matching `gnome-terminal-server`).

## Impact

- Every apt host gets a native X11 clipboard bridge; herdr copy works with mouse capture left on (no config change, no restart — herdr resolves the tool per copy).
- `.tmux.conf`'s `copy-pipe-and-cancel "xsel -i -b"` binds, which already assumed `xsel`, start working.
- Two small packages (~200 KB). No change on macOS. Wayland hosts still need `wl-clipboard` (tracked in #262).

## Testing

- `bash opt/bin/pkg-install_test.sh` → `PASS=15 FAIL=0` (was 13/2 before the manifest rows).
- `bash opt/scripts/system/install_ai_teams_test.sh` → `27 passed, 0 failed` on top of current main (was 26/1); `ai/teams/validate.sh`, `route-eval.sh --check` and `gen-index.sh` (no diff) also pass locally, i.e. every step of the teams-eval job.
- `shellcheck -x -S warning` + `bash -n` on the driver: clean. `make lint-portability`: 0 Tier 1/2. `markdownlint-cli2 docs/macos-keys.md`: 0 issues.
- Live: installed `xclip xsel` on the Spark by hand; the herdr server (`DISPLAY=:1`) now copies to the X `CLIPBOARD` and `Cmd+V` pastes the fresh selection in gnome-terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ts9ixfuBiS54aXbKdDjcGn

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **herdr**.

- #261 — edward-raigosa/install (base: `main`) ← parent of this PR
- **#263 — edward-raigosa/clipboard (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
