### PR TITLE
fleet-wsl-scan: scan-fixes

### DIFF
--- a/sdk/fleet/AGENTS.md
+++ b/sdk/fleet/AGENTS.md
@@ -81,6 +81,37 @@ without opening a socket.
   turns a DHCP move into a one-line `HostName` refresh instead of a duplicate `Host` block
   under a second alias, and the refresh goes through `sshconf.Update` so a `ProxyCommand`
   survives it. Pinned by `TestScanPlanRefreshesAMovedHostRatherThanAddingIt`.
+- **`moved` is decided against the RESOLVED `HostName`, not its text.** A block may say
+  `HostName named-box`, and that string never equals `10.0.0.5`, so a literal
+  comparison reported every name-based host as `moved` on every run and each apply rewrote
+  a working DNS name into a DHCP address that expires — actively downgrading a config that
+  was correct. `classifyScan` takes a resolver; an unresolvable name is still `moved`,
+  because the address we found is then the only thing that works. Pinned by
+  `TestClassifyScanTreatsAResolvedDNSNameAsCurrent`,
+  `TestClassifyScanStillReportsAGenuineMoveWhenTheNameResolvesElsewhere`.
+- **A scan probe carries the fleet credentials EXPLICITLY.** The sweep dials an address,
+  and no `Host` block matches an address — it matches an alias — so ssh offered neither the
+  fleet user nor the fleet key and every responder came back "would not authenticate",
+  including hosts already in the fleet. `scanIdentities` collects the distinct
+  `User`/`IdentityFile` pairs of the fleet-marked blocks and `identify` tries each, bare
+  `ssh` last (right when a wildcard block or the agent already supplies the key). Nothing
+  outside the config is ever guessed at. **Beware the mux caveat above when testing this:**
+  a live master pins the credentials it was opened with, so a stale socket makes an
+  unfixed binary look fixed — compare with `FLEET_NO_MUX=1`. Pinned by
+  `TestScanIdentitiesCollectsDistinctFleetCredentials`,
+  `TestIdentifyTriesEachFleetIdentityUntilOneAuthenticates`.
+- **Under WSL the subnet comes from the WINDOWS host, not from this kernel.** The default
+  route here leaves on the Hyper-V NAT interface (`172.x/20`), a private segment the fleet
+  is not on; WSL holds no interface on the real LAN, so it can route there but cannot
+  enumerate it and no amount of inspecting local interfaces finds it. That `/20` also
+  exceeds `lanscan`'s 1024-address ceiling, so the old behaviour did not merely scan the
+  wrong network — it refused to scan at all. `detectCIDR` asks Windows for the address and
+  prefix of its lowest-metric default route, and falls back to the local interfaces when
+  interop is unavailable or mirrored networking already puts the LAN on `eth0`. Every
+  impure edge is injected via `subnetDeps`. Pinned by
+  `TestDetectCIDRPrefersTheWindowsHostLANUnderWSL`,
+  `TestDetectCIDRFallsBackToLocalInterfacesWhenHostLANUnavailable`,
+  `TestDetectCIDRUsesLocalInterfacesWhenNotUnderWSL`.
 - **A responder that will not authenticate is never written.** We do not know what it is or
   which user it wants, and guessing would put a broken block in the file every command
   depends on. It is reported and left alone. Pinned by

--- a/sdk/fleet/cmd/discover.go
+++ b/sdk/fleet/cmd/discover.go
@@ -92,7 +92,21 @@ var (
 var discoverCmd = &cobra.Command{
 	Use:   "discover",
 	Short: "List ssh-config hosts and which are in the fleet (`--add-all` adopts every available one)",
-	Args:  cobra.NoArgs,
+	Example: `  # List what is in the fleet and what is merely in ssh_config.
+  fleet discover
+
+  # Sweep the LAN for SSH hosts, refreshing moved addresses and offering
+  # unknown responders. The subnet is detected automatically.
+  fleet discover --scan
+
+  # Sweep a subnet explicitly. Needed when the machine holds no interface on
+  # the LAN you mean — a VM on a NAT segment, a second LAN reachable by route,
+  # or WSL with interop unavailable.
+  fleet discover --scan --subnet 192.168.0.0/24
+
+  # See what a sweep WOULD write before it writes anything.
+  fleet discover --scan --subnet 192.168.0.0/24 --dry-run`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// --scan is the only path here that opens a socket; without it,
 		// discover stays a pure local read of ~/.ssh/config.
@@ -158,7 +172,8 @@ func init() {
 	discoverCmd.Flags().BoolVar(&discoverDryRun, "dry-run", false, "print the resulting config without writing")
 	discoverCmd.Flags().BoolVar(&discoverScan, "scan", false,
 		"sweep the local subnet for SSH hosts: refresh a moved HostName and offer unknown responders")
-	discoverCmd.Flags().StringVar(&scanSubnet, "subnet", "", "CIDR to sweep (default: the subnet of the default route)")
+	discoverCmd.Flags().StringVar(&scanSubnet, "subnet", "",
+		"CIDR to sweep, e.g. 192.168.0.0/24 (default: the LAN subnet, asking the Windows host when under WSL)")
 	discoverCmd.Flags().IntVar(&scanWorkers, "jobs", 64, "concurrent probes during a scan")
 	discoverCmd.Flags().DurationVar(&scanTimeout, "probe-timeout", 400*time.Millisecond, "per-address TCP timeout during a scan")
 	rootCmd.AddCommand(discoverCmd)

--- a/sdk/fleet/cmd/discover_scan.go
+++ b/sdk/fleet/cmd/discover_scan.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
+	"os/exec"
 	"sort"
 	"strings"
 	"sync"
@@ -45,7 +47,14 @@ type scanRow struct {
 // keeps pointing at the old address, and every fleet command reports it dead.
 // Matching on the host's OWN reported name — not on the address — is what
 // turns that into a one-line refresh instead of a duplicate Host block.
-func classifyScan(hosts []sshconf.Host, found []responder) []scanRow {
+//
+// resolve maps a configured HostName to its addresses, and is what keeps a
+// NAME-based config stable. A block may legitimately say `HostName named-box`
+// rather than an address; comparing that string to "192.168.0.63" is never
+// equal, so without resolution every named host reported `moved` on every run
+// and each apply rewrote a working name into a DHCP address that expires. A nil
+// resolve degrades to the literal comparison.
+func classifyScan(hosts []sshconf.Host, found []responder, resolve func(string) []string) []scanRow {
 	byName := make(map[string]sshconf.Host, len(hosts))
 	for _, h := range hosts {
 		byName[h.Alias] = h
@@ -59,7 +68,7 @@ func classifyScan(hosts []sshconf.Host, found []responder) []scanRow {
 		default:
 			if h, ok := byName[r.Hostname]; ok {
 				row.Alias = h.Alias
-				if h.HostName == r.IP {
+				if configPointsAt(h, r.IP, resolve) {
 					row.Kind = scanCurrent
 				} else {
 					row.Kind, row.WasIP = scanMoved, h.HostName
@@ -74,6 +83,28 @@ func classifyScan(hosts []sshconf.Host, found []responder) []scanRow {
 	// before .61, so a column of addresses reads as noise.
 	sort.SliceStable(out, func(i, j int) bool { return lessAddr(out[i].IP, out[j].IP) })
 	return out
+}
+
+// configPointsAt reports whether the block already directs ssh at ip, either
+// literally or by a name that resolves there. An empty HostName means ssh falls
+// back to the alias, so that is what gets resolved.
+func configPointsAt(h sshconf.Host, ip string, resolve func(string) []string) bool {
+	name := h.HostName
+	if name == "" {
+		name = h.Alias
+	}
+	if name == ip {
+		return true
+	}
+	if resolve == nil {
+		return false
+	}
+	for _, got := range resolve(name) {
+		if got == ip {
+			return true
+		}
+	}
+	return false
 }
 
 // lessAddr orders two IPv4 strings by value. Unparseable input falls back to a
@@ -115,9 +146,52 @@ func applyScan(cfg string, rows []scanRow, marker string) (string, int, error) {
 	return out, changed, nil
 }
 
-// identify asks each responder who it is, over the fleet key. Concurrent
-// because a silent host costs a full connect timeout and a sweep finds many.
-func identify(r runner.Runner, ips []string, workers int) []responder {
+// scanIdentity is one credential pair the fleet already uses. The sweep probes
+// by ADDRESS, so ssh_config cannot supply either half: a Host block matches the
+// alias, never the address behind it.
+type scanIdentity struct{ User, Identity string }
+
+// scanIdentities collects the distinct credentials of the fleet-marked hosts,
+// so a probe offers exactly what the operator already trusts and nothing else.
+//
+// The zero identity is always tried LAST: it is what a bare `ssh <ip>` does, and
+// it is the right answer when ssh_config carries a wildcard block or the agent
+// already holds the key. Ordering is deterministic so a scan of an unchanged
+// network reads the same on every run.
+func scanIdentities(hosts []sshconf.Host) []scanIdentity {
+	seen := map[scanIdentity]bool{}
+	var out []scanIdentity
+	for _, h := range hosts {
+		if !h.Fleet {
+			continue
+		}
+		id := scanIdentity{User: h.User, Identity: h.Identity}
+		if id == (scanIdentity{}) || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].User != out[j].User {
+			return out[i].User < out[j].User
+		}
+		return out[i].Identity < out[j].Identity
+	})
+	return append(out, scanIdentity{})
+}
+
+// identify asks each responder who it is, trying the fleet credentials in turn
+// and stopping at the first that authenticates. Concurrent because a silent
+// host costs a full connect timeout and a sweep finds many.
+//
+// A host that accepts none of them stays unidentified: that is a real and
+// common state on a home LAN, and guessing would write a broken block into the
+// file every other command depends on.
+func identify(mk func(scanIdentity) runner.Runner, ids []scanIdentity, ips []string, workers int) []responder {
+	if len(ids) == 0 {
+		ids = []scanIdentity{{}}
+	}
 	out := make([]responder, len(ips))
 	sem := make(chan struct{}, workers)
 	var wg sync.WaitGroup
@@ -128,8 +202,12 @@ func identify(r runner.Runner, ips []string, workers int) []responder {
 			sem <- struct{}{}
 			defer func() { <-sem }()
 			out[i] = responder{IP: ip}
-			if name, err := r.Run(ip, "hostname"); err == nil && strings.TrimSpace(name) != "" {
-				out[i].Hostname, out[i].Identified = strings.TrimSpace(name), true
+			for _, id := range ids {
+				name, err := mk(id).Run(ip, "hostname")
+				if err == nil && strings.TrimSpace(name) != "" {
+					out[i].Hostname, out[i].Identified = strings.TrimSpace(name), true
+					return
+				}
 			}
 		}(i, ip)
 	}
@@ -137,12 +215,56 @@ func identify(r runner.Runner, ips []string, workers int) []responder {
 	return out
 }
 
-// localCIDR reports the subnet of the interface carrying the default route.
-func localCIDR() (string, error) {
-	ifaces, err := net.Interfaces()
+// subnetDeps are the impure edges of subnet detection, injected so the decision
+// itself is unit-tested without an interface or a subprocess.
+type subnetDeps struct {
+	localCIDRs func() ([]string, error) // this kernel's own IPv4 interfaces
+	hostLAN    func() (string, error)   // the LAN of the machine hosting this kernel
+	underWSL   func() bool
+}
+
+// detectCIDR picks the subnet to sweep.
+//
+// Under WSL the default route leaves on the Hyper-V NAT interface — 172.x.y.z/20
+// here — which is a private segment shared with nothing. The fleet lives on the
+// LAN of the WINDOWS host, and WSL holds no interface on it: it can route there
+// but cannot enumerate it, so no amount of looking at local interfaces finds it.
+// Asking Windows is the only way. A /20 is also over lanscan's sweep ceiling, so
+// the old behaviour did not merely scan the wrong network, it refused to scan at
+// all.
+//
+// The fallback still matters: with interop unavailable, or under WSL's mirrored
+// networking mode where the local interface already IS the LAN, the local answer
+// is the right one.
+func detectCIDR(d subnetDeps) (string, error) {
+	if d.underWSL() {
+		if cidr, err := d.hostLAN(); err == nil && cidr != "" {
+			return cidr, nil
+		}
+	}
+	cidrs, err := d.localCIDRs()
 	if err != nil {
 		return "", err
 	}
+	if len(cidrs) == 0 {
+		return "", fmt.Errorf("no usable IPv4 interface found")
+	}
+	return cidrs[0], nil
+}
+
+// realSubnetDeps wires detectCIDR to the machine it is running on.
+func realSubnetDeps() subnetDeps {
+	return subnetDeps{localCIDRs: localCIDRs, hostLAN: windowsHostLAN, underWSL: underWSL}
+}
+
+// localCIDRs reports the subnets of every up, non-loopback IPv4 interface, the
+// default-route one first by virtue of interface order.
+func localCIDRs() ([]string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	var out []string
 	for _, i := range ifaces {
 		if i.Flags&net.FlagUp == 0 || i.Flags&net.FlagLoopback != 0 {
 			continue
@@ -157,10 +279,54 @@ func localCIDR() (string, error) {
 				continue
 			}
 			ones, _ := n.Mask.Size()
-			return fmt.Sprintf("%s/%d", n.IP.String(), ones), nil
+			out = append(out, fmt.Sprintf("%s/%d", n.IP.String(), ones))
 		}
 	}
-	return "", fmt.Errorf("no usable IPv4 interface found")
+	return out, nil
+}
+
+// underWSL reports whether this kernel is running under WSL. The environment
+// variables are the cheap answer; osrelease is the one that survives a login
+// shell that scrubbed them.
+func underWSL() bool {
+	if os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSL_INTEROP") != "" {
+		return true
+	}
+	b, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	return err == nil && strings.Contains(strings.ToLower(string(b)), "microsoft")
+}
+
+// windowsHostLAN asks Windows for the address and prefix of the adapter
+// carrying ITS default route — the LAN the fleet is actually on.
+//
+// The lowest-metric default route is the one Windows would use, which is what
+// makes this pick the Wi-Fi adapter over a Bluetooth PAN or the vEthernet
+// switch that faces this VM.
+func windowsHostLAN() (string, error) {
+	const ps = `$i = Get-NetRoute -DestinationPrefix '0.0.0.0/0' | ` +
+		`Sort-Object RouteMetric | Select-Object -First 1 -ExpandProperty ifIndex; ` +
+		`Get-NetIPAddress -AddressFamily IPv4 -InterfaceIndex $i | ` +
+		`ForEach-Object { "$($_.IPAddress)/$($_.PrefixLength)" }`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-NonInteractive", "-Command", ps).Output()
+	if err != nil {
+		return "", fmt.Errorf("asking Windows for its LAN: %w", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		// Windows writes CRLF; a bare TrimSpace on the whole blob would still
+		// leave the \r on every line but the last.
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if _, err := netip.ParsePrefix(line); err != nil {
+			continue
+		}
+		return line, nil
+	}
+	return "", fmt.Errorf("no IPv4 subnet reported by the Windows host")
 }
 
 func renderScan(rows []scanRow) string {
@@ -180,6 +346,17 @@ func renderScan(rows []scanRow) string {
 	return b.String()
 }
 
+// lookupHost resolves a configured HostName to its addresses. A failure is not
+// an error here: an unresolvable name simply cannot vouch for the address we
+// found, which classifyScan reads as a move.
+func lookupHost(name string) []string {
+	addrs, err := net.LookupHost(name)
+	if err != nil {
+		return nil
+	}
+	return addrs
+}
+
 var (
 	scanSubnet  string
 	scanWorkers int
@@ -191,7 +368,7 @@ func runScan(cmd *cobra.Command) error {
 	cidr := scanSubnet
 	if cidr == "" {
 		var err error
-		if cidr, err = localCIDR(); err != nil {
+		if cidr, err = detectCIDR(realSubnetDeps()); err != nil {
 			return err
 		}
 	}
@@ -214,7 +391,17 @@ func runScan(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	rows := classifyScan(hosts, identify(runner.Exec{ConnectTimeout: "3"}, open, scanWorkers))
+	// Probing is by address, so the credentials must be handed over explicitly;
+	// see scanIdentities. Resolution is what keeps a NAME-based config stable.
+	mk := func(id scanIdentity) runner.Runner {
+		e := runner.Exec{ConnectTimeout: "3", User: id.User}
+		if id.Identity != "" {
+			e.Identities = []string{id.Identity}
+		}
+		return e
+	}
+	found := identify(mk, scanIdentities(hosts), open, scanWorkers)
+	rows := classifyScan(hosts, found, lookupHost)
 	fmt.Fprint(out, renderScan(rows))
 
 	next, changed, err := applyScan(cfg, rows, flagMarker)

--- a/sdk/fleet/cmd/discover_scan_test.go
+++ b/sdk/fleet/cmd/discover_scan_test.go
@@ -20,7 +20,7 @@ func TestClassifyScanIdentifiesMovedNewCurrentAndUnidentified(t *testing.T) {
 	}
 	got := map[string]scanKind{}
 	alias := map[string]string{}
-	for _, r := range classifyScan(hosts, found) {
+	for _, r := range classifyScan(hosts, found, nil) {
 		got[r.IP] = r.Kind
 		alias[r.IP] = r.Alias
 	}
@@ -43,7 +43,7 @@ func TestClassifyScanIdentifiesMovedNewCurrentAndUnidentified(t *testing.T) {
 func TestScanPlanRefreshesAMovedHostRatherThanAddingIt(t *testing.T) {
 	cfg := "Host wanderer  #fleet\n    HostName 10.0.0.9\n    ProxyCommand nc %h %p\n"
 	hosts, _ := sshconf.Parse(cfg, "#fleet")
-	rows := classifyScan(hosts, []responder{{IP: "10.0.0.7", Hostname: "wanderer", Identified: true}})
+	rows := classifyScan(hosts, []responder{{IP: "10.0.0.7", Hostname: "wanderer", Identified: true}}, nil)
 	next, changed, err := applyScan(cfg, rows, "#fleet")
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +77,7 @@ func TestApplyScanNeverWritesAnUnidentifiedResponder(t *testing.T) {
 
 // A new host is adopted under its own reported hostname as the alias.
 func TestApplyScanAdoptsANewHostUnderItsReportedName(t *testing.T) {
-	rows := classifyScan(nil, []responder{{IP: "10.0.0.8", Hostname: "newbox", Identified: true}})
+	rows := classifyScan(nil, []responder{{IP: "10.0.0.8", Hostname: "newbox", Identified: true}}, nil)
 	next, changed, err := applyScan("", rows, "#fleet")
 	if err != nil {
 		t.Fatal(err)
@@ -91,7 +91,7 @@ func TestApplyScanAdoptsANewHostUnderItsReportedName(t *testing.T) {
 func TestScanIsANoOpWhenNothingMoved(t *testing.T) {
 	cfg := "Host steady  #fleet\n    HostName 10.0.0.5\n"
 	hosts, _ := sshconf.Parse(cfg, "#fleet")
-	rows := classifyScan(hosts, []responder{{IP: "10.0.0.5", Hostname: "steady", Identified: true}})
+	rows := classifyScan(hosts, []responder{{IP: "10.0.0.5", Hostname: "steady", Identified: true}}, nil)
 	next, changed, err := applyScan(cfg, rows, "#fleet")
 	if err != nil {
 		t.Fatal(err)
@@ -110,7 +110,7 @@ func TestClassifyScanOrdersAddressesNumerically(t *testing.T) {
 		{IP: "192.168.0.61"}, {IP: "192.168.0.128"}, {IP: "192.168.0.16"},
 		{IP: "192.168.0.201"}, {IP: "192.168.0.9"},
 	}
-	rows := classifyScan(nil, found)
+	rows := classifyScan(nil, found, nil)
 	var got []string
 	for _, r := range rows {
 		got = append(got, r.IP)

--- a/sdk/fleet/cmd/discover_scan_wsl_test.go
+++ b/sdk/fleet/cmd/discover_scan_wsl_test.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/runner"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/sshconf"
+)
+
+// A fleet whose config holds DNS NAMES rather than addresses must classify as
+// current when the name already resolves to the discovered address.
+//
+// This is the bug that made every scan a no-op-in-name-only: the comparison was
+// `HostName == IP`, and "named-box" is never equal to "10.0.0.5", so
+// every DNS-named host reported `moved` forever and each run rewrote a working
+// name into a DHCP address that expires.
+func TestClassifyScanTreatsAResolvedDNSNameAsCurrent(t *testing.T) {
+	hosts := []sshconf.Host{{Alias: "named-box", HostName: "named-box", Fleet: true}}
+	resolve := func(name string) []string {
+		if name == "named-box" {
+			return []string{"10.0.0.5"}
+		}
+		return nil
+	}
+	rows := classifyScan(hosts, []responder{
+		{IP: "10.0.0.5", Hostname: "named-box", Identified: true},
+	}, resolve)
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].Kind != scanCurrent {
+		t.Fatalf("kind = %q, want current (a resolved name is not a move)", rows[0].Kind)
+	}
+}
+
+// The fix must not blind the scan to a REAL move: if the configured name
+// resolves somewhere else, the host genuinely moved and must be refreshed.
+func TestClassifyScanStillReportsAGenuineMoveWhenTheNameResolvesElsewhere(t *testing.T) {
+	hosts := []sshconf.Host{{Alias: "wanderer", HostName: "wanderer", Fleet: true}}
+	resolve := func(string) []string { return []string{"10.0.0.9"} } // stale record
+	rows := classifyScan(hosts, []responder{
+		{IP: "10.0.0.7", Hostname: "wanderer", Identified: true},
+	}, resolve)
+	if rows[0].Kind != scanMoved {
+		t.Fatalf("kind = %q, want moved", rows[0].Kind)
+	}
+}
+
+// A name that does not resolve at all must not crash or silently pass; it is a
+// move, because the address we found is the only thing that works.
+func TestClassifyScanTreatsAnUnresolvableNameAsMoved(t *testing.T) {
+	hosts := []sshconf.Host{{Alias: "ghost", HostName: "ghost", Fleet: true}}
+	rows := classifyScan(hosts, []responder{
+		{IP: "10.0.0.7", Hostname: "ghost", Identified: true},
+	}, func(string) []string { return nil })
+	if rows[0].Kind != scanMoved {
+		t.Fatalf("kind = %q, want moved", rows[0].Kind)
+	}
+}
+
+// Under WSL the default route leaves on the Hyper-V NAT interface, whose subnet
+// is NOT the LAN the fleet lives on. Detection must prefer the LAN reported by
+// the Windows host.
+func TestDetectCIDRPrefersTheWindowsHostLANUnderWSL(t *testing.T) {
+	got, err := detectCIDR(subnetDeps{
+		underWSL:   func() bool { return true },
+		hostLAN:    func() (string, error) { return "192.168.0.236/24", nil },
+		localCIDRs: func() ([]string, error) { return []string{"172.21.70.21/20"}, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "192.168.0.236/24" {
+		t.Fatalf("cidr = %q, want the Windows host LAN, not the WSL NAT segment", got)
+	}
+}
+
+// With interop unavailable (or mirrored networking, where the local interface
+// already IS the LAN) detection must still produce an answer.
+func TestDetectCIDRFallsBackToLocalInterfacesWhenHostLANUnavailable(t *testing.T) {
+	got, err := detectCIDR(subnetDeps{
+		underWSL:   func() bool { return true },
+		hostLAN:    func() (string, error) { return "", errors.New("no interop") },
+		localCIDRs: func() ([]string, error) { return []string{"192.168.0.236/24"}, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "192.168.0.236/24" {
+		t.Fatalf("cidr = %q, want the local interface fallback", got)
+	}
+}
+
+// Off WSL the host query must never run: the local interface is the answer.
+func TestDetectCIDRUsesLocalInterfacesWhenNotUnderWSL(t *testing.T) {
+	called := false
+	got, err := detectCIDR(subnetDeps{
+		underWSL:   func() bool { return false },
+		hostLAN:    func() (string, error) { called = true; return "192.168.0.236/24", nil },
+		localCIDRs: func() ([]string, error) { return []string{"10.0.0.5/24"}, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if called {
+		t.Fatal("queried the Windows host while not under WSL")
+	}
+	if got != "10.0.0.5/24" {
+		t.Fatalf("cidr = %q, want 10.0.0.5/24", got)
+	}
+}
+
+// The sweep probes by raw ADDRESS, so no per-alias Host block matches and the
+// fleet key is never offered. The credentials the fleet already uses must be
+// gathered from the config and presented explicitly.
+func TestScanIdentitiesCollectsDistinctFleetCredentials(t *testing.T) {
+	hosts := []sshconf.Host{
+		{Alias: "a", User: "operator", Identity: "~/.ssh/id_fleet", Fleet: true},
+		{Alias: "b", User: "operator", Identity: "~/.ssh/id_fleet", Fleet: true}, // duplicate
+		{Alias: "c", User: "operator", Identity: "~/.ssh/id_other", Fleet: true},
+		{Alias: "d", User: "nobody", Identity: "~/.ssh/id_skip"}, // not in fleet
+	}
+	ids := scanIdentities(hosts)
+	// Two distinct fleet credentials, then the zero identity — a bare `ssh <ip>`,
+	// which is the right answer when a wildcard Host block or the agent already
+	// supplies the key. It must come LAST so an explicit credential wins.
+	want := []scanIdentity{
+		{User: "operator", Identity: "~/.ssh/id_fleet"},
+		{User: "operator", Identity: "~/.ssh/id_other"},
+		{},
+	}
+	if len(ids) != len(want) {
+		t.Fatalf("identities = %+v, want %+v", ids, want)
+	}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("identities = %+v, want %+v", ids, want)
+		}
+	}
+	for _, id := range ids {
+		if id.Identity == "~/.ssh/id_skip" {
+			t.Fatal("a non-fleet host's credential was used for probing")
+		}
+	}
+}
+
+// identify must try each fleet credential until one authenticates, rather than
+// giving up after a bare connection that offers no key.
+func TestIdentifyTriesEachFleetIdentityUntilOneAuthenticates(t *testing.T) {
+	ids := []scanIdentity{
+		{User: "operator", Identity: "~/.ssh/id_wrong"},
+		{User: "operator", Identity: "~/.ssh/id_right"},
+	}
+	mk := func(id scanIdentity) runner.Runner {
+		if id.Identity == "~/.ssh/id_right" {
+			return runner.Fake{Out: map[string]string{"10.0.0.5": "named-box"}}
+		}
+		return runner.Fake{Err: map[string]error{"10.0.0.5": errors.New("permission denied")}}
+	}
+	got := identify(mk, ids, []string{"10.0.0.5"}, 4)
+	if len(got) != 1 {
+		t.Fatalf("responders = %d, want 1", len(got))
+	}
+	if !got[0].Identified || got[0].Hostname != "named-box" {
+		t.Fatalf("responder = %+v, want identified as named-box", got[0])
+	}
+}
+
+// A host that answers :22 but accepts no fleet credential stays unidentified —
+// it must never be guessed at or written into the config.
+func TestIdentifyLeavesAHostWithNoWorkingCredentialUnidentified(t *testing.T) {
+	mk := func(scanIdentity) runner.Runner {
+		return runner.Fake{Err: map[string]error{"10.0.0.11": errors.New("permission denied")}}
+	}
+	got := identify(mk, []scanIdentity{{Identity: "~/.ssh/id_fleet"}}, []string{"10.0.0.11"}, 4)
+	if got[0].Identified {
+		t.Fatalf("responder = %+v, want unidentified", got[0])
+	}
+}

--- a/sdk/fleet/internal/runner/runner.go
+++ b/sdk/fleet/internal/runner/runner.go
@@ -79,7 +79,33 @@ func muxArgs() []string {
 }
 
 // Exec is the real SSH-backed runner.
-type Exec struct{ ConnectTimeout string }
+//
+// User and Identities exist for probes addressed by RAW IP. No per-alias Host
+// block in ~/.ssh/config can match an address, so ssh offers neither the fleet
+// user nor the fleet key and the probe fails on credentials rather than on
+// reachability. Both are empty for every alias-addressed call, which keeps
+// ssh_config the single source of truth there. ssh expands a leading ~ in -i
+// itself, so paths are passed through as written in the config.
+type Exec struct {
+	ConnectTimeout string
+	User           string
+	Identities     []string
+}
+
+// identityArgs presents the credentials explicitly. It yields nothing when
+// neither field is set, so the alias-addressed paths keep their exact argv.
+func (e Exec) identityArgs() []string {
+	var args []string
+	if e.User != "" {
+		args = append(args, "-l", e.User)
+	}
+	for _, id := range e.Identities {
+		if id != "" {
+			args = append(args, "-i", id)
+		}
+	}
+	return args
+}
 
 func (e Exec) timeout() string {
 	if e.ConnectTimeout == "" {
@@ -93,6 +119,7 @@ func (e Exec) timeout() string {
 // would authenticate separately and prompt again.
 func (e Exec) baseArgs(host string) []string {
 	args := []string{"-o", "BatchMode=yes", "-o", "ConnectTimeout=" + e.timeout()}
+	args = append(args, e.identityArgs()...)
 	args = append(args, muxArgs()...)
 	return append(args, host)
 }


### PR DESCRIPTION
WSL host-LAN subnet detection, fleet-key identity for raw-IP probes, and resolve HostName before the moved/current comparison

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **fleet-wsl-scan**.

- **(no PR yet) — edward-raigosa/scan-fixes (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
