### PR TITLE
ci(mergify): stop label events restarting required checks (queue livelock)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,9 +33,40 @@ on:
     #   - ready_for_review: fires when a draft is marked "Ready for review";
     #     this is what lets build-and-validate start the moment a PR leaves draft.
     #   - labeled / unlabeled: fire when `ready-for-merge` is added or removed,
-    #     so the gate re-runs (or correctly re-skips) on label churn even while
-    #     the PR is still a draft.
+    #     so the gate re-runs (or correctly re-skips) on label churn while the
+    #     PR is still a draft. NOTE: these two are the narrowest trigger here —
+    #     the jobs below gate themselves to the draft case only, because
+    #     restarting a required check on a QUEUED PR livelocks the merge queue.
+    #     See "MERGIFY QUEUE LIVELOCK" below before widening them.
     types: [ opened, synchronize, reopened, ready_for_review, labeled, unlabeled ]
+    #
+    # MERGIFY QUEUE LIVELOCK (PR #264) — why the label events above are GATED
+    # at the job level (`lint`, `shell-lint`, `go-lint` each carry the matching
+    # `if:`; the other three jobs `needs:` them and skip with them).
+    #
+    # A `labeled`/`unlabeled` event carries no new code, but dispatching a run
+    # re-creates this workflow's FIVE required check runs as `expected` /
+    # `in_progress`. Mergify writes `queued` / `dequeued` labels as it moves a
+    # PR through the queue — so its own bookkeeping restarted the ~7-min heavy
+    # build at the exact moment it held the merge lock. GitHub then refused the
+    # merge with "5 of 8 required status checks have not succeeded: 3 expected",
+    # Mergify retried for its 10-minute budget, gave up, and dequeued — which
+    # writes the `dequeued` label, another label event, restarting the cycle.
+    # Observed on #264: eight runs on ONE unchanged SHA, and a dequeue at
+    # 03:38:03 that landed 16 seconds AFTER the checks went green at 03:37:47.
+    #
+    # This is the sibling of PR #243's bug, not the same one: the unique
+    # concurrency group below stopped these label-triggered runs CANCELLING
+    # each other, but did nothing about them RESTARTING the required checks.
+    #
+    # The gate keeps the phase-7 draft fast path and drops nothing else:
+    #   - `ready-for-merge` on a DRAFT still dispatches a run. That is the only
+    #     case the label trigger exists for (see the `build-and-validate` gate).
+    #   - On a NON-DRAFT PR the label is redundant — `draft == false` already
+    #     lets the heavy job run — and Mergify only queues non-drafts, so after
+    #     this gate no label event can restart a queued PR's checks.
+    #   - A job skipped by `if:` reports its required check as SUCCESSFUL, so
+    #     the green checks from the code-driven run stay green.
   # Phase 6 of CI hygiene (issue #46). `merge_group:` is the synthetic-commit
   # event GitHub's merge queue dispatches BEFORE landing a PR on main. Every
   # job below is wired in as a required check via branch protection, so they
@@ -86,6 +117,11 @@ concurrency:
 jobs:
   lint:
     name: Lint (go + shell + markdown + actions)
+    # Label-event guard — see "MERGIFY QUEUE LIVELOCK" in the `on:` block above.
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
+      || (github.event.label.name == 'ready-for-merge' && github.event.pull_request.draft)
     runs-on: ubuntu-latest
     # A hang must die in minutes, not burn the 6-hour default (PR #182 lesson).
     timeout-minutes: 15
@@ -151,6 +187,11 @@ jobs:
 
   shell-lint:
     name: Shell Lint (shellcheck)
+    # Label-event guard — see "MERGIFY QUEUE LIVELOCK" in the `on:` block above.
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
+      || (github.event.label.name == 'ready-for-merge' && github.event.pull_request.draft)
     runs-on: ubuntu-latest
     # A hang must die in minutes, not burn the 6-hour default (PR #182 lesson).
     timeout-minutes: 15
@@ -174,6 +215,11 @@ jobs:
 
   go-lint:
     name: Go Lint (golangci-lint)
+    # Label-event guard — see "MERGIFY QUEUE LIVELOCK" in the `on:` block above.
+    if: >-
+      github.event_name != 'pull_request'
+      || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
+      || (github.event.label.name == 'ready-for-merge' && github.event.pull_request.draft)
     runs-on: ubuntu-latest
     # A hang must die in minutes, not burn the 6-hour default (PR #182 lesson).
     timeout-minutes: 15

--- a/docs/mergify.md
+++ b/docs/mergify.md
@@ -85,6 +85,51 @@ and auditable:
 - **Settings changes leave diffs**: ruleset snapshots + the GitHub audit log
   cover the one surface PRs can't.
 
+## Troubleshooting: a green PR that keeps getting dequeued
+
+Symptom: every required check is green, the branch is up to date and
+conflict-free, yet Mergify dequeues with
+
+> Mergify failed to merge the pull request. GitHub can't merge the pull
+> request after 10 minutes of retrying. Repository rule violations found —
+> N of 8 required status checks have not succeeded: M expected.
+
+That is a **queue livelock**, and it is a CI-trigger bug, not a code problem.
+Mergify writes `queued` / `dequeued` labels as it moves a PR through the
+queue. If a workflow that owns required checks is dispatched by
+`labeled` / `unlabeled` pull_request events, Mergify's own bookkeeping
+restarts that workflow at the exact moment it holds the merge lock — the
+required checks flip back to `expected`, GitHub refuses the merge, Mergify
+exhausts its 10-minute retry budget and dequeues, and the `dequeued` label
+write restarts the whole cycle.
+
+How to tell it apart from a real failure: list the check runs for the head
+SHA and look for many runs of the same job on **one unchanged commit**.
+
+```sh
+sha=$(gh pr view <N> --json headRefOid -q .headRefOid)
+gh api "repos/{owner}/{repo}/commits/$sha/check-runs?per_page=100" \
+  -q '.check_runs[] | "\(.started_at)\t\(.name)\t\(.conclusion)"' | sort -k2
+gh api "repos/{owner}/{repo}/issues/<N>/timeline?per_page=100" \
+  -q '.[] | select(.event | test("labeled")) | "\(.created_at)\t\(.event)\t\(.label.name)\t\(.actor.login)"'
+```
+
+If the label timeline and the extra runs line up second-for-second, it is
+this bug. Two rules keep it away, both learned the hard way:
+
+1. **Never let a label event restart a required check on a non-draft PR.**
+   `.github/workflows/docker-image.yml` gates its three root jobs on the
+   label name and draft status (see "MERGIFY QUEUE LIVELOCK" in that file's
+   `on:` block, found via #264). A label event carries no new code, so there
+   is nothing to re-validate.
+2. **Never fold label events into a shared, cancelling concurrency group.**
+   Entering the queue can add and remove labels in the same instant; two runs
+   start together and one cancels the other, and a required check whose newest
+   run is `cancelled` is not `success` (found via #243).
+
+A job skipped by `if:` reports its required check as successful, so gating
+jobs this way does not strand the merge.
+
 ## Break-glass (admin emergencies)
 
 The ruleset grants `Repository admin` unconditional bypass (`bypass_actors`,


### PR DESCRIPTION
## What

Gates `docker-image.yml`'s three root jobs (`lint`, `shell-lint`, `go-lint`) so a
`labeled`/`unlabeled` pull_request event only dispatches a run for
`ready-for-merge` **on a still-draft PR**. `unit-tests`, `shell-tests` and
`build-and-validate` `needs:` them and skip with them.

Also documents the failure mode in `docs/mergify.md` — the symptom, how to tell
it apart from a real failure, and the two rules that prevent it.

## Why

A green, up-to-date PR (#264) could not land. Mergify dequeued it three times
with `N of 8 required status checks have not succeeded: M expected` while every
required check was in fact green.

The workflow dispatches on `labeled`/`unlabeled`, and Mergify writes
`queued`/`dequeued` labels as it moves a PR through the queue. Each label write
restarted the workflow, re-creating its **five** required check runs as
`expected`/`in_progress` at the exact moment Mergify held the merge lock. GitHub
refused the merge, Mergify burned its 10-minute retry budget and dequeued —
which writes another label, restarting the cycle.

Evidence from #264 (head SHA `3e65e52`, never changed):

| Time (UTC) | Event |
|---|---|
| 03:19:13 | `mergify[bot]` labels `queued` → run `33710933155` at 03:19:16 |
| 03:23:00/01 | unlabels `queued`, labels `dequeued` → runs `33711154362` + `33711155008` |
| 03:30:24/38 | labels `queued`, unlabels `queued` → runs `33711606253` + `33711621762` |
| 03:37:47 | checks go green |
| 03:38:03 | **dequeued — 16 seconds too late** |

Eight `Docker Image CI` runs on one unchanged commit. The first dequeue had a
second, one-off cause — an `npm error network` flake (exit 146) in the Lint job
of run `33710933155` — but that run existed only because of the `queued` label
event, so the flake was itself a product of the loop.

This is the **sibling** of PR #243's bug, not the same one: the unique
concurrency group added there stopped these label-triggered runs from
*cancelling* each other, but did nothing about them *restarting* the required
checks.

## Impact

- Mergify's queue bookkeeping can no longer restart CI on a queued PR, so the
  livelock class is closed.
- Cuts wasted CI: label pairs previously started **two** full parallel runs
  (03:23 and 03:30 above), each including the ~7-min heavy Docker build.
- **Nothing is lost.** The phase-7 draft fast path is preserved: `ready-for-merge`
  on a draft still dispatches a run — the only case the label trigger exists for.
  On a non-draft PR the label was already redundant (`draft == false` alone runs
  `build-and-validate`), and Mergify only queues non-drafts.
- A job skipped by `if:` reports its required check as **successful**, so the
  green checks from the code-driven run stay green and the merge is not stranded.
- Self-applying: `pull_request` workflows run from the merge ref, so this PR is
  validated under its own fix. Once merged, Mergify updates #264 against the new
  `main` and #264 picks it up.

## Testing

- `actionlint v1.7.12` clean across all six workflows.
- YAML parses; the gate is present on exactly the three root jobs and nowhere
  else (verified by inspecting the parsed `jobs.*.if` map).
- `markdownlint-cli2 docs/mergify.md` — the 6 findings are pre-existing on
  line 38 (a table separator row present in `HEAD`); the new section is clean.
- Trigger matrix reasoned through: `push`/`merge_group` unaffected (first
  clause); `opened`/`synchronize`/`reopened`/`ready_for_review` unaffected
  (second clause); label events run only for `ready-for-merge` on a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZP3hRYhTn8kNga7H1ZRzW