### PR TITLE
macos-keys: mapper-restart

### DIFF
--- a/docs/macos-keys.md
+++ b/docs/macos-keys.md
@@ -156,6 +156,17 @@ cannot reach keyd. Run `--doctor`; if "mapper running" is `no`, or the log at
 the `keyd` group — the installer adds you, but an already-open session does not
 pick up a new group until you log out and back in.
 
+**Every Cmd shortcut stopped working right after `install.sh` / `fleet update`
+re-ran.** Run `--doctor`: if keyd is `inactive` and both configs are `absent`, the
+installer rolled itself back. Before 2026-09-02 it judged an *already-running*
+mapper by that mapper's cumulative `app.log`, which collects keyd's IPC error every
+time the socket blinks — including the `systemctl restart keyd` the installer
+itself performs — so a re-run on a healthy host could read old errors and
+uninstall everything. The installer now stops any running mapper (including a
+legacy `~/.config/autostart/keyd-application-mapper.desktop` instance, which runs
+without the `keyd` group and can never connect) and judges only the fresh
+supervised one. Recovery is simply re-running `macos-keys-linux.sh`.
+
 **`Cmd+V` prints `^V` in gnome-terminal (and `Cmd+C` may interrupt).** The mapper
 is fine; gnome-terminal's *own* copy/paste accelerators are no longer the stock
 `Ctrl+Shift+C/V` that `app.conf` emits. A pre-keyd version of

--- a/docs/macos-keys.md
+++ b/docs/macos-keys.md
@@ -165,7 +165,9 @@ itself performs — so a re-run on a healthy host could read old errors and
 uninstall everything. The installer now stops any running mapper (including a
 legacy `~/.config/autostart/keyd-application-mapper.desktop` instance, which runs
 without the `keyd` group and can never connect) and judges only the fresh
-supervised one. Recovery is simply re-running `macos-keys-linux.sh`.
+supervised one. If the pre-existing mapper refuses to stop, the installer keeps
+it as-is rather than rolling back on its stale log. Recovery is simply re-running
+`macos-keys-linux.sh`.
 
 **`Cmd+V` prints `^V` in gnome-terminal (and `Cmd+C` may interrupt).** The mapper
 is fine; gnome-terminal's *own* copy/paste accelerators are no longer the stock

--- a/opt/scripts/system/macos-keys-linux.sh
+++ b/opt/scripts/system/macos-keys-linux.sh
@@ -40,6 +40,13 @@ PROC_DIR="${PROC_DIR:-/proc}"
 APP_CONF="${HOME}/.config/keyd/app.conf"
 KEYD_DROPIN="${KEYD_DROPIN:-/etc/systemd/system/keyd.service.d/10-dotfiles-restart.conf}"
 UNIT="${HOME}/.config/systemd/user/keyd-application-mapper.service"
+# An earlier install shape started the mapper from an XDG autostart entry. That
+# instance runs WITHOUT the keyd group, so it can never reach the socket, yet it
+# owns the mapper's single-instance lock and blocks the supervised unit forever.
+AUTOSTART_ENTRY="${HOME}/.config/autostart/keyd-application-mapper.desktop"
+# `kill` is a builtin, so the test driver cannot stub it via PATH; it points this
+# at a stub instead. Never set in normal use.
+KILL_CMD="${KILL_CMD:-kill}"
 BUILD_CACHE="${HOME}/.cache/dotfiles/keyd"
 
 # Populated by detect_graphical_session().
@@ -198,14 +205,39 @@ mapper_pids() {
 		# A process can exit between the glob and the read, so the redirect itself
 		# must not be what fails -- guard the file rather than the pipeline.
 		[ -r "${_d}/cmdline" ] || continue
-		tr '\0' ' ' 2> /dev/null < "${_d}/cmdline" |
-			grep -q 'bin/keyd-application-mapper' || continue
+		# Only argv[0..1] count (`keyd-application-mapper …` or `python3 …/keyd-
+		# application-mapper …`). Matching the WHOLE command line would also hit a
+		# shell whose -c string merely mentions the path -- it did, during the
+		# 2026-09-02 fix, killing the shell that was running this script.
+		tr '\0' '\n' 2> /dev/null < "${_d}/cmdline" | head -n 2 |
+			grep -q 'bin/keyd-application-mapper$' || continue
 		echo "${_p}"
 	done
 }
 
 mapper_running() {
 	[ -n "$(mapper_pids)" ]
+}
+
+# Stop every running mapper -- the supervised unit and any stray daemonized
+# instance -- and wait for the process table to agree, so the caller can start a
+# fresh one whose log reflects only itself.
+stop_mappers() {
+	systemctl --user stop keyd-application-mapper.service > /dev/null 2>&1
+	for _mp in $(mapper_pids); do ${KILL_CMD} "${_mp}" 2> /dev/null; done
+	_tries=0
+	while mapper_running && [ "${_tries}" -lt 10 ]; do
+		sleep 0.2
+		_tries=$((_tries + 1))
+	done
+	mapper_running && return 1
+	return 0
+}
+
+remove_autostart_entry() {
+	[ -f "${AUTOSTART_ENTRY}" ] || return 0
+	log "Removing the legacy autostart entry ${AUTOSTART_ENTRY} (the mapper is a systemd user unit now)."
+	rm -f "${AUTOSTART_ENTRY}"
 }
 
 # --- The fail-closed gate -----------------------------------------------------
@@ -373,6 +405,18 @@ install_unit() {
 start_mapper() {
 	_log="${HOME}/.config/keyd/app.log"
 
+	# A mapper that is already running is not trusted, it is REPLACED. Its app.log
+	# is cumulative for as long as it lives, and keyd's IPC error lands in it every
+	# time the socket is briefly unavailable -- including the `systemctl restart
+	# keyd` enable_keyd() just ran. Judging that instance by that log rolled the
+	# whole layout back on a healthy host (2026-09-02). It may also be a legacy
+	# autostart instance with no keyd group, which can never work at all. Either
+	# way: stop it, start a fresh supervised one, and judge only the fresh one.
+	if mapper_running; then
+		log "Replacing the already-running application mapper with a fresh supervised one..."
+		stop_mappers || warn "an old application mapper is still running; the new one may refuse to start"
+	fi
+
 	if ! mapper_running; then
 		# Clear the log so the health check below only judges this run.
 		rm -f "${_log}"
@@ -399,9 +443,7 @@ start_mapper() {
 	# A live process is NOT proof of success: the mapper daemonizes FIRST and only
 	# then discovers it cannot open /var/run/keyd.socket, so it sits there running
 	# and applying nothing. That is precisely the state that leaves Cmd+C as SIGINT
-	# in a terminal. Check the log unconditionally -- including for a mapper that
-	# was already running when we got here, which may be a stale broken one from a
-	# previous boot.
+	# in a terminal. The log was reset above, so it speaks for this run only.
 	if grep -q 'Failed to connect' "${_log}" 2> /dev/null; then
 		return 1
 	fi
@@ -436,9 +478,9 @@ uninstall() {
 	sudo rm -f "${KEYD_DROPIN}"
 	sudo rmdir "$(dirname "${KEYD_DROPIN}")" 2> /dev/null
 	sudo systemctl daemon-reload > /dev/null 2>&1
-	for _mp in $(mapper_pids); do kill "${_mp}" 2> /dev/null; done
+	for _mp in $(mapper_pids); do ${KILL_CMD} "${_mp}" 2> /dev/null; done
 	systemctl --user disable --now keyd-application-mapper.service > /dev/null 2>&1
-	rm -f "${UNIT}" "${APP_CONF}"
+	rm -f "${UNIT}" "${APP_CONF}" "${AUTOSTART_ENTRY}"
 	systemctl --user daemon-reload > /dev/null 2>&1
 	if [ -f "${KEYD_ETC}/default.conf.pre-dotfiles" ]; then
 		sudo mv "${KEYD_ETC}/default.conf.pre-dotfiles" "${KEYD_ETC}/default.conf"
@@ -503,6 +545,7 @@ main() {
 	}
 	enable_keyd || return 0
 	install_unit || warn "could not install the mapper user unit"
+	remove_autostart_entry
 	if ! start_mapper; then
 		warn "the application mapper did not come up; rolling back so the keyboard"
 		warn "is not left with Cmd+C mapped to SIGINT inside terminals."

--- a/opt/scripts/system/macos-keys-linux.sh
+++ b/opt/scripts/system/macos-keys-linux.sh
@@ -205,12 +205,16 @@ mapper_pids() {
 		# A process can exit between the glob and the read, so the redirect itself
 		# must not be what fails -- guard the file rather than the pipeline.
 		[ -r "${_d}/cmdline" ] || continue
-		# Only argv[0..1] count (`keyd-application-mapper …` or `python3 …/keyd-
-		# application-mapper …`). Matching the WHOLE command line would also hit a
-		# shell whose -c string merely mentions the path -- it did, during the
-		# 2026-09-02 fix, killing the shell that was running this script.
+		# Only argv[0..1] count: a BARE name (the env/sg launch shape -- PATH
+		# resolution leaves a bare argv[0], so `bin/...` alone would miss it), a
+		# full path (`…/bin/keyd-application-mapper`), or an interpreter argument
+		# (`python3 …/keyd-application-mapper …`). Matching the WHOLE command line
+		# would also hit a shell whose -c string merely mentions the path -- it
+		# did, during the 2026-09-02 fix, killing the shell that was running this
+		# script. argv[0] is the executable itself (never a -c string), so its
+		# bare name is bystander-safe to match.
 		tr '\0' '\n' 2> /dev/null < "${_d}/cmdline" | head -n 2 |
-			grep -q 'bin/keyd-application-mapper$' || continue
+			grep -qE '^keyd-application-mapper$|/bin/keyd-application-mapper$' || continue
 		echo "${_p}"
 	done
 }
@@ -414,7 +418,16 @@ start_mapper() {
 	# way: stop it, start a fresh supervised one, and judge only the fresh one.
 	if mapper_running; then
 		log "Replacing the already-running application mapper with a fresh supervised one..."
-		stop_mappers || warn "an old application mapper is still running; the new one may refuse to start"
+		if ! stop_mappers; then
+			# SIGTERM did not take within the wait window. This mapper was running
+			# BEFORE we touched the machine, and its log is exactly the cumulative
+			# kind of stale evidence that caused the 2026-09-02 false rollback --
+			# so neither judge it by that log nor uninstall over a mapper we cannot
+			# displace. Keep the previous state; a human can inspect with --doctor.
+			warn "could not stop the pre-existing application mapper; keeping it as-is"
+			warn "instead of judging it by its stale log. Inspect with 'macos-keys-linux.sh --doctor'."
+			return 0
+		fi
 	fi
 
 	if ! mapper_running; then

--- a/opt/scripts/system/macos-keys-linux_test.sh
+++ b/opt/scripts/system/macos-keys-linux_test.sh
@@ -81,6 +81,16 @@ cat > "$H/bin/usermod" <<'STUB'
 echo "usermod $*" >> "$STUB_LOG"; exit 0
 STUB
 
+# `kill` is a shell builtin, so PATH stubbing cannot intercept it; the SUT goes
+# through KILL_CMD instead. Without this, rollback/replace tests would send a real
+# SIGTERM to whatever real process happens to own pid 4242 on the build machine.
+cat > "$H/bin/kill" <<'STUB'
+#!/usr/bin/env bash
+echo "kill $*" >> "$STUB_LOG"
+for p in "$@"; do rm -rf "$PROC_DIR/$p"; done
+exit 0
+STUB
+
 # Unstubbed, this finds the BUILD MACHINE's real desktop session and the
 # no-graphical-session guard never fires.
 cat > "$H/bin/loginctl" <<'STUB'
@@ -111,10 +121,20 @@ run_sut() { # run_sut [VAR=val ...]
     printf '/usr/local/bin/keyd-application-mapper\0' > "$H/proc/4242/cmdline"
     echo 'ERROR: Failed to connect to "/var/run/keyd.socket"' > "$H/home/.config/keyd/app.log"
   fi
+  if [ "${PRESEED_BYSTANDER:-0}" = "1" ]; then
+    mkdir -p "$H/proc/4243"
+    printf 'bash\0-c\0pgrep -af bin/keyd-application-mapper | head\0' > "$H/proc/4243/cmdline"
+  fi
+  if [ "${PRESEED_AUTOSTART:-0}" = "1" ]; then
+    mkdir -p "$H/home/.config/autostart"
+    printf '[Desktop Entry]\nExec=keyd-application-mapper -d\n' \
+      > "$H/home/.config/autostart/keyd-application-mapper.desktop"
+  fi
   env PATH="$H/bin:$PATH" HOME="$H/home" KEYD_ETC="$H/etc/keyd" \
       STUB_LOG="$H/stublog" XDG_SESSION_TYPE=x11 DISPLAY=:99 \
       KEYD_DROPIN="$H/etc/systemd/keyd.service.d/10-dotfiles-restart.conf" \
       INPUT_DEVICES_DIR="$H/sys/class/input" PROC_DIR="$H/proc" \
+      KILL_CMD="$H/bin/kill" \
       "$@" bash "$SUT"
 }
 
@@ -152,11 +172,42 @@ assert_eq "$r" "0" "refusal explains the SIGINT hazard"
 # --- ROLLBACK: mapper starts but cannot reach the keyd socket -------------------
 # A live process is not proof of success; it daemonizes and only then fails to
 # open the socket. Leaving that state configured is the worst outcome.
-out="$(PRESEED_BROKEN_LOG=1 run_sut 2>&1)"
+out="$(PRESEED_BROKEN_LOG=1 run_sut FAKE_MAPPER_SOCKET_OK=0 2>&1)"
 assert_eq "$([ -f "$H/etc/keyd/default.conf" ] && echo yes || echo no)" "no" \
-    "already-running mapper that never reached the socket: config rolled back"
+    "mapper that cannot reach the socket: config rolled back"
 case "$out" in *"rolling back"*) r=0 ;; *) r=1 ;; esac
 assert_eq "$r" "0" "rollback is announced"
+
+# --- REPLACE, don't judge by a stale log (regression: 2026-09-02 self-uninstall) --
+# The mapper's app.log is cumulative for the life of a daemonized instance, and
+# keyd's own IPC error lands in it every time the socket is briefly unavailable --
+# including the `systemctl restart keyd` this very script runs a few lines
+# earlier. A re-run of install.sh found a mapper already running, skipped the log
+# reset, read 69 old errors, and rolled the whole layout back on a healthy host.
+# A pre-existing mapper is therefore REPLACED with a fresh supervised one, and
+# only the fresh instance's log decides.
+out="$(PRESEED_BROKEN_LOG=1 run_sut 2>&1)"
+assert_eq "$?" "0" "stale mapper + stale broken log: exits clean"
+assert_eq "$([ -f "$H/etc/keyd/default.conf" ] && echo yes || echo no)" "yes" \
+    "stale mapper + stale broken log: healthy fresh mapper keeps the config installed"
+assert_grep "stale mapper + stale broken log: the old mapper is stopped" "^kill 4242" "$H/stublog"
+assert_grep "stale mapper + stale broken log: a fresh mapper is started" "mapper started" "$H/stublog"
+case "$out" in *"rolling back"*) r=1 ;; *) r=0 ;; esac
+assert_eq "$r" "0" "stale mapper + stale broken log: no rollback"
+
+# A shell whose -c string merely MENTIONS the mapper path (a grep, an editor, the
+# shell running this very test) must never be treated as a mapper and killed.
+out="$(PRESEED_BROKEN_LOG=1 PRESEED_BYSTANDER=1 run_sut 2>&1)"
+assert_grep "replace stops the real mapper" "^kill 4242" "$H/stublog"
+assert_grep_negative "replace leaves a bystander shell that mentions the path alone" \
+    "^kill 4243" "$H/stublog"
+
+# The old XDG autostart entry (an earlier install shape) launches a mapper at login
+# WITHOUT the keyd group, which then owns the single-instance lock and blocks the
+# supervised unit forever. Install and uninstall must both remove it.
+out="$(PRESEED_AUTOSTART=1 run_sut 2>&1)"
+assert_eq "$([ -f "$H/home/.config/autostart/keyd-application-mapper.desktop" ] && echo yes || echo no)" "no" \
+    "stale autostart entry is removed on install"
 
 # The mapper failing to start at all is the same hazard as it starting broken.
 out="$(run_sut FAKE_MAPPER_STARTS=0 2>&1)"

--- a/opt/scripts/system/macos-keys-linux_test.sh
+++ b/opt/scripts/system/macos-keys-linux_test.sh
@@ -87,6 +87,8 @@ STUB
 cat > "$H/bin/kill" <<'STUB'
 #!/usr/bin/env bash
 echo "kill $*" >> "$STUB_LOG"
+# FAKE_KILL_REFUSES=1 simulates a mapper ignoring SIGTERM (the entry stays).
+[ "${FAKE_KILL_REFUSES:-0}" = "1" ] && exit 0
 for p in "$@"; do rm -rf "$PROC_DIR/$p"; done
 exit 0
 STUB
@@ -125,6 +127,11 @@ run_sut() { # run_sut [VAR=val ...]
     mkdir -p "$H/proc/4243"
     printf 'bash\0-c\0pgrep -af bin/keyd-application-mapper | head\0' > "$H/proc/4243/cmdline"
   fi
+  if [ "${PRESEED_BARE_ARGV:-0}" = "1" ]; then
+    # The env/sg launch shape: PATH resolution leaves a BARE argv[0].
+    mkdir -p "$H/proc/4244"
+    printf 'keyd-application-mapper\0-d\0' > "$H/proc/4244/cmdline"
+  fi
   if [ "${PRESEED_AUTOSTART:-0}" = "1" ]; then
     mkdir -p "$H/home/.config/autostart"
     printf '[Desktop Entry]\nExec=keyd-application-mapper -d\n' \
@@ -136,6 +143,26 @@ run_sut() { # run_sut [VAR=val ...]
       INPUT_DEVICES_DIR="$H/sys/class/input" PROC_DIR="$H/proc" \
       KILL_CMD="$H/bin/kill" \
       "$@" bash "$SUT"
+}
+
+# The --uninstall twin: the VAR=val pass-through in run_sut cannot carry a script
+# argument (env would consume it as the command to run), so the SUT is invoked
+# with --uninstall here, preseeded only with what this path needs.
+run_sut_uninstall() {
+    : > "$H/stublog"
+    rm -rf "$H/etc/keyd" "$H/etc/systemd" "$H/home/.config" "$H/proc"
+    mkdir -p "$H/proc"
+    if [ "${PRESEED_AUTOSTART:-0}" = "1" ]; then
+        mkdir -p "$H/home/.config/autostart"
+        printf '[Desktop Entry]\nExec=keyd-application-mapper -d\n' \
+            > "$H/home/.config/autostart/keyd-application-mapper.desktop"
+    fi
+    env PATH="$H/bin:$PATH" HOME="$H/home" KEYD_ETC="$H/etc/keyd" \
+        STUB_LOG="$H/stublog" XDG_SESSION_TYPE=x11 DISPLAY=:99 \
+        KEYD_DROPIN="$H/etc/systemd/keyd.service.d/10-dotfiles-restart.conf" \
+        INPUT_DEVICES_DIR="$H/sys/class/input" PROC_DIR="$H/proc" \
+        KILL_CMD="$H/bin/kill" \
+        bash "$SUT" --uninstall
 }
 
 # --- guards: must no-op where there is no desktop ------------------------------
@@ -202,12 +229,38 @@ assert_grep "replace stops the real mapper" "^kill 4242" "$H/stublog"
 assert_grep_negative "replace leaves a bystander shell that mentions the path alone" \
     "^kill 4243" "$H/stublog"
 
+# The env/sg launch shape (PATH resolution) leaves a BARE argv[0], which the
+# `bin/...` pathname rule alone would miss -- that mapper must still be
+# recognized and replaced, not left holding the single-instance lock.
+out="$(PRESEED_BROKEN_LOG=1 PRESEED_BARE_ARGV=1 run_sut 2>&1)"
+assert_grep "bare-argv mapper is recognized and replaced" "^kill 4244" "$H/stublog"
+assert_eq "$([ -f "$H/etc/keyd/default.conf" ] && echo yes || echo no)" "yes" \
+    "bare-argv mapper: clean replacement keeps the config installed"
+
+# SIGTERM that simply does not take: the pre-existing mapper was running BEFORE
+# the installer touched anything, and its log is the kind of stale evidence that
+# caused the 2026-09-02 false rollback -- so keep it; do not roll back on it.
+out="$(PRESEED_BROKEN_LOG=1 run_sut FAKE_KILL_REFUSES=1 2>&1)"
+assert_eq "$?" "0" "un-stoppable mapper: exits clean"
+assert_eq "$([ -f "$H/etc/keyd/default.conf" ] && echo yes || echo no)" "yes" \
+    "un-stoppable mapper: the layout survives"
+case "$out" in *"could not stop"*) r=0 ;; *) r=1 ;; esac
+assert_eq "$r" "0" "un-stoppable mapper: the refusal is announced"
+case "$out" in *"rolling back"*) r=1 ;; *) r=0 ;; esac
+assert_eq "$r" "0" "un-stoppable mapper: no stale-log rollback"
+
 # The old XDG autostart entry (an earlier install shape) launches a mapper at login
 # WITHOUT the keyd group, which then owns the single-instance lock and blocks the
 # supervised unit forever. Install and uninstall must both remove it.
 out="$(PRESEED_AUTOSTART=1 run_sut 2>&1)"
 assert_eq "$([ -f "$H/home/.config/autostart/keyd-application-mapper.desktop" ] && echo yes || echo no)" "no" \
     "stale autostart entry is removed on install"
+
+# ...and on --uninstall: if the entry survived, the very next login would
+# relaunch the group-less mapper that blocks the supervised unit forever.
+out="$(PRESEED_AUTOSTART=1 run_sut_uninstall 2>&1)"
+assert_eq "$([ -f "$H/home/.config/autostart/keyd-application-mapper.desktop" ] && echo yes || echo no)" "no" \
+    "stale autostart entry is removed on uninstall"
 
 # The mapper failing to start at all is the same hazard as it starting broken.
 out="$(run_sut FAKE_MAPPER_STARTS=0 2>&1)"


### PR DESCRIPTION
install.sh self-uninstalled keyd: `start_mapper` judged the already-running mapper by its stale cumulative log. It now replaces it with a fresh supervised one, judges only the fresh log, and drops the stale autostart entry — plus hardening (recognize bare-argv mappers; keep the layout when the old mapper won't stop).

**What**
- `mapper_pids`: recognize the mapper precisely — full path in argv[0..1], the **bare name** in argv[0..1] (the env/sg PATH-resolution shape leaves a bare argv[0]), or an interpreter argument (`python3 …/keyd-application-mapper …`). Never the whole command line — that once matched a bystander shell's `-c` string and killed the shell running the installer (2026-09-02).
- `start_mapper`: a running mapper is *replaced*, not judged — stop it (supervised unit + stray instances), start a fresh one, judge only the fresh `app.log`. If the stale instance ignores SIGTERM, it is kept as-is with a loud WARNING instead of being rolled back on its cumulative log.
- Legacy `~/.config/autostart/keyd-application-mapper.desktop` (group-less instance that owns the single-instance lock) removed on install *and* uninstall.
- `KILL_CMD` indirection for testability (`kill` is a builtin, not PATH-stubbable; never set in normal use).

**Why**
2026-09-02: an `install.sh` re-run found the mapper already running, skipped the log reset, read ~69 stale `Failed to connect` lines (every socket blink — including the installer's own `systemctl restart keyd` — lands one there) and uninstalled the whole layout on a healthy host.

**Impact**
- A re-run on a healthy host no longer rolls the layout back; recovery is simply re-running `macos-keys-linux.sh`.
- Fail-closed preserved: a fresh mapper that cannot reach keyd's socket still rolls back (tested).
- `docs/macos-keys.md`: symptom/recovery entry + the keep-as-is behavior.

**Testing**
- `opt/scripts/system/macos-keys-linux_test.sh` **55/55**: stale mapper + stale broken log → replaced, no rollback; bystander shell mentioning the path left alive; bare-argv mapper recognized and replaced; un-stoppable mapper keeps the layout and announces it; autostart entry removed on install and on `--uninstall`.
- `shellcheck`: no new findings · `shell-portability-scan.sh --strict`: Tier 1/2 = 0.
