### PR TITLE
herdr: managed config.toml — host-following Solarized theme + ctrl+a prefix

### DIFF
--- a/.github/gff/features.yaml
+++ b/.github/gff/features.yaml
@@ -45,7 +45,7 @@ sets:
       - path: install.pkg.brewfile
         description: Runs the macOS brew bundle block for the Brewfile extras including vault-setup.
         boolDefault: true
-      # --- tools (8) ---
+      # --- tools (9) ---
       - path: install.tools.sops
         description: Runs the install_sops.sh block that fetches the sops release binary.
         boolDefault: true
@@ -69,6 +69,9 @@ sets:
         boolDefault: true
       - path: install.tools.herdr-integrations
         description: Runs `install_herdr.sh integrations` (config phase) to (re)install herdr's agent-state hooks for the agent CLIs present on the host (claude, antigravity-cli); must follow install_antigravity_skills.sh, which re-renders hooks.json.
+        boolDefault: true
+      - path: install.tools.herdr-config
+        description: Runs `install_herdr.sh config` (config phase) to render ai/herdr/config.toml into ~/.config/herdr/config.toml so herdr follows the host terminal's light/dark appearance with the Solarized palette; converges a dotfiles-managed file, never clobbers a hand-edited one (HERDR_CONFIG_FORCE=1 to reclaim).
         boolDefault: true
       # --- runtime (5) ---
       - path: install.runtime.goenv

--- a/ai/herdr/config.toml
+++ b/ai/herdr/config.toml
@@ -1,0 +1,29 @@
+# managed by dotfiles: opt/scripts/system/install_herdr.sh config
+#
+# Rendered into ~/.config/herdr/config.toml by install.sh (config phase, gff
+# flag install.tools.herdr-config). Re-rendered on every run while this marker
+# line is present; delete the marker to take ownership of the file (install.sh
+# then leaves it alone), or set HERDR_CONFIG_FORCE=1 to reclaim it.
+#
+# Full defaults: `herdr --default-config`   Validate: `herdr config check`
+# Apply to a running server: `herdr server reload-config`
+
+[theme]
+# herdr asks the host terminal for its light/dark appearance (DEC 2031 color
+# scheme reports) and switches between the two siblings below, so the same
+# shell opened from a "Solarized Dark" or "Solarized Light" terminal profile
+# gets a readable sidebar either way. `name` is the fallback when the host
+# does not answer: the fleet standard is Solarized Dark (terminal-theme.sh,
+# Windows Terminal profiles from setup-apps.ps1). Override at install time
+# with HERDR_THEME_DARK / HERDR_THEME_LIGHT (any built-in herdr theme name).
+name = "@HERDR_THEME_DARK@"
+auto_switch = true
+light_name = "@HERDR_THEME_LIGHT@"
+dark_name = "@HERDR_THEME_DARK@"
+
+[keys]
+# tmux-style prefix on ctrl+a. herdr's default ctrl+b is also tmux's default,
+# so a herdr pane running inside (or alongside) tmux would fight over it.
+# Press ctrl+a twice to send a literal ctrl+a to the pane (shell line-start).
+# Everything else keeps herdr's defaults: `prefix+?` lists every binding.
+prefix = "ctrl+a"

--- a/ai/skills/herdr/SKILL.md
+++ b/ai/skills/herdr/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: herdr
+description: Use when the user mentions herdr or is working inside a herdr pane and wants to save/restore a pane layout, change herdr's theme, prefix or other preferences on this host only, start or check on an agent in another herdr pane, or asks why the herdr sidebar colors are unreadable. Requires HERDR_ENV=1.
+---
+
+# herdr
+
+herdr is the terminal workspace manager the dotfiles install for coding agents
+(workspaces > tabs > panes, with agent state in the sidebar). This skill is the
+herdr counterpart of the `tmux` skill: the same verbs, backed by herdr's own
+CLI plus two bundled tools for what the CLI lacks.
+
+**Gate first.** Every command below talks to the server socket of the pane you
+are in. Run `test "${HERDR_ENV:-}" = 1`; if it fails, say you are not inside
+herdr and stop. Never control a herdr session from outside it.
+
+**Host-local by design.** Everything this skill writes lives under
+`~/.config/herdr/` (`layouts/`, `config.toml`), never in the dotfiles repo.
+The fleet baseline for `config.toml` is `ai/herdr/config.toml`, rendered by
+`install_herdr.sh config`; per-host changes go through `herdr-prefs`, which
+takes ownership of the file away from `install.sh`.
+
+## Verb map (tmux skill -> herdr)
+
+| tmux-mgr | herdr | Notes |
+| --- | --- | --- |
+| `session list/new/attach/kill` | `herdr session list/attach <name>/stop <name>` | Named sessions are separate servers; prefer workspaces |
+| `window split`, `pane split` | `herdr pane split --current --direction right\|down --cwd "$PWD" --no-focus` | Read the new id from `.result.pane.pane_id` |
+| `window move/resize` | `herdr pane focus/resize --direction ...` | |
+| `capture` | `herdr pane read <id>` / `herdr agent read <name>` | |
+| `agent start` | `herdr agent start <name> --kind claude --pane <id>` | Pane must be an idle shell; then `herdr agent prompt <name> "..." --wait` |
+| `agent list/complete` | `herdr agent list` / `herdr agent wait <name>` + `agent read` | States: working, blocked, done, idle, unknown |
+| `save` / `restore` | `scripts/herdr-layout save\|restore <name>` | No CLI equivalent in herdr; see below |
+| (none) | `scripts/herdr-prefs status\|get\|set\|reset` | Host-local preferences |
+
+The installed binary is the syntax authority: `herdr <group>` with no
+subcommand prints that group's usage. Do not run bare `herdr` (it attaches the
+TUI). Never answer a `blocked` approval dialog on the user's behalf.
+
+## Layouts (`scripts/herdr-layout`)
+
+herdr auto-restores the last session shape on restart (`session.json`) but has
+no named layouts and no `herdr layout` CLI; only the socket methods
+`layout.export` / `layout.apply` exist. The bundled tool wraps them:
+
+```bash
+S=~/.claude/skills/herdr/scripts        # skill folder, symlinked by sync-skills
+$S/herdr-layout save review --current    # the caller's tab -> ~/.config/herdr/layouts/review.json
+$S/herdr-layout save review --tab w1:t2  # a specific tab; bare `save` = the UI-focused tab
+$S/herdr-layout list | show review | delete review
+$S/herdr-layout restore review [--workspace w2] [--label dev] [--replace-tab w1:t1] [--focus]
+```
+
+Facts that matter:
+
+- From an agent pane use `--current`: the UI-focused tab may belong to the
+  user or another client.
+- One tab per saved layout (export is per tab). Save each tab under its own name.
+- Saved JSON is portable: ephemeral `pane_id`s are stripped; tree, labels,
+  cwd, env and argv commands are kept.
+- Restore creates a NEW tab from the tree, labelled after the layout and left
+  in the background unless `--focus`. It does not preserve live PTYs,
+  scrollback or running processes. `--replace-tab` closes the old tab after
+  the new one exists. The printed tab id is the new tab (ids are monotonic
+  per session, so expect `w1:t5`, not `w1:t2`).
+- `HERDR_LAYOUT_DIR` and `HERDR_CONFIG_DIR` redirect where the tools read and
+  write (dry runs, tests). herdr itself ignores them: to validate a redirected
+  config use `XDG_CONFIG_HOME=<dir-containing-herdr/> herdr config check`.
+
+## Preferences (`scripts/herdr-prefs`)
+
+```bash
+$S/herdr-prefs status                    # ownership, theme/prefix keys, and the host's light/dark report
+$S/herdr-prefs set theme.dark_name nord  # edit one key, drop the managed marker, reload the server
+$S/herdr-prefs reset                     # back to the fleet baseline (keeps config.toml.bak)
+```
+
+`set` removes the `managed by dotfiles` marker, so from then on `install.sh`
+warns and leaves the file alone. Keys are `section.key`; true/false/numbers
+stay unquoted. herdr reloads live, no restart.
+
+**Theme trap.** The baseline has `auto_switch = true`, so herdr follows the
+host terminal's light/dark report and `theme.name` is only the fallback.
+Setting `theme.name = nord` alone changes nothing visible on a host that
+reports its appearance. Read `host appearance:` from `herdr-prefs status`
+(never assume dark) and change the sibling that applies, `theme.dark_name` or
+`theme.light_name`, or pin one theme for every terminal profile:
+
+```bash
+$S/herdr-prefs set theme.auto_switch false && $S/herdr-prefs set theme.name nord
+```
+
+Built-in themes (0.8.2): catppuccin / catppuccin-latte, tokyo-night /
+tokyo-night-day, gruvbox / gruvbox-light, one-dark / one-light, solarized /
+solarized-light, kanagawa / kanagawa-lotus, rose-pine / rose-pine-dawn,
+`terminal` (follows the host ANSI palette), and dark-only dracula, nord,
+vesper. A dark-only theme pinned with `auto_switch = false` is unreadable on
+a light profile; as `dark_name` it is not.
+
+## Unreadable sidebar
+
+Dark text on grey means a dark herdr theme over a light terminal (or vice
+versa). Run `herdr-prefs status`: a host-owned file with `auto_switch =
+false` and a dark `name` on a light terminal is the usual cause. Fix with
+`herdr-prefs reset` (managed, auto-switching) or set the matching sibling.
+
+## Common mistakes
+
+- Building a socket client or grepping the schema: the tools above already do it.
+- Editing `~/.config/herdr/config.toml` by hand and leaving the marker: the
+  next `install.sh` run overwrites the edit. Use `herdr-prefs set`.
+- Committing a rendered `config.toml` or a layout JSON to the dotfiles repo.
+- Sending keys into an agent pane to "check on it": use `agent list`/`read`.

--- a/ai/skills/herdr/evals/evals.json
+++ b/ai/skills/herdr/evals/evals.json
@@ -1,0 +1,41 @@
+{
+  "skill_name": "herdr",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Save my current herdr tab layout as 'review' so I can bring it back later on this machine, and show me how to restore it.",
+      "expected_output": "Checks HERDR_ENV=1, runs `herdr-layout save review` (from the skill's scripts dir) which writes ~/.config/herdr/layouts/review.json via layout.export, then shows `herdr-layout restore review [--workspace ID] [--label TEXT] [--focus]`, warning that restore creates fresh panes and does not carry running processes; nothing is written into the dotfiles repo.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Switch my herdr sidebar theme to nord on this host only. I don't want install.sh to keep resetting it.",
+      "expected_output": "Runs `herdr-prefs set theme.name nord` (plus dark_name/light_name if auto_switch is on), explains that this removes the 'managed by dotfiles' marker so install.sh leaves the file alone, that the running server was reloaded, and that `herdr-prefs reset` returns to the fleet Solarized baseline. Does not edit ai/herdr/config.toml or anything in the dotfiles repo.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I'm in herdr. Start a second Claude in a pane next to this one to review the current diff, wait for it, and read me its answer.",
+      "expected_output": "Verifies HERDR_ENV=1, inspects the caller pane layout, splits a sibling pane with --cwd \"$PWD\" --no-focus, starts the agent with `herdr agent start <name> --kind claude --pane <id>`, sends the task with `herdr agent prompt <name> \"...\" --wait`, then reads with `herdr agent read <name>`. Uses the returned pane id, not a guessed one, and never answers a blocked approval dialog on the user's behalf.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "The herdr sidebar shows dark grey text on a grey background again on this laptop. What's going on and how do I fix it here?",
+      "expected_output": "Runs `herdr-prefs status` to see ownership and theme keys; explains herdr paints its own colors and follows the host light/dark report when auto_switch is on; checks whether the file is host-owned with a dark theme forced, or the host terminal is not reporting its appearance; offers `herdr-prefs set theme.name solarized-light` (host-local) or `herdr-prefs reset` to return to the managed auto-switching config. Does not propose editing the dotfiles repo.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Is my Claude in the other workspace still working or is it waiting on me?",
+      "expected_output": "Runs `herdr agent list` (or `herdr workspace list`) and reports each agent's state using herdr's vocabulary: working, blocked (needs input/approval), done (finished, unseen), idle, unknown. Offers `herdr agent focus <name>` or `herdr agent read <name>` rather than sending keys into the pane.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Can you set up herdr so my panes come back the same way after a reboot?",
+      "expected_output": "Explains herdr already restores the session shape from session.json on server restart and that agent panes can resume via integrations (session.resume_agents_on_restore), so nothing extra is needed for the last layout; for named alternative layouts points to `herdr-layout save <name>` / `restore <name>`, kept host-local under ~/.config/herdr/layouts.",
+      "files": []
+    }
+  ]
+}

--- a/ai/skills/herdr/scripts/herdr-layout
+++ b/ai/skills/herdr/scripts/herdr-layout
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# herdr-layout — save/restore named herdr tab layouts, host-local.
+#
+# herdr already restores the last session shape on server restart (session.json)
+# but has no *named* layouts. This wraps the socket API's layout.export /
+# layout.apply into files under ~/.config/herdr/layouts/<name>.json — the same
+# role `tmux-mgr save|restore` plays for tmux. Layouts are per-host state and
+# are never tracked in the dotfiles repo.
+#
+# Usage:
+#   herdr-layout save <name> [--tab ID | --pane ID | --current]
+#   herdr-layout restore <name> [--workspace ID] [--label TEXT] [--replace-tab ID] [--focus]
+#   herdr-layout list | show <name> | delete <name>
+#
+# Env:
+#   HERDR_SOCKET_PATH  server API socket (herdr injects it into managed panes;
+#                      default: ${XDG_CONFIG_HOME:-~/.config}/herdr/herdr.sock)
+#   HERDR_LAYOUT_DIR   where layouts live (default: <config dir>/layouts)
+#
+# restore creates a NEW tab from the saved tree (structure, labels, cwd, env,
+# argv commands). It does not preserve live PTYs, scrollback, or running
+# processes — herdr's layout.apply contract. --replace-tab closes the given
+# tab after the new one exists.
+set -eu
+
+CONFIG_DIR="${HERDR_CONFIG_DIR:-${XDG_CONFIG_HOME:-${HOME}/.config}/herdr}"
+SOCK="${HERDR_SOCKET_PATH:-${CONFIG_DIR}/herdr.sock}"
+LAYOUT_DIR="${HERDR_LAYOUT_DIR:-${CONFIG_DIR}/layouts}"
+
+die()   { echo "herdr-layout: $*" >&2; exit 1; }
+usage() { sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+need_socket() {
+    [ -S "${SOCK}" ] || die "no herdr server socket at ${SOCK} (run inside a herdr pane, or set HERDR_SOCKET_PATH)"
+}
+
+check_name() {
+    case "$1" in
+        ""|*/*|.*|*[!A-Za-z0-9._-]*) die "invalid layout name '$1' (use [A-Za-z0-9._-], no leading dot)" ;;
+    esac
+}
+
+# rpc <method> <params-json>  -> prints the result JSON, or dies with the error code.
+rpc() {
+    python3 - "${SOCK}" "$1" "$2" <<'PY'
+import json, socket, sys
+sock, method, params = sys.argv[1], sys.argv[2], json.loads(sys.argv[3])
+req = {"id": "herdr-layout:" + method, "method": method, "params": params}
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(10)
+s.connect(sock)
+s.sendall((json.dumps(req) + "\n").encode())
+buf = b""
+while not buf.endswith(b"\n"):
+    chunk = s.recv(65536)
+    if not chunk:
+        break
+    buf += chunk
+s.close()
+resp = json.loads(buf.decode() or "{}")
+if "error" in resp:
+    err = resp["error"]
+    sys.stderr.write("herdr-layout: server error %s: %s\n" % (err.get("code"), err.get("message")))
+    sys.exit(1)
+print(json.dumps(resp.get("result", {})))
+PY
+}
+
+cmd_save() {
+    [ $# -ge 1 ] || usage 1
+    name="$1"; shift
+    check_name "${name}"
+    params='{}'
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --tab)     params="$(printf '{"tab_id":"%s"}' "$2")"; shift 2 ;;
+            --pane)    params="$(printf '{"pane_id":"%s"}' "$2")"; shift 2 ;;
+            --current) [ -n "${HERDR_PANE_ID:-}" ] || die "--current needs HERDR_PANE_ID (not inside a herdr pane?)"
+                       params="$(printf '{"pane_id":"%s"}' "${HERDR_PANE_ID}")"; shift ;;
+            *) die "unknown option '$1'" ;;
+        esac
+    done
+    need_socket
+    result="$(rpc layout.export "${params}")"
+    mkdir -p "${LAYOUT_DIR}"
+    out="${LAYOUT_DIR}/${name}.json"
+    printf '%s' "${result}" | python3 -c '
+import json, sys, datetime
+name, out = sys.argv[1], sys.argv[2]
+layout = json.load(sys.stdin)["layout"]
+def strip(node):
+    node.pop("pane_id", None)
+    for k in ("first", "second"):
+        if k in node:
+            strip(node[k])
+    return node
+doc = {
+    "name": name,
+    "saved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+    "source": {"workspace_id": layout.get("workspace_id"), "tab_id": layout.get("tab_id")},
+    "zoomed": bool(layout.get("zoomed", False)),
+    "root": strip(layout["root"]),
+}
+with open(out + ".tmp", "w") as fh:
+    json.dump(doc, fh, indent=2); fh.write("\n")
+' "${name}" "${out}"
+    mv "${out}.tmp" "${out}"
+    echo "saved layout '${name}' -> ${out}"
+}
+
+cmd_restore() {
+    [ $# -ge 1 ] || usage 1
+    name="$1"; shift
+    check_name "${name}"
+    file="${LAYOUT_DIR}/${name}.json"
+    [ -r "${file}" ] || die "no saved layout '${name}' (looked for ${file}; see: herdr-layout list)"
+    workspace=""; label="${name}"; replace=""; focus=false
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --workspace)   workspace="$2"; shift 2 ;;
+            --label)       label="$2"; shift 2 ;;
+            --replace-tab) replace="$2"; shift 2 ;;
+            --focus)       focus=true; shift ;;
+            *) die "unknown option '$1'" ;;
+        esac
+    done
+    need_socket
+    params="$(python3 -c '
+import json, sys
+file, workspace, label, replace, focus = sys.argv[1:6]
+doc = json.load(open(file))
+p = {"root": doc["root"], "tab_label": label, "focus": focus == "true"}
+if workspace: p["workspace_id"] = workspace
+if replace:   p["tab_id"] = replace
+print(json.dumps(p))
+' "${file}" "${workspace}" "${label}" "${replace}" "${focus}")"
+    result="$(rpc layout.apply "${params}")"
+    tab="$(printf '%s' "${result}" | python3 -c 'import json,sys; r=json.load(sys.stdin); print((r.get("layout") or {}).get("tab_id",""))')"
+    echo "restored layout '${name}' into tab ${tab:-?} (new panes; running processes are not carried over)"
+}
+
+cmd_list()   { [ -d "${LAYOUT_DIR}" ] || exit 0; for f in "${LAYOUT_DIR}"/*.json; do [ -e "$f" ] || continue; b="$(basename "$f")"; echo "${b%.json}"; done; }
+cmd_show()   { [ $# -eq 1 ] || usage 1; check_name "$1"; f="${LAYOUT_DIR}/$1.json"; [ -r "$f" ] || die "no saved layout '$1'"; cat "$f"; }
+cmd_delete() { [ $# -eq 1 ] || usage 1; check_name "$1"; f="${LAYOUT_DIR}/$1.json"; [ -e "$f" ] || die "no saved layout '$1'"; rm -f "$f"; echo "deleted layout '$1'"; }
+
+[ $# -ge 1 ] || usage 1
+cmd="$1"; shift
+case "${cmd}" in
+    save)    cmd_save "$@" ;;
+    restore) cmd_restore "$@" ;;
+    list)    cmd_list "$@" ;;
+    show)    cmd_show "$@" ;;
+    delete)  cmd_delete "$@" ;;
+    -h|--help|help) usage 0 ;;
+    *) die "unknown command '${cmd}' (save|restore|list|show|delete)" ;;
+esac

--- a/ai/skills/herdr/scripts/herdr-prefs
+++ b/ai/skills/herdr/scripts/herdr-prefs
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# herdr-prefs — host-local herdr preferences without touching the dotfiles repo.
+#
+# install.sh renders a dotfiles-MANAGED ~/.config/herdr/config.toml (see
+# opt/scripts/system/install_herdr.sh config). The file is host-owned by
+# marker: install.sh rewrites it only while the "managed by dotfiles" line is
+# present. `herdr-prefs set` edits one key and removes that marker, so from
+# then on this host owns its config and install.sh leaves it alone.
+# `herdr-prefs reset` hands the file back to the fleet baseline.
+#
+# Usage:
+#   herdr-prefs status                 ownership + the keys people change most
+#   herdr-prefs get <section.key>
+#   herdr-prefs set <section.key> <value>   (true/false/numbers unquoted, else a string)
+#   herdr-prefs reset                  re-render the managed file (keeps a .bak)
+#
+# Env:
+#   HERDR_CONFIG_DIR   (default: ${XDG_CONFIG_HOME:-~/.config}/herdr)
+#   HERDR_SOCKET_PATH  used only to reload a running server after a change
+#
+# Keys are two-level TOML (`theme.name`, `keys.prefix`, `ui.sidebar_width`).
+# Valid theme names: run `herdr config check` after a typo — herdr lists them.
+set -eu
+
+CONFIG_DIR="${HERDR_CONFIG_DIR:-${XDG_CONFIG_HOME:-${HOME}/.config}/herdr}"
+CONFIG="${CONFIG_DIR}/config.toml"
+SOCK="${HERDR_SOCKET_PATH:-${CONFIG_DIR}/herdr.sock}"
+MARKER="managed by dotfiles"
+# The skill folder is symlinked into ~/.claude/skills by sync-skills; `pwd -P`
+# resolves that to the physical repo checkout (portable: no GNU readlink -f).
+SELF_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+REPO_ROOT="$(cd "${SELF_DIR}/../../../.." && pwd -P)"
+INSTALLER="${REPO_ROOT}/opt/scripts/system/install_herdr.sh"
+
+die()   { echo "herdr-prefs: $*" >&2; exit 1; }
+usage() { sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+split_key() {
+    case "$1" in
+        *.*) SECTION="${1%%.*}"; KEY="${1#*.}" ;;
+        *)   die "key must be <section>.<key>, e.g. theme.name (got '$1')" ;;
+    esac
+    case "${SECTION}${KEY}" in *[!A-Za-z0-9_.-]*) die "bad key '$1'" ;; esac
+    case "${KEY}" in *.*) die "only two-level keys are supported (got '$1')" ;; esac
+}
+
+toml_get() {  # toml_get <section> <key>  -> raw value without quotes, or nothing
+    python3 - "${CONFIG}" "$1" "$2" <<'PY'
+import re, sys
+path, section, key = sys.argv[1:4]
+cur = None
+for line in open(path):
+    s = line.strip()
+    m = re.match(r'^\[([^\]]+)\]\s*(#.*)?$', s)
+    if m:
+        cur = m.group(1); continue
+    if cur != section or not s or s.startswith("#"):
+        continue
+    m = re.match(r'^([A-Za-z0-9_.-]+)\s*=\s*(.*?)\s*$', s)
+    if m and m.group(1) == key:
+        v = m.group(2)
+        # drop a trailing comment on unquoted values
+        if not v.startswith('"'):
+            v = v.split("#", 1)[0].strip()
+        print(v.strip('"'))
+        break
+PY
+}
+
+toml_set() {  # toml_set <section> <key> <value>
+    python3 - "${CONFIG}" "$1" "$2" "$3" "${MARKER}" <<'PY'
+import re, sys, os
+path, section, key, value, marker = sys.argv[1:6]
+if re.fullmatch(r'true|false|-?\d+(\.\d+)?', value):
+    rendered = value
+else:
+    rendered = '"' + value.replace('\\', '\\\\').replace('"', '\\"') + '"'
+lines = open(path).read().splitlines()
+out, cur, done, sec_seen, last_in_sec = [], None, False, False, None
+for i, line in enumerate(lines):
+    s = line.strip()
+    m = re.match(r'^\[([^\]]+)\]\s*(#.*)?$', s)
+    if m:
+        cur = m.group(1)
+        if cur == section: sec_seen = True
+    elif cur == section and not done:
+        m = re.match(r'^([A-Za-z0-9_.-]+)\s*=', s)
+        if m and m.group(1) == key:
+            line = f"{key} = {rendered}"; done = True
+    out.append(line)
+    if cur == section and s and not s.startswith("#"):
+        last_in_sec = len(out) - 1
+if not done:
+    if sec_seen:
+        out.insert((last_in_sec if last_in_sec is not None else len(out) - 1) + 1, f"{key} = {rendered}")
+    else:
+        if out and out[-1].strip(): out.append("")
+        out += [f"[{section}]", f"{key} = {rendered}"]
+# Ownership handoff: drop the managed marker so install.sh leaves the file alone.
+handed = False
+for i, line in enumerate(out):
+    if marker in line and line.lstrip().startswith("#"):
+        out[i] = "# host-owned: edited with herdr-prefs; install.sh no longer rewrites this file (herdr-prefs reset to reclaim)"
+        handed = True
+        break
+tmp = path + ".tmp"
+with open(tmp, "w") as fh:
+    fh.write("\n".join(out) + "\n")
+os.replace(tmp, path)
+print("handed" if handed else "kept")
+PY
+}
+
+reload_server() {
+    [ -S "${SOCK}" ] || return 0
+    python3 - "${SOCK}" <<'PY' || echo "herdr-prefs: running server did not reload (applies on next launch)" >&2
+import json, socket, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.settimeout(5); s.connect(sys.argv[1])
+s.sendall(b'{"id":"herdr-prefs:reload","method":"server.reload_config","params":{}}\n')
+buf = b""
+while not buf.endswith(b"\n"):
+    c = s.recv(65536)
+    if not c: break
+    buf += c
+r = json.loads(buf.decode() or "{}")
+sys.exit(1 if "error" in r else 0)
+PY
+}
+
+ownership() {
+    if [ ! -e "${CONFIG}" ]; then echo "absent"
+    elif grep -q "${MARKER}" "${CONFIG}"; then echo "managed"
+    else echo "host-owned"; fi
+}
+
+# Ask the terminal which appearance it reports (DEC 2031 / DSR 996). herdr
+# forwards the host answer into its panes, so this is what auto_switch sees.
+# Prints light | dark | unknown; never guesses when there is no tty.
+host_appearance() {
+    python3 - <<'PY' 2>/dev/null || echo unknown
+import os, select, termios, tty, time
+try:
+    fd = os.open("/dev/tty", os.O_RDWR | os.O_NOCTTY)
+except OSError:
+    print("unknown"); raise SystemExit
+old = termios.tcgetattr(fd)
+try:
+    tty.setraw(fd)
+    os.write(fd, b"\x1b[?996n")
+    buf, t0 = b"", time.time()
+    while time.time() - t0 < 0.5 and not buf.endswith(b"n"):
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if r:
+            buf += os.read(fd, 64)
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    os.close(fd)
+print({b"997;1n": "dark", b"997;2n": "light"}.get(buf[-6:], "unknown"))
+PY
+}
+
+cmd_status() {
+    echo "config: ${CONFIG}"
+    echo "ownership: $(ownership)  (managed = install.sh rewrites it; host-owned = install.sh leaves it alone)"
+    [ -e "${CONFIG}" ] || return 0
+    for k in theme.name theme.auto_switch theme.light_name theme.dark_name keys.prefix; do
+        split_key "${k}"
+        v="$(toml_get "${SECTION}" "${KEY}")"
+        echo "${k} = ${v:-<unset>}"
+    done
+    [ -S "${SOCK}" ] && echo "server: running (${SOCK})" || echo "server: not running"
+    echo "host appearance: $(host_appearance)  (what auto_switch follows: light -> light_name, dark -> dark_name, unknown -> name)"
+}
+
+cmd_get() {
+    [ $# -eq 1 ] || usage 1
+    [ -e "${CONFIG}" ] || die "no config at ${CONFIG}"
+    split_key "$1"
+    toml_get "${SECTION}" "${KEY}"
+}
+
+cmd_set() {
+    [ $# -eq 2 ] || usage 1
+    [ -e "${CONFIG}" ] || die "no config at ${CONFIG} (run install_herdr.sh config first)"
+    split_key "$1"
+    handoff="$(toml_set "${SECTION}" "${KEY}" "$2")"
+    echo "set $1 = $2 in ${CONFIG}"
+    if [ "${handoff}" = "handed" ]; then
+        echo "this file is now host-owned: install.sh will leave it alone (herdr-prefs reset to return to the fleet baseline)"
+    fi
+    reload_server
+}
+
+cmd_reset() {
+    [ -x "${INSTALLER}" ] || die "installer not found at ${INSTALLER}"
+    HERDR_CONFIG_FORCE=1 HERDR_CONFIG_DIR="${CONFIG_DIR}" "${INSTALLER}" config
+}
+
+[ $# -ge 1 ] || usage 1
+cmd="$1"; shift
+case "${cmd}" in
+    status) cmd_status "$@" ;;
+    get)    cmd_get "$@" ;;
+    set)    cmd_set "$@" ;;
+    reset)  cmd_reset "$@" ;;
+    -h|--help|help) usage 0 ;;
+    *) die "unknown command '${cmd}' (status|get|set|reset)" ;;
+esac

--- a/ai/skills/herdr/scripts/herdr-skill_test.sh
+++ b/ai/skills/herdr/scripts/herdr-skill_test.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Test driver for the herdr skill's bundled tools:
+#   scripts/herdr-layout  save/restore/list/show/delete named tab layouts
+#                         (host-local JSON under ~/.config/herdr/layouts) via
+#                         the socket API's layout.export / layout.apply
+#   scripts/herdr-prefs   host-local config.toml edits that take ownership
+#                         away from install.sh (drops the managed marker)
+#
+# What must hold:
+#   * the socket is never touched unless HERDR_SOCKET_PATH (or the default
+#     socket) exists; a missing socket is a clear error, not a hang;
+#   * save writes portable JSON: ephemeral pane_ids are stripped, the tree,
+#     zoom state, and a saved_at stamp are kept;
+#   * restore sends layout.apply with the saved root and the caller's options;
+#   * a server error is surfaced with its code and exits non-zero;
+#   * prefs set edits exactly one key in one section, preserves comments,
+#     removes the "managed by dotfiles" marker (host takes ownership), and
+#     reloads a running server best-effort;
+#   * prefs reset re-renders the managed file via install_herdr.sh config.
+#
+# The herdr server is a fake: a one-request-per-connection newline-JSON unix
+# socket server (python3) that records what it received.
+#
+# Run: bash ai/skills/herdr/scripts/herdr-skill_test.sh
+set -u
+
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SELF_DIR}/../../../.." && pwd)"
+# shellcheck source=../../../_test_helpers.sh
+. "${REPO_ROOT}/ai/_test_helpers.sh"
+
+LAYOUT="${SELF_DIR}/herdr-layout"
+PREFS="${SELF_DIR}/herdr-prefs"
+SKILL="${SELF_DIR}/../SKILL.md"
+
+assert_file_exists "${LAYOUT}" "herdr-layout exists"
+assert_file_exists "${PREFS}" "herdr-prefs exists"
+assert_file_exists "${SKILL}" "SKILL.md exists"
+assert_exit_code 0 "herdr-layout parses" bash -n "${LAYOUT}"
+assert_exit_code 0 "herdr-prefs parses" bash -n "${PREFS}"
+set +e
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/herdr_skill_test.XXXXXX")"
+trap 'rm -rf "${TMP}"; [ -n "${SRV_PID:-}" ] && kill "${SRV_PID}" 2>/dev/null' EXIT
+
+# --- fake herdr socket server ------------------------------------------------
+SOCK="${TMP}/herdr.sock"
+LOG="${TMP}/requests.jsonl"
+cat > "${TMP}/fake_server.py" <<'PY'
+import socket, json, os, sys
+path, log = sys.argv[1], sys.argv[2]
+srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+srv.bind(path); srv.listen(8)
+while True:
+    conn, _ = srv.accept()
+    buf = b""
+    while not buf.endswith(b"\n"):
+        c = conn.recv(65536)
+        if not c: break
+        buf += c
+    req = json.loads(buf.decode() or "{}")
+    with open(log, "a") as fh: fh.write(json.dumps(req) + "\n")
+    m, p = req.get("method"), req.get("params", {})
+    if m == "layout.export":
+        if p.get("tab_id") == "w9:t9":
+            res = {"id": req["id"], "error": {"code": "layout_not_found", "message": "layout target not found"}}
+        else:
+            res = {"id": req["id"], "result": {"type": "layout_export", "layout": {
+                "workspace_id": "w1", "tab_id": "w1:t1", "zoomed": False, "focused_pane_id": "w1:p2",
+                "root": {"type": "split", "direction": "right", "ratio": 0.6,
+                         "first": {"type": "pane", "pane_id": "w1:p1", "cwd": "/repo", "label": "editor"},
+                         "second": {"type": "pane", "pane_id": "w1:p2", "cwd": "/repo",
+                                    "command": ["sh", "-c", "make test"]}}}}}
+    elif m == "layout.apply":
+        # Real 0.8.2 shape: the applied layout comes back with the NEW tab id.
+        res = {"id": req["id"], "result": {"type": "layout_apply", "layout": {
+            "workspace_id": p.get("workspace_id") or "w1", "tab_id": "w1:t2", "zoomed": False,
+            "focused_pane_id": "w1:p3", "root": p["root"]}}}
+    elif m == "server.reload_config":
+        res = {"id": req["id"], "result": {"type": "config_reload", "status": "applied", "diagnostics": []}}
+    else:
+        res = {"id": req["id"], "error": {"code": "unknown_method", "message": m}}
+    conn.sendall((json.dumps(res) + "\n").encode()); conn.close()
+PY
+python3 "${TMP}/fake_server.py" "${SOCK}" "${LOG}" &
+SRV_PID=$!
+for _ in 1 2 3 4 5 6 7 8 9 10; do [ -S "${SOCK}" ] && break; sleep 0.1; done
+[ -S "${SOCK}" ] || { echo "FAIL: fake server did not start"; FAIL=$((FAIL+1)); }
+
+LAYOUTS="${TMP}/layouts"
+run_layout() { HERDR_SOCKET_PATH="${SOCK}" HERDR_LAYOUT_DIR="${LAYOUTS}" bash "${LAYOUT}" "$@"; }
+
+# 1. No socket -> clear error, non-zero, nothing written.
+out="$(HERDR_SOCKET_PATH="${TMP}/missing.sock" HERDR_LAYOUT_DIR="${LAYOUTS}" bash "${LAYOUT}" save nope 2>&1)"; rc=$?
+assert_eq "${rc}" "1" "layout save: missing socket exits 1"
+assert_eq "$(printf '%s' "${out}" | grep -c 'no herdr server socket')" "1" "layout save: missing socket is explained"
+assert_eq "$(ls "${LAYOUTS}" 2>/dev/null | wc -l | tr -d ' ')" "0" "layout save: missing socket writes nothing"
+
+# 2. save <name>: exports the active tab, strips pane_ids, keeps the tree.
+out="$(run_layout save review 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "layout save: exits 0"
+assert_file_exists "${LAYOUTS}/review.json" "layout save: writes <dir>/<name>.json"
+assert_eq "$(tail -1 "${LOG}" | jq -r .method)" "layout.export" "layout save: calls layout.export"
+assert_eq "$(jq -r '.root.type' "${LAYOUTS}/review.json")" "split" "layout save: keeps the split tree"
+assert_eq "$(jq -r '.root.second.command | join(" ")' "${LAYOUTS}/review.json")" "sh -c make test" "layout save: keeps pane commands"
+assert_eq "$(jq -r '.root.first.label' "${LAYOUTS}/review.json")" "editor" "layout save: keeps pane labels"
+assert_eq "$(grep -c pane_id "${LAYOUTS}/review.json")" "0" "layout save: strips ephemeral pane_ids"
+assert_eq "$(jq -r '.zoomed' "${LAYOUTS}/review.json")" "false" "layout save: records zoom state"
+assert_eq "$(jq -r '.name' "${LAYOUTS}/review.json")" "review" "layout save: records the name"
+assert_eq "$(jq -r '.saved_at | length > 0' "${LAYOUTS}/review.json")" "true" "layout save: records saved_at"
+assert_eq "$(printf '%s' "${out}" | grep -c 'review.json')" "1" "layout save: prints the file path"
+
+# 3. save --tab ID forwards the target; a server error is surfaced.
+run_layout save other --tab w1:t1 >/dev/null 2>&1
+assert_eq "$(tail -1 "${LOG}" | jq -r .params.tab_id)" "w1:t1" "layout save --tab: forwards tab_id"
+out="$(run_layout save bad --tab w9:t9 2>&1)"; rc=$?
+assert_eq "${rc}" "1" "layout save: server error exits 1"
+assert_eq "$(printf '%s' "${out}" | grep -c 'layout_not_found')" "1" "layout save: server error code is shown"
+assert_eq "$([ -e "${LAYOUTS}/bad.json" ] && echo yes || echo no)" "no" "layout save: server error writes nothing"
+
+# 4. Names are validated (they become file names).
+out="$(run_layout save '../evil' 2>&1)"; rc=$?
+assert_eq "${rc}" "1" "layout save: path-like name is rejected"
+
+# 5. list / show / delete.
+assert_eq "$(run_layout list 2>&1 | sort | tr '\n' ' ')" "other review " "layout list: names, one per line"
+assert_eq "$(run_layout show review | jq -r .name)" "review" "layout show: prints the JSON"
+out="$(run_layout show missing 2>&1)"; rc=$?
+assert_eq "${rc}" "1" "layout show: unknown name exits 1"
+run_layout delete other >/dev/null 2>&1
+assert_eq "$([ -e "${LAYOUTS}/other.json" ] && echo yes || echo no)" "no" "layout delete: removes the file"
+
+# 6. restore <name>: layout.apply with the saved root; options forwarded.
+out="$(run_layout restore review 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "layout restore: exits 0"
+assert_eq "$(tail -1 "${LOG}" | jq -r .method)" "layout.apply" "layout restore: calls layout.apply"
+assert_eq "$(tail -1 "${LOG}" | jq -r .params.root.direction)" "right" "layout restore: sends the saved root"
+assert_eq "$(tail -1 "${LOG}" | jq -r .params.tab_label)" "review" "layout restore: tab label defaults to the name"
+assert_eq "$(tail -1 "${LOG}" | jq -r .params.focus)" "false" "layout restore: does not steal focus by default"
+assert_eq "$(printf '%s' "${out}" | grep -c 'w1:t2')" "1" "layout restore: reports the new tab id"
+run_layout restore review --workspace w2 --label dev --focus --replace-tab w1:t1 >/dev/null 2>&1
+assert_eq "$(tail -1 "${LOG}" | jq -r '[.params.workspace_id, .params.tab_label, .params.focus, .params.tab_id] | join(" ")')" \
+    "w2 dev true w1:t1" "layout restore: forwards --workspace/--label/--focus/--replace-tab"
+
+# --- herdr-prefs --------------------------------------------------------------
+CFG="${TMP}/cfg"; mkdir -p "${CFG}"
+run_prefs() { HERDR_SOCKET_PATH="${SOCK}" HERDR_CONFIG_DIR="${CFG}" bash "${PREFS}" "$@"; }
+# Seed the managed file exactly as install_herdr.sh config would.
+HERDR_CONFIG_DIR="${CFG}" HERDR_INSTALL_DIR="${TMP}/nobin" bash "${REPO_ROOT}/opt/scripts/system/install_herdr.sh" config >/dev/null 2>&1
+assert_grep "prefs fixture: seeded managed config" '^# managed by dotfiles' "${CFG}/config.toml"
+
+# 7. status: reports managed vs host-owned and the live values.
+out="$(run_prefs status 2>&1)"
+assert_eq "$(printf '%s' "${out}" | grep -c 'ownership: managed')" "1" "prefs status: managed file is reported"
+assert_eq "$(printf '%s' "${out}" | grep -c 'theme.name = solarized')" "1" "prefs status: shows theme.name"
+assert_eq "$(printf '%s' "${out}" | grep -c 'keys.prefix = ctrl+a')" "1" "prefs status: shows keys.prefix"
+assert_eq "$(printf '%s' "${out}" | grep -c 'host appearance: unknown')" "1" "prefs status: host appearance is unknown without a tty (never guessed)"
+
+# 8. get / set on an existing key in an existing section.
+assert_eq "$(run_prefs get theme.name)" "solarized" "prefs get: reads a string"
+assert_eq "$(run_prefs get theme.auto_switch)" "true" "prefs get: reads a boolean"
+out="$(run_prefs set theme.name nord 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "prefs set: exits 0"
+assert_grep "prefs set: rewrites the key in place" '^name = "nord"$' "${CFG}/config.toml"
+assert_eq "$(grep -c '^name = ' "${CFG}/config.toml")" "1" "prefs set: exactly one name key remains"
+assert_grep "prefs set: other keys untouched" '^light_name = "solarized-light"$' "${CFG}/config.toml"
+assert_grep "prefs set: comments preserved" '^# tmux-style prefix on ctrl\+a' "${CFG}/config.toml"
+assert_grep_negative "prefs set: managed marker removed (host owns the file now)" 'managed by dotfiles' "${CFG}/config.toml"
+assert_grep "prefs set: ownership handoff is recorded in the file" '^# host-owned' "${CFG}/config.toml"
+assert_eq "$(tail -1 "${LOG}" | jq -r .method)" "server.reload_config" "prefs set: reloads the running server"
+assert_eq "$(printf '%s' "${out}" | grep -c 'host-owned')" "1" "prefs set: tells the user install.sh will leave it alone"
+assert_eq "$(run_prefs status 2>&1 | grep -c 'ownership: host-owned')" "1" "prefs status: host-owned after set"
+
+# 9. set: booleans/numbers unquoted, strings quoted; new key appended to its section; new section created.
+run_prefs set theme.auto_switch false >/dev/null 2>&1
+assert_grep "prefs set: boolean stays unquoted" '^auto_switch = false$' "${CFG}/config.toml"
+run_prefs set ui.sidebar_width 30 >/dev/null 2>&1
+assert_grep "prefs set: creates a missing section" '^\[ui\]$' "${CFG}/config.toml"
+assert_grep "prefs set: number stays unquoted" '^sidebar_width = 30$' "${CFG}/config.toml"
+run_prefs set keys.new_tab prefix+c >/dev/null 2>&1
+assert_grep "prefs set: new key lands in its section" '^new_tab = "prefix\+c"$' "${CFG}/config.toml"
+assert_eq "$(awk '/^\[keys\]/{f=1;next} /^\[/{f=0} f && /^new_tab/{print "in-keys"}' "${CFG}/config.toml")" "in-keys" \
+    "prefs set: appended key is inside [keys], not at EOF"
+out="$(run_prefs set nodots value 2>&1)"; rc=$?
+assert_eq "${rc}" "1" "prefs set: key must be section.key"
+
+# 10. reset: re-renders the managed file (install_herdr.sh config, forced), keeping a .bak.
+out="$(HERDR_INSTALL_DIR="${TMP}/nobin" run_prefs reset 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "prefs reset: exits 0"
+assert_grep "prefs reset: managed marker is back" '^# managed by dotfiles' "${CFG}/config.toml"
+assert_grep "prefs reset: fleet theme is back" '^name = "solarized"$' "${CFG}/config.toml"
+assert_grep "prefs reset: the host-owned file was backed up" '^name = "nord"$' "${CFG}/config.toml.bak"
+
+# 11. reset through a symlinked skill folder (how sync-skills installs it) still
+#     finds the installer in the physical checkout.
+ln -s "${SELF_DIR}" "${TMP}/skill-link"
+run_prefs set theme.name dracula >/dev/null 2>&1
+out="$(HERDR_SOCKET_PATH="${SOCK}" HERDR_CONFIG_DIR="${CFG}" HERDR_INSTALL_DIR="${TMP}/nobin" bash "${TMP}/skill-link/herdr-prefs" reset 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "prefs reset via symlinked skill dir: exits 0"
+assert_grep "prefs reset via symlinked skill dir: managed marker is back" '^# managed by dotfiles' "${CFG}/config.toml"
+
+# --- SKILL.md shape -------------------------------------------------------------
+assert_grep "SKILL.md: frontmatter name is herdr" '^name: herdr$' "${SKILL}"
+assert_grep "SKILL.md: description starts with a trigger, not a workflow" '^description: Use when' "${SKILL}"
+assert_grep "SKILL.md: gates on HERDR_ENV like the upstream skill" 'HERDR_ENV' "${SKILL}"
+assert_grep "SKILL.md: documents layout save" 'herdr-layout save' "${SKILL}"
+assert_grep "SKILL.md: documents prefs set" 'herdr-prefs set' "${SKILL}"
+assert_grep "SKILL.md: warns that restore does not carry running processes" 'not preserve live' "${SKILL}"
+assert_grep "SKILL.md: says layouts are host-local, not in the repo" 'never in the dotfiles repo' "${SKILL}"
+assert_file_exists "${SELF_DIR}/../evals/evals.json" "evals corpus exists"
+
+_test_report

--- a/docs/mbo/designs/herdr.md
+++ b/docs/mbo/designs/herdr.md
@@ -60,7 +60,8 @@ configured too, and how do we keep up with releases across the fleet (including 
   channel is a per-host setting. Without a fleet-wide convergence step, hosts drift.
 - **Key collision with tmux.** herdr's default prefix is `ctrl+b`, the same as our untouched tmux default;
   `.tmux.conf` also binds `C-h/j/k/l` in the root table and claims the mouse. herdr **inside** tmux loses
-  its prefix and its mouse. Run it as the outer layer or rebind `[keys]`.
+  its prefix and its mouse. Run it as the outer layer or rebind `[keys]`. *Resolved (worker `theme`):* the
+  managed `ai/herdr/config.toml` sets `prefix = "ctrl+a"`.
 - **Integration clobbering.** `install_antigravity_skills.sh` re-renders `~/.gemini/config/hooks.json`
   from the repo template on every run, deleting herdr's `herdr` hook entry. The Claude `SessionStart` hook
   survives the forced-settings merge only because that merge replaces `hooks.PreToolUse` /
@@ -200,6 +201,9 @@ hooks should go too. `~/.config/herdr` and `~/.herdr/worktrees` are user data an
 
 - A gff **choice** flag for the version policy (`latest` vs a pinned string) once a pin is actually needed.
 - `tmux-mgr`/`gsl`: the cross-session agent-state roll-up from (h).
-- Track `~/.config/herdr/config.toml` under `opt/etc/` via the copy pattern if the config grows beyond the
-  current two `[ui]` keys.
+- ~~Track `~/.config/herdr/config.toml` under `opt/etc/` via the copy pattern.~~ Done (worker `theme`):
+  `ai/herdr/config.toml` is rendered by `install_herdr.sh config` (gff `install.tools.herdr-config`). It
+  turns on herdr's host light/dark following (DEC 2031, verified against Windows Terminal) with the
+  Solarized pair, so the default dark catppuccin sidebar no longer lands on a Solarized Light profile, and
+  moves the prefix to `ctrl+a`. Host-owned: rewritten only while the `managed by dotfiles` marker is present.
 - Re-evaluate at herdr 1.0 or when signed/attested release assets appear.

--- a/docs/mbo/designs/herdr.md
+++ b/docs/mbo/designs/herdr.md
@@ -201,6 +201,10 @@ hooks should go too. `~/.config/herdr` and `~/.herdr/worktrees` are user data an
 
 - A gff **choice** flag for the version policy (`latest` vs a pinned string) once a pin is actually needed.
 - `tmux-mgr`/`gsl`: the cross-session agent-state roll-up from (h).
+- ~~A herdr counterpart of the `tmux` skill.~~ Done (worker `theme`): `ai/skills/herdr` maps the tmux-mgr
+  verbs onto herdr's CLI and bundles `herdr-layout` (named tab layouts via socket `layout.export` /
+  `layout.apply`, host-local under `~/.config/herdr/layouts`) and `herdr-prefs` (host-local
+  `config.toml` edits that drop the managed marker; `reset` returns to the baseline).
 - ~~Track `~/.config/herdr/config.toml` under `opt/etc/` via the copy pattern.~~ Done (worker `theme`):
   `ai/herdr/config.toml` is rendered by `install_herdr.sh config` (gff `install.tools.herdr-config`). It
   turns on herdr's host light/dark following (DEC 2031, verified against Windows Terminal) with the

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ unset _ip_prev _ip_arg
 #   - CONFIG / SKILL / SYMLINK / any repo-content step -> _IP_CONFIG_FLAGS. Runs
 #     in the per-commit config layer; omitting it BAKES the step into the cached
 #     deps layer, so later edits to it stop taking effect per commit (a bug).
-_IP_CONFIG_FLAGS="INSTALL_SHELL_PROFILES INSTALL_SHELL_DEFAULT_ZSH INSTALL_DESKTOP_GNOME_KEYS INSTALL_AI_SKILLS INSTALL_AI_ANTIGRAVITY INSTALL_AI_CLAUDE INSTALL_TOOLS_GIT_ALIASES INSTALL_TOOLS_HERDR_INTEGRATIONS INSTALL_SDK_GSS INSTALL_SDK_TMUX_MGR INSTALL_SDK_WOL INSTALL_SDK_GSL INSTALL_SDK_GFF"
+_IP_CONFIG_FLAGS="INSTALL_SHELL_PROFILES INSTALL_SHELL_DEFAULT_ZSH INSTALL_DESKTOP_GNOME_KEYS INSTALL_AI_SKILLS INSTALL_AI_ANTIGRAVITY INSTALL_AI_CLAUDE INSTALL_TOOLS_GIT_ALIASES INSTALL_TOOLS_HERDR_INTEGRATIONS INSTALL_TOOLS_HERDR_CONFIG INSTALL_SDK_GSS INSTALL_SDK_TMUX_MGR INSTALL_SDK_WOL INSTALL_SDK_GSL INSTALL_SDK_GFF"
 _IP_DEPS_FLAGS="INSTALL_PKG_COMMON_CORE INSTALL_PKG_BREWFILE INSTALL_TOOLS_SOPS INSTALL_TOOLS_YQ INSTALL_TOOLS_K8S INSTALL_TOOLS_HERDR INSTALL_TOOLS_SNOWFLAKE INSTALL_TOOLS_DOCKER INSTALL_RUNTIME_GOENV INSTALL_RUNTIME_PYENV INSTALL_RUNTIME_RBENV INSTALL_RUNTIME_NVM INSTALL_SHELL_OH_MY_ZSH_UPDATE"
 apply_install_phase() {
   case "$INSTALL_PHASE" in
@@ -312,6 +312,19 @@ if gff_on install.tools.herdr-integrations; then
     "${BASE_DIR}/opt/scripts/system/install_herdr.sh" integrations || echo "WARNING: herdr integrations reported problems; continuing."
   fi
 else gff_skip_msg install.tools.herdr-integrations; fi
+
+# herdr managed config (~/.config/herdr/config.toml): herdr paints its own
+# sidebar/panel colors, and its default dark catppuccin theme is unreadable on
+# a Solarized Light terminal profile. The rendered template turns on herdr's
+# host light/dark following with the fleet Solarized pair, so the right palette
+# is picked per terminal profile at runtime. The host owns the file: it is only
+# rewritten while it carries the "managed by dotfiles" marker.
+if gff_on install.tools.herdr-config; then
+  if [ -f "${BASE_DIR}/opt/scripts/system/install_herdr.sh" ]; then
+    echo "Installing herdr config..."
+    "${BASE_DIR}/opt/scripts/system/install_herdr.sh" config || echo "WARNING: herdr config reported problems; continuing."
+  fi
+else gff_skip_msg install.tools.herdr-config; fi
 
 NIX_MANAGED_FILE="${HOME}/.config/nix_managed"
 

--- a/opt/scripts/system/install_herdr.sh
+++ b/opt/scripts/system/install_herdr.sh
@@ -25,6 +25,15 @@
 # Modes:
 #   install_herdr.sh                # the binary            (install.sh --phase deps)
 #   install_herdr.sh integrations   # agent integrations    (install.sh --phase config)
+#   install_herdr.sh config         # managed config.toml   (install.sh --phase config)
+#
+#   `config` renders ai/herdr/config.toml into ~/.config/herdr/config.toml so
+#   herdr follows the host terminal's light/dark appearance with the fleet
+#   Solarized palette (a dark catppuccin sidebar on a Solarized Light terminal
+#   is unreadable). The host OWNS the file: it is written when missing or when
+#   it still carries the "managed by dotfiles" marker; a hand-edited file
+#   without the marker is left alone (HERDR_CONFIG_FORCE=1 reclaims it, keeping
+#   a .bak). A running server is reloaded best-effort so the change is live.
 #
 #   `integrations` runs `herdr integration install <id>` for each id in
 #   HERDR_INTEGRATIONS whose agent CLI is present on this host. Ordering
@@ -39,6 +48,11 @@
 #   HERDR_INSTALL_DIR   target dir (default: ~/opt/bin)
 #   HERDR_FORCE=1       reinstall even when the wanted version is already present
 #   HERDR_INTEGRATIONS  space-separated integration ids (default: claude antigravity-cli)
+#   HERDR_CONFIG_DIR    herdr config dir (default: ${XDG_CONFIG_HOME:-~/.config}/herdr)
+#   HERDR_CONFIG_TEMPLATE  template to render (default: ai/herdr/config.toml in this repo)
+#   HERDR_THEME_DARK    dark theme / no-report fallback (default: solarized)
+#   HERDR_THEME_LIGHT   light theme (default: solarized-light)
+#   HERDR_CONFIG_FORCE=1  overwrite a hand-edited (unmanaged) config.toml, keeping a .bak
 #   HERDR_MANIFEST_URL  manifest location (default: https://herdr.dev/latest.json)
 #   HERDR_MANIFEST_FILE use a local manifest file instead of fetching (tests)
 set -e
@@ -47,6 +61,13 @@ MODE="${1:-install}"
 HERDR_VERSION="${HERDR_VERSION:-latest}"
 INSTALL_DIR="${HERDR_INSTALL_DIR:-${HOME}/opt/bin}"
 HERDR_INTEGRATIONS="${HERDR_INTEGRATIONS:-claude antigravity-cli}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+CONFIG_DIR="${HERDR_CONFIG_DIR:-${XDG_CONFIG_HOME:-${HOME}/.config}/herdr}"
+CONFIG_TEMPLATE="${HERDR_CONFIG_TEMPLATE:-${REPO_ROOT}/ai/herdr/config.toml}"
+HERDR_THEME_DARK="${HERDR_THEME_DARK:-solarized}"
+HERDR_THEME_LIGHT="${HERDR_THEME_LIGHT:-solarized-light}"
+MANAGED_MARKER="managed by dotfiles"
 MANIFEST_URL="${HERDR_MANIFEST_URL:-https://herdr.dev/latest.json}"
 RELEASE_BASE="https://github.com/herdrdev/herdr/releases/download"
 
@@ -267,8 +288,67 @@ install_integrations() {
     return "${status}"
 }
 
+# ------------------------------------------------------------------------------
+# Mode: managed config.toml
+# ------------------------------------------------------------------------------
+render_config() {
+    sed -e "s|@HERDR_THEME_DARK@|${HERDR_THEME_DARK}|g" \
+        -e "s|@HERDR_THEME_LIGHT@|${HERDR_THEME_LIGHT}|g" "${CONFIG_TEMPLATE}"
+}
+
+# Best-effort: only when a server is up (its API socket exists). Never fails
+# the install; the next `herdr` launch reads the file anyway.
+reload_running_server() {
+    HERDR_BIN="${INSTALL_DIR}/herdr"
+    [ -x "${HERDR_BIN}" ] || HERDR_BIN="$(command -v herdr 2>/dev/null || true)"
+    [ -n "${HERDR_BIN}" ] || return 0
+    [ -e "${CONFIG_DIR}/herdr.sock" ] || return 0
+    if "${HERDR_BIN}" server reload-config 2>&1 | sed 's/^/  /'; then
+        ok "  herdr: running server reloaded config"
+    else
+        warn "running server did not reload config (it will apply on next launch)"
+    fi
+}
+
+install_config() {
+    [ -r "${CONFIG_TEMPLATE}" ] || die "config template not readable: ${CONFIG_TEMPLATE}"
+    for t in "${HERDR_THEME_DARK}" "${HERDR_THEME_LIGHT}"; do
+        case "${t}" in
+            *[!a-z0-9-]*|"") die "theme names must match [a-z0-9-]+ (got '${t}')" ;;
+        esac
+    done
+    TARGET="${CONFIG_DIR}/config.toml"
+    WANT_CONTENT="$(render_config)"
+
+    if [ -e "${TARGET}" ]; then
+        if ! grep -q "${MANAGED_MARKER}" "${TARGET}"; then
+            if [ "${HERDR_CONFIG_FORCE:-0}" != "1" ]; then
+                warn "${TARGET} is hand-edited (no '${MANAGED_MARKER}' marker); leaving it alone. Set HERDR_CONFIG_FORCE=1 to replace it (a .bak is kept)."
+                return 0
+            fi
+            cp -p "${TARGET}" "${TARGET}.bak"
+            info "Replacing hand-edited ${TARGET} (backup: ${TARGET}.bak)..."
+        elif [ "$(cat "${TARGET}")" = "${WANT_CONTENT}" ]; then
+            ok "herdr config up to date: ${TARGET}"
+            return 0
+        else
+            info "Updating managed ${TARGET}..."
+        fi
+    else
+        info "Seeding ${TARGET} (theme: ${HERDR_THEME_DARK} / ${HERDR_THEME_LIGHT}, follows host appearance)..."
+    fi
+
+    mkdir -p "${CONFIG_DIR}"
+    # Write-then-rename so a reload never sees a half-written file.
+    printf '%s\n' "${WANT_CONTENT}" > "${TARGET}.tmp"
+    mv "${TARGET}.tmp" "${TARGET}"
+    ok "  herdr config written: ${TARGET}"
+    reload_running_server
+}
+
 case "${MODE}" in
     install)      install_binary ;;
     integrations) install_integrations ;;
-    *) die "unknown mode '${MODE}' (expected: install | integrations)" ;;
+    config)       install_config ;;
+    *) die "unknown mode '${MODE}' (expected: install | integrations | config)" ;;
 esac

--- a/opt/scripts/system/install_herdr_test.sh
+++ b/opt/scripts/system/install_herdr_test.sh
@@ -8,7 +8,12 @@
 #   * "already on the wanted version" is a cheap no-op (fleet update re-runs
 #     install.sh on every host, so this path is the common one);
 #   * the integrations mode only touches agent CLIs that exist on the host;
-#   * the gff wiring is complete: both flags exist in features.yaml, each key is
+#   * the config mode seeds a dotfiles-MANAGED ~/.config/herdr/config.toml that
+#     lets herdr follow the host terminal's light/dark appearance with the
+#     fleet Solarized palette; it converges a managed file, never clobbers a
+#     hand-edited one (no marker) unless HERDR_CONFIG_FORCE=1, and reloads a
+#     running server best-effort;
+#   * the gff wiring is complete: all three flags exist in features.yaml, each key is
 #     in exactly one install-phase list, and the integrations block runs AFTER
 #     install_antigravity_skills.sh (which re-renders hooks.json and drops
 #     herdr's entry).
@@ -76,6 +81,7 @@ cat > "${STUB_DIR}/herdr" <<'SH'
 case "$1" in
   --version) echo "herdr 0.8.2" ;;
   integration) echo "stub: herdr $*"; exit 0 ;;
+  server) echo "stub: herdr $*"; exit 0 ;;
   *) exit 1 ;;
 esac
 SH
@@ -117,6 +123,69 @@ out="$(HERDR_INSTALL_DIR="${EMPTY_DIR}" PATH="${EMPTY_DIR}:/usr/bin:/bin" bash "
 assert_eq "${rc}" "0" "integrations: no herdr -> exit 0"
 assert_eq "$(printf '%s' "${out}" | grep -c 'herdr is not installed; skipping')" "1" "integrations: no herdr is reported"
 
+# --- config mode: managed config.toml ----------------------------------------
+TEMPLATE="${REPO_ROOT}/ai/herdr/config.toml"
+assert_file_exists "${TEMPLATE}" "config template is tracked at ai/herdr/config.toml"
+assert_grep "template turns on host light/dark following" '^auto_switch = true' "${TEMPLATE}"
+assert_grep "template carries the managed marker" 'managed by dotfiles' "${TEMPLATE}"
+assert_grep "template renders the dark theme from a token" '@HERDR_THEME_DARK@' "${TEMPLATE}"
+assert_grep "template renders the light theme from a token" '@HERDR_THEME_LIGHT@' "${TEMPLATE}"
+assert_grep "template ships no hardcoded home path" '^# managed by dotfiles' "${TEMPLATE}"
+assert_grep "template sets the prefix to ctrl+a (tmux muscle memory, no ctrl+b clash)" '^prefix = "ctrl\+a"$' "${TEMPLATE}"
+
+# 6. Fresh host: no config.toml -> seeded with the Solarized pair, dark fallback.
+CFG_DIR="${TMP}/cfg-fresh"
+out="$(HERDR_INSTALL_DIR="${EMPTY_DIR}" HERDR_CONFIG_DIR="${CFG_DIR}" bash "${SCRIPT}" config 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "config: fresh host exits 0"
+assert_file_exists "${CFG_DIR}/config.toml" "config: fresh host gets config.toml"
+assert_grep "config: dark fallback theme is solarized" '^name = "solarized"$' "${CFG_DIR}/config.toml"
+assert_grep "config: auto_switch is on" '^auto_switch = true$' "${CFG_DIR}/config.toml"
+assert_grep "config: light sibling is solarized-light" '^light_name = "solarized-light"$' "${CFG_DIR}/config.toml"
+assert_grep "config: dark sibling is solarized" '^dark_name = "solarized"$' "${CFG_DIR}/config.toml"
+assert_grep "config: written file carries the managed marker" '^# managed by dotfiles' "${CFG_DIR}/config.toml"
+assert_grep_negative "config: no unrendered tokens remain" '@HERDR_THEME_' "${CFG_DIR}/config.toml"
+assert_grep "config: rendered file keeps the ctrl+a prefix" '^prefix = "ctrl\+a"$' "${CFG_DIR}/config.toml"
+assert_grep_negative "config: no herdr -> no reload attempted" 'reload' <(printf '%s\n' "${out}")
+
+# 7. Re-run on a managed file is a converge no-op.
+before="$(cat "${CFG_DIR}/config.toml")"
+out="$(HERDR_INSTALL_DIR="${EMPTY_DIR}" HERDR_CONFIG_DIR="${CFG_DIR}" bash "${SCRIPT}" config 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "config: re-run exits 0"
+assert_eq "$(cat "${CFG_DIR}/config.toml")" "${before}" "config: re-run leaves a managed file byte-identical"
+assert_eq "$(printf '%s' "${out}" | grep -c 'up to date')" "1" "config: re-run reports up to date"
+
+# 8. Theme overrides render into the managed file.
+CFG_DIR2="${TMP}/cfg-override"
+out="$(HERDR_INSTALL_DIR="${EMPTY_DIR}" HERDR_CONFIG_DIR="${CFG_DIR2}" HERDR_THEME_DARK=nord HERDR_THEME_LIGHT=one-light bash "${SCRIPT}" config 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "config: theme override exits 0"
+assert_grep "config: HERDR_THEME_DARK renders name" '^name = "nord"$' "${CFG_DIR2}/config.toml"
+assert_grep "config: HERDR_THEME_DARK renders dark_name" '^dark_name = "nord"$' "${CFG_DIR2}/config.toml"
+assert_grep "config: HERDR_THEME_LIGHT renders light_name" '^light_name = "one-light"$' "${CFG_DIR2}/config.toml"
+
+# 9. A hand-edited config (no managed marker) is left alone, with a warning.
+CFG_DIR3="${TMP}/cfg-hand"
+mkdir -p "${CFG_DIR3}"
+printf '[theme]\nname = "dracula"\n' > "${CFG_DIR3}/config.toml"
+out="$(HERDR_INSTALL_DIR="${EMPTY_DIR}" HERDR_CONFIG_DIR="${CFG_DIR3}" bash "${SCRIPT}" config 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "config: hand-edited file -> exit 0"
+assert_grep "config: hand-edited file is untouched" '^name = "dracula"$' "${CFG_DIR3}/config.toml"
+assert_eq "$(printf '%s' "${out}" | grep -c 'leaving it alone')" "1" "config: hand-edited file is reported, not clobbered"
+assert_eq "$(printf '%s' "${out}" | grep -c 'HERDR_CONFIG_FORCE=1')" "1" "config: warning names the override"
+
+# 10. HERDR_CONFIG_FORCE=1 replaces a hand-edited file but keeps a backup.
+out="$(HERDR_INSTALL_DIR="${EMPTY_DIR}" HERDR_CONFIG_DIR="${CFG_DIR3}" HERDR_CONFIG_FORCE=1 bash "${SCRIPT}" config 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "config: force exits 0"
+assert_grep "config: force writes the managed file" '^# managed by dotfiles' "${CFG_DIR3}/config.toml"
+assert_grep "config: force keeps a backup of the hand-edited file" '^name = "dracula"$' "${CFG_DIR3}/config.toml.bak"
+
+# 11. A running server (socket present) is reloaded best-effort after a write.
+CFG_DIR4="${TMP}/cfg-live"
+mkdir -p "${CFG_DIR4}"; : > "${CFG_DIR4}/herdr.sock"
+out="$(HERDR_INSTALL_DIR="${STUB_DIR}" HERDR_CONFIG_DIR="${CFG_DIR4}" bash "${SCRIPT}" config 2>&1)"; rc=$?
+assert_eq "${rc}" "0" "config: live server path exits 0"
+assert_eq "$(printf '%s' "${out}" | grep -c 'stub: herdr server reload-config')" "1" \
+    "config: running server gets 'herdr server reload-config'"
+
 # --- gff wiring -------------------------------------------------------------
 assert_grep "features.yaml declares install.tools.herdr" 'path: install\.tools\.herdr$' "${FEATURES}"
 assert_grep "features.yaml declares install.tools.herdr-integrations" \
@@ -124,6 +193,11 @@ assert_grep "features.yaml declares install.tools.herdr-integrations" \
 assert_grep "install.sh gates the binary on install.tools.herdr" 'gff_on install\.tools\.herdr;' "${INSTALL_SH}"
 assert_grep "install.sh gates integrations on install.tools.herdr-integrations" \
     'gff_on install\.tools\.herdr-integrations;' "${INSTALL_SH}"
+assert_grep "features.yaml declares install.tools.herdr-config" \
+    'path: install\.tools\.herdr-config$' "${FEATURES}"
+assert_grep "install.sh gates the managed config on install.tools.herdr-config" \
+    'gff_on install\.tools\.herdr-config;' "${INSTALL_SH}"
+assert_grep "install.sh runs install_herdr.sh in config mode" 'install_herdr\.sh" config' "${INSTALL_SH}"
 
 # Phase lists: a downloaded CLI is a deps step; writing into ~/.claude and
 # ~/.gemini is a config step. A key in NEITHER list runs in BOTH phases (the
@@ -138,6 +212,10 @@ assert_eq "$(printf '%s' "${config_line}" | grep -c -w 'INSTALL_TOOLS_HERDR_INTE
     "INSTALL_TOOLS_HERDR_INTEGRATIONS is in _IP_CONFIG_FLAGS"
 assert_eq "$(printf '%s' "${deps_line}" | grep -c -w 'INSTALL_TOOLS_HERDR_INTEGRATIONS')" "0" \
     "INSTALL_TOOLS_HERDR_INTEGRATIONS is NOT in _IP_DEPS_FLAGS"
+assert_eq "$(printf '%s' "${config_line}" | grep -c -w 'INSTALL_TOOLS_HERDR_CONFIG')" "1" \
+    "INSTALL_TOOLS_HERDR_CONFIG is in _IP_CONFIG_FLAGS"
+assert_eq "$(printf '%s' "${deps_line}" | grep -c -w 'INSTALL_TOOLS_HERDR_CONFIG')" "0" \
+    "INSTALL_TOOLS_HERDR_CONFIG is NOT in _IP_DEPS_FLAGS"
 
 # Ordering: the integrations block must come after install_antigravity_skills.sh
 # is invoked, or the hooks.json re-render undoes it on every run.


### PR DESCRIPTION
## Why

herdr paints its own sidebar and panel colors. Its default dark catppuccin theme rendered as unreadable dark-on-grey text on the Windows Terminal **Solarized Light** profile. The same distro is opened from both Solarized Dark and Solarized Light profiles, so an install-time light/dark guess would be wrong half the time.

herdr can ask the host terminal for its appearance itself (DEC 2031 color-scheme reports). Verified against Windows Terminal from inside a herdr pane: `CSI ? 996 n` answers light, `OSC 11` answers `#fdf6e3` (Solarized base3), and the answer does not change when herdr's own theme is swapped, so it is real host detection.

## What

**Commit 1: managed config**

- **`ai/herdr/config.toml`**, a managed template rendered into `~/.config/herdr/config.toml`:
  - `[theme]` `name = "solarized"` (fallback when the host does not report), `auto_switch = true`, `light_name = "solarized-light"`, `dark_name = "solarized"`. Same Solarized pair as `terminal-theme.sh` and the Windows Terminal profiles from `setup-apps.ps1`.
  - `[keys]` `prefix = "ctrl+a"`. herdr's default `ctrl+b` is also tmux's default, which the herdr design doc flagged as a clash. `ctrl+a ctrl+a` sends a literal ctrl+a to the pane.
- **`install_herdr.sh config`** (new mode, config phase): renders the template (XDG-aware config dir). The host owns the file: written when missing or while the `managed by dotfiles` marker is present; a hand-edited file without the marker is left alone with a warning; `HERDR_CONFIG_FORCE=1` reclaims it and keeps a `.bak`. Theme overrides via `HERDR_THEME_DARK` / `HERDR_THEME_LIGHT` (validated `[a-z0-9-]+`). Write-then-rename, then `herdr server reload-config` best-effort when a server socket exists, so a live session picks it up.
- **gff** `install.tools.herdr-config` (config phase; `INSTALL_TOOLS_HERDR_CONFIG` in `_IP_CONFIG_FLAGS`) and an `install.sh` block after the integrations block. Tools count comment bumped to 9.

**Commit 2: `ai/skills/herdr`, the herdr counterpart of the tmux skill**

- **`SKILL.md`**: `HERDR_ENV` gate, a tmux-mgr to herdr verb map (herdr's CLI already covers sessions, splits, capture, agent start/wait/read), the auto_switch theme trap, the full 0.8.2 theme list including the dark-only ones, and the host-local rule: everything the skill writes lives under `~/.config/herdr/`, never in the repo.
- **`scripts/herdr-layout`** `save|restore|list|show|delete <name>`: named tab layouts via the socket API's `layout.export` / `layout.apply` (herdr has no `layout` CLI). Save strips ephemeral `pane_id`s; restore creates a new background tab (`--focus`, `--replace-tab`, `--workspace`, `--label`) and does not carry running processes.
- **`scripts/herdr-prefs`** `status|get|set|reset`: host-local `config.toml` edits. `set` rewrites one `section.key` in place (comments kept), drops the managed marker so `install.sh` leaves the file alone, and reloads a running server. `status` reports the host's light/dark report so agents do not guess which auto_switch sibling applies. `reset` re-renders the baseline with a `.bak`.
- **`evals/evals.json`**: 6 cases, `make skill-evals` PASS.
- **Skill TDD**: a fresh agent without the skill spent ~4 min rediscovering the socket, wrote its own client, never tested restore, and told the user to hand-edit TOML. With the skill it completed both tasks, exercised restore, and caught the auto_switch trap; its review drove the final doc refactors.

**Both**: `docs/mbo/designs/herdr.md` marks the prefix clash resolved and closes the config-tracking and skill follow-ups.

## Tests

- `install_herdr_test.sh`: 69 checks (38 new): template shape, fresh seed, converge no-op, overrides, hand-edited skip, force + backup, live-server reload, gff wiring and phase lists.
- `ai/skills/herdr/scripts/herdr-skill_test.sh`: 70 checks against a fake newline-JSON socket server: missing socket, save/restore/list/show/delete, server errors, name validation, prefs get/set/append/new-section/ownership handoff/reload/reset, SKILL.md shape.
- Live on 0.8.2: rendered config passes `herdr config check`; `herdr-layout restore` creates the tab and reports `layout.tab_id`; `herdr-prefs status` reads `host appearance: light` from a real pane.
- `install_test.sh` 21/21, `make skill-evals` OK, shellcheck clean. `make shell-test`: 43 of 44 drivers pass; `macos-keys-linux_test.sh` fails identically on `main`.

## Review guide

1. `ai/herdr/config.toml`: the two theme names and the prefix are the only policy here.
2. `install_herdr.sh` `install_config()`: the marker rule and the force/backup path.
3. `ai/skills/herdr/scripts/herdr-prefs` `toml_set`: the line-based TOML edit and the ownership handoff.
4. `ai/skills/herdr/SKILL.md`: the theme-trap section is the part agents get wrong without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9bEFfvar8H2gbbeuKx58f

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **herdr**.

- **#282 — edward-raigosa/theme (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->
