### PR TITLE
fix(fleet): stop the TUI frame outgrowing the terminal and eating the header

### DIFF
--- a/sdk/fleet/AGENTS.md
+++ b/sdk/fleet/AGENTS.md
@@ -420,6 +420,29 @@ I/O are all injected), so the decision surface is unit-tested without opening a 
 - **Branch costs no extra round-trip.** The live checked-out branch rides in the *same*
   remote command as the stamp read, split on `probeDelim`. A second dial per host would
   double the poll for one column. Pinned by `TestBranchCostsNoExtraRoundTrip`.
+- **The frame must never be taller than the terminal.** bubbletea's standard renderer
+  drops lines from the TOP of an over-tall frame ("we can't navigate the cursor into the
+  terminal's scrollback buffer"), so a single row of overflow silently walks the banner off
+  the screen — which is what an operator sees as "the window shifted up and ate the header"
+  during a multi-host update. Three things kept it from fitting, and all three are now
+  structural rather than arithmetic: **(a)** lipgloss counts horizontal padding INSIDE
+  `Style.Width`, so a panel declared `Width(n)` with `Padding(0, 1)` gives content only
+  `n-2` cells — `panelInner()` is that number and `renderPanel` clamps every line to it, so
+  a long log line can no longer wrap onto a second row; **(b)** the log pane's height is
+  MEASURED against the already-rendered banner, list and status blocks rather than predicted
+  from a constant (the old `- 10` was three short: the banner had grown a row and the panels
+  had grown borders); **(c)** a style is never applied to already-rendered text — lipgloss
+  re-styles character by character, so nesting stranded the streaming legend's escape bytes,
+  printed them as literal `[38;5;33mhost-nano[0m`, and counted them as visible cells.
+  `View()` then verifies rather than trusts: it hands log rows back until the frame fits,
+  drops the pane entirely for a dialog that outgrows it, and `fitFrame` clips the BOTTOM as
+  a last resort so the header is never what is lost. Prose dialogs (`wrapPanel`) still wrap
+  — losing the tail of the force-reset warning is worse than spending a row — and their
+  height is measured, so they cost the log pane rather than the banner. Pinned by
+  `TestViewNeverExceedsTerminalHeight`, `TestViewFitsAcrossEveryTerminalSize` (1219 sizes),
+  `TestLogTitleNeverNestsStyles`,
+  `TestHelpOverlayOnAShortTerminalSaysWhatItHidRatherThanOverflowing`, and the height guard
+  in `TestDemoFrames` — the twin of the width guard, whose absence is why this shipped.
 - **Row width is derived, not guessed.** `rowPrefixWidth` sums the same numbers as
   `rowView`'s format string and `failWidth` budgets from it; the failure cause is dropped
   rather than clamped to a floor when nothing fits. Adding the BRANCH column against a

--- a/sdk/fleet/cmd/tui_demo_test.go
+++ b/sdk/fleet/cmd/tui_demo_test.go
@@ -32,7 +32,11 @@ func TestDemoFrames(t *testing.T) {
 	build := func() tuiModel {
 		m := newTUIModel(hosts("host-desktop", "host-nano", "host-pi", "host-edge", "host-lab"),
 			nil, base, testNow, "main", 2, updplan.Default())
-		m.vp = viewport{height: 16, width: 100}
+		// 13 of these rows are chrome with the log pane open-but-empty
+		// (banner 5 + list frame 3 + collapsed-hint frame 3 + blank + status),
+		// so five hosts need 18. The old 16 only ever "fit" because the frame
+		// overflowed the terminal and bubbletea scrolled the banner away.
+		m.vp = viewport{height: 20, width: 100}
 		return m
 	}
 
@@ -159,6 +163,14 @@ func TestDemoFrames(t *testing.T) {
 				t.Errorf("frame %q line too wide (%d): %q", f.name, w, line)
 			}
 		}
+		// The height guard is the twin of the width one, and the reason the
+		// banner used to disappear mid-update: bubbletea drops lines from the
+		// TOP of a frame taller than the terminal, so one row of overflow
+		// costs the operator the header.
+		if h := lipgloss.Height(out); h > m.vp.height {
+			t.Errorf("frame %q too tall (%d lines for a %d-line terminal; %d scrolled off the top):\n%s",
+				f.name, h, m.vp.height, h-m.vp.height, out)
+		}
 		if demo {
 			fmt.Printf("\n\033[1;33m━━━ %s ━━━\033[0m\n%s\n", f.name, out)
 		}
@@ -172,7 +184,7 @@ var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
 func build2Empty() tuiModel {
 	m := newTUIModel(nil, nil, fakeBaseline{head: "72392c9"}, testNow, "main", 2, updplan.Default())
-	m.vp = viewport{height: 16, width: 100}
+	m.vp = viewport{height: 20, width: 100}
 	return m
 }
 

--- a/sdk/fleet/cmd/tui_layout_test.go
+++ b/sdk/fleet/cmd/tui_layout_test.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updplan"
+)
+
+// layoutModel is a settled five-host fleet at a fixed terminal size, the shape
+// an operator actually watches an update from.
+func layoutModel(h, w int) tuiModel {
+	m := newTUIModel(hosts("host-desktop", "host-nano", "host-pi", "host-edge", "host-lab"),
+		nil, fakeBaseline{head: "72392c9"}, testNow, "main", 2, updplan.Default())
+	m.vp = viewport{height: h, width: w}
+	for _, r := range []Row{
+		{Alias: "host-desktop", Class: "up-to-date", Commit: "72392c9", Age: testNow.Add(-2 * time.Hour), Branch: "main", InstalledBranch: "main"},
+		{Alias: "host-nano", Class: "behind", Behind: 24, Commit: "9484943", Age: testNow.Add(-16 * 24 * time.Hour), Branch: "main", InstalledBranch: "main"},
+		{Alias: "host-pi", Class: "unreachable"},
+		{Alias: "host-edge", Class: "unknown", Note: "corrupt stamp"},
+		{Alias: "host-lab", Class: "divergent", Commit: "abc1234", Age: testNow.Add(-3 * time.Hour), Branch: "feature/gff", InstalledBranch: "main"},
+	} {
+		m.setRow(r)
+		delete(m.pending, r.Alias)
+	}
+	m.resort()
+	return m
+}
+
+// TestViewNeverExceedsTerminalHeight is the guard for the scrolled-header bug.
+//
+// bubbletea's standard renderer drops lines from the TOP of the frame when the
+// view is taller than the terminal ("we can't navigate the cursor into the
+// terminal's scrollback buffer"), so one line of overflow silently eats the
+// banner. Every state below must therefore fit in vp.height EXACTLY.
+func TestViewNeverExceedsTerminalHeight(t *testing.T) {
+	long := strings.Repeat("x", 300)
+	states := []struct {
+		name string
+		mut  func(m *tuiModel)
+	}{
+		{"idle, log pane closed", func(m *tuiModel) { m.logOpen = false }},
+		{"log pane open but empty", func(m *tuiModel) { m.logOpen = true }},
+		{"update streaming, short lines", func(m *tuiModel) {
+			m.logOpen = true
+			m.streams = map[string]stream{"host-nano": {}}
+			for i := 0; i < 60; i++ {
+				m.appendLog("host-nano", fmt.Sprintf("Installing package %d...", i))
+			}
+		}},
+		{"update streaming from five hosts at once", func(m *tuiModel) {
+			m.logOpen = true
+			m.streams = map[string]stream{"host-nano": {}, "host-pi": {},
+				"host-edge": {}, "host-lab": {}, "host-desktop": {}}
+			for i := 0; i < 60; i++ {
+				m.appendLog("host-nano", fmt.Sprintf("Installing package %d...", i))
+			}
+		}},
+		{"update streaming with line-wrapping output", func(m *tuiModel) {
+			m.logOpen = true
+			m.streams = map[string]stream{"host-nano": {}, "host-pi": {}}
+			for i := 0; i < 60; i++ {
+				m.appendLog("host-nano", long)
+				m.appendLog("host-pi", long)
+			}
+		}},
+		{"confirm gate over a running update", func(m *tuiModel) {
+			m.logOpen = true
+			m.mode = modeConfirm
+			m.ans = answers{sudoSecret: "xxxx", windows: "s", gemini: "keep", reset: "y"}
+			m.selected = map[string]bool{"host-nano": true, "host-pi": true}
+			for i := 0; i < 60; i++ {
+				m.appendLog("host-nano", long)
+			}
+		}},
+		{"answers form over a running update", func(m *tuiModel) {
+			m.logOpen = true
+			m.mode = modeAnswers
+			for i := 0; i < 60; i++ {
+				m.appendLog("host-nano", long)
+			}
+		}},
+		{"long-lined update, log focused and scrolled", func(m *tuiModel) {
+			m.logOpen = true
+			m.logFocus = true
+			m.logFollow = false
+			m.logTop = 5
+			for i := 0; i < 60; i++ {
+				m.appendLog("host-nano", long)
+			}
+		}},
+	}
+	sizes := [][2]int{{24, 80}, {26, 100}, {40, 100}, {50, 120}, {14, 60}}
+
+	for _, s := range states {
+		for _, sz := range sizes {
+			m := layoutModel(sz[0], sz[1])
+			s.mut(&m)
+			out := m.View()
+			if got := lipgloss.Height(out); got > m.vp.height {
+				t.Errorf("%s at %dx%d: frame is %d lines for a %d-line terminal "+
+					"(%d would be scrolled off the top)",
+					s.name, sz[1], sz[0], got, m.vp.height, got-m.vp.height)
+			}
+			for _, line := range strings.Split(out, "\n") {
+				if wdt := lipgloss.Width(line); wdt > m.vp.width {
+					t.Errorf("%s at %dx%d: line too wide (%d): %q",
+						s.name, sz[1], sz[0], wdt, stripANSI(line))
+				}
+			}
+		}
+	}
+}
+
+// TestViewFitsAcrossEveryTerminalSize sweeps the sizes an operator can actually
+// drag a window to, in the state that produced the report: several hosts
+// streaming at once, with output long enough to wrap. Every frame must fit.
+func TestViewFitsAcrossEveryTerminalSize(t *testing.T) {
+	for h := 8; h <= 60; h++ {
+		for w := 40; w <= 200; w += 7 {
+			m := layoutModel(h, w)
+			m.logOpen = true
+			m.streams = map[string]stream{"host-nano": {}, "host-pi": {}, "host-edge": {}}
+			for i := 0; i < 40; i++ {
+				m.appendLog("host-nano", strings.Repeat("x", 250))
+				m.appendLog("host-pi", fmt.Sprintf("Installing package %d...", i))
+			}
+			out := m.View()
+			if got := lipgloss.Height(out); got > h {
+				t.Fatalf("%dx%d: frame is %d lines, %d would be scrolled off the top",
+					w, h, got, got-h)
+			}
+			for _, line := range strings.Split(out, "\n") {
+				if wd := lipgloss.Width(line); wd > w {
+					t.Fatalf("%dx%d: line too wide (%d): %q", w, h, wd, stripANSI(line))
+				}
+			}
+		}
+	}
+}
+
+// A style must never be applied to already-rendered text. lipgloss re-styles
+// character by character, so nesting strands the inner escape bytes: the log
+// pane printed a literal "[38;5;33mhost-nano[0m" in its streaming legend, and
+// those orphaned codes counted as visible cells — which is how a wave across
+// several hosts pushed the title onto a second row and grew the frame.
+func TestLogTitleNeverNestsStyles(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	defer lipgloss.SetColorProfile(termenv.Ascii)
+
+	m := layoutModel(40, 100)
+	m.logOpen = true
+	m.streams = map[string]stream{"host-nano": {}, "host-pi": {}, "host-edge": {}}
+	m.appendLog("host-nano", "Installing 28 core packages via apt...")
+
+	// stripANSI removes well-formed SGR runs; anything colour-code-shaped left
+	// behind was printed as literal text by a nested Render.
+	if got := stripANSI(m.logView()); strings.Contains(got, "38;5;") {
+		t.Fatalf("nested style leaked escape codes as text:\n%q", got)
+	}
+	if !strings.Contains(stripANSI(m.logView()), "streaming: host-edge, host-nano, host-pi") {
+		t.Fatalf("the streaming legend must name every live host:\n%s", stripANSI(m.logView()))
+	}
+}

--- a/sdk/fleet/cmd/tui_logpane_test.go
+++ b/sdk/fleet/cmd/tui_logpane_test.go
@@ -93,10 +93,12 @@ func TestLogPaneTogglesAndRestoresFullHeight(t *testing.T) {
 }
 
 // Even on a short terminal the split must leave both halves usable rather
-// than collapsing the list to zero rows.
+// than collapsing the list to zero rows. 15 rows is the floor at which that is
+// possible at all: 13 go to chrome (banner 5 + list frame 3 + log frame 3 +
+// blank + status), leaving one row each.
 func TestSplitKeepsBothHalvesUsableOnASmallTerminal(t *testing.T) {
 	m := testModel("a", "b")
-	mm, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 12})
+	mm, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 16})
 	open := mm.(tuiModel)
 	open.appendLog("a", "line") // make the pane active
 	if open.visibleRows() < 1 || open.logHeight() < 1 {

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/drift"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/reach"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/runner"
@@ -731,41 +732,51 @@ func (m tuiModel) tailFor(alias string, n int) string {
 // fifth to display nothing.
 func (m tuiModel) logActive() bool { return m.logOpen && len(m.logs) > 0 }
 
-// logHeight splits the frame: the host list keeps the top fifth (floor of 3
-// rows so it never collapses) and the log takes the rest.
+// bannerHeight is the intro panel: three hint lines inside two border rows.
+// It is a constant because renderPanel clamps each line to one row, so the
+// banner cannot grow no matter how many keys headerHints has to advertise.
+const bannerHeight = 3 + 2
+
+// listPanelChrome is the host table's two border rows plus its column header.
+const listPanelChrome = 2 + 1
+
+// listChrome is everything a host row must be paid for out of. The tail is
+// measured rather than counted: the answers form and the confirm gate render
+// where the one-line status bar normally sits.
+func (m tuiModel) listChrome() int {
+	return bannerHeight + listPanelChrome + m.tailHeight()
+}
+
+// logHeight is the rows the streaming pane gets. It MEASURES the blocks above
+// it instead of predicting them: the arithmetic here has silently drifted
+// before (a banner row, then panel borders), and every line of overflow is
+// paid for by bubbletea dropping the banner off the top of the frame.
 func (m tuiModel) logHeight() int {
-	if !m.logOpen {
-		return 0
+	if !m.logOpen || !m.logActive() {
+		return 0 // hidden, or collapsed to a single framed hint; no rows
 	}
-	if !m.logActive() {
-		return 0 // collapsed to a single unframed hint line; no rows reserved
-	}
-	h := m.vp.height - m.listHeight() - 10 // both panels' borders + chrome
-	if h < 3 {
-		h = 3
-	}
-	return h
+	return max0(m.vp.height - lipgloss.Height(m.banner()) -
+		lipgloss.Height(m.listPanel()) - logPanelChrome - m.tailHeight())
 }
 
 // listHeight is the rows available to the host table.
 func (m tuiModel) listHeight() int {
 	if !m.logActive() {
-		// Closed, or open-but-empty: the list keeps everything except the
-		// couple of lines the collapsed hint occupies.
-		h := m.vp.height - 7 // chrome + the list panel's own border
+		// Closed, or open-but-empty: the list keeps everything the fixed
+		// chrome does not need.
+		h := m.vp.height - m.listChrome()
 		if m.logOpen {
-			h -= 3 // the collapsed hint line and its frame
+			h -= logPanelChrome // the collapsed hint line and its frame
 		}
-		if h < 1 {
-			h = 1
-		}
-		return h
+		return maxInt(1, h)
 	}
 	h := m.vp.height/5 - 2 // top ~20% once logs are flowing, less its border
 	if h < 3 {
 		h = 3
 	}
-	return h
+	// The list's floor must never push the log pane off the bottom: leave it
+	// at least its frame plus one line of output.
+	return maxInt(1, minInt(h, m.vp.height-m.listChrome()-logPanelChrome-1))
 }
 
 // ---- log navigation -------------------------------------------------------

--- a/sdk/fleet/cmd/tui_model_test.go
+++ b/sdk/fleet/cmd/tui_model_test.go
@@ -188,8 +188,10 @@ func TestWindowResizeKeepsCursorVisible(t *testing.T) {
 
 func TestHalfPageMovesAndStaysInBounds(t *testing.T) {
 	m := testModel("a", "b", "c", "d", "e", "f", "g", "h")
-	mm, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 13}) // 6 list rows once framed
-	m2, _ := send(mm.(tuiModel), "l")                           // hide the log pane so the math is the list's alone
+	// 10 rows are chrome once the log pane is hidden (banner 5 + list frame 3
+	// + blank + status), so 16 is what leaves the 6 list rows this asserts on.
+	mm, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 16})
+	m2, _ := send(mm.(tuiModel), "l") // hide the log pane so the math is the list's alone
 	m3, _ := send(m2, "ctrl+d")
 	if m3.indexOf(m3.cursor) != 3 {
 		t.Fatalf("ctrl+d should move half a page (3), got %d", m3.indexOf(m3.cursor))
@@ -499,7 +501,11 @@ func TestSSHIsBlockedWhileThatHostUpdates(t *testing.T) {
 
 func TestHelpOverlayRendersEveryKeyAndClosesOnAnyKey(t *testing.T) {
 	m := testModel("a")
-	m2, _ := send(m, "?")
+	// Tall enough for all of keyHelp: the overlay is budgeted now (banner 5 +
+	// its own 2 border rows + title, blank, blank, footer), so a short terminal
+	// shows a "… N more" line instead of running off the bottom.
+	tall, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: len(keyHelp) + 11})
+	m2, _ := send(tall.(tuiModel), "?")
 	view := m2.View()
 	for _, k := range keyHelp {
 		if !strings.Contains(view, k.keys) {
@@ -512,6 +518,27 @@ func TestHelpOverlayRendersEveryKeyAndClosesOnAnyKey(t *testing.T) {
 	}
 	if m3.indexOf(m3.cursor) != 0 {
 		t.Fatal("the closing key must not also act as a motion")
+	}
+}
+
+// On a terminal too short for 24 keys the overlay says so rather than growing
+// past the bottom — an overlay taller than the screen is scrolled from the TOP
+// by bubbletea, which hides the heading and the first keys.
+func TestHelpOverlayOnAShortTerminalSaysWhatItHidRatherThanOverflowing(t *testing.T) {
+	m := testModel("a")
+	short, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 20})
+	m2, _ := send(short.(tuiModel), "?")
+	view := m2.View()
+	if h := lipgloss.Height(view); h > 20 {
+		t.Fatalf("help overlay is %d lines on a 20-line terminal:\n%s", h, view)
+	}
+	if !strings.Contains(stripANSI(view), "more — make the window taller") {
+		t.Fatalf("a clamped overlay must name what it hid:\n%s", view)
+	}
+	// The clamp must fit the whole panel, border included — a frame cut by
+	// fitFrame would leave the box hanging open at the bottom of the screen.
+	if !strings.HasSuffix(strings.TrimRight(stripANSI(view), "\n"), "╯") {
+		t.Fatalf("the clamped overlay lost its bottom border:\n%s", view)
 	}
 }
 

--- a/sdk/fleet/cmd/tui_view.go
+++ b/sdk/fleet/cmd/tui_view.go
@@ -88,23 +88,92 @@ func (m tuiModel) banner() string {
 	b.WriteString(th.title.Render("🛰️  "+versionString()) + "\n")
 	b.WriteString(th.dim.Render(headerHints(0)) + "\n")
 	b.WriteString(th.dim.Render(headerHints(1)))
-	return th.panel.Width(m.panelWidth()).Render(b.String())
+	return m.renderPanel(th.panel, b.String())
+}
+
+// fitFrame is the last resort, and it decides WHICH end of an over-tall frame
+// is lost. bubbletea drops lines from the top — "we can't navigate the cursor
+// into the terminal's scrollback buffer" — which takes the banner and leaves
+// the operator looking at a dashboard whose header has silently walked off.
+// Keeping the first vp.height lines loses the bottom instead, which is at
+// least visible and at least stationary.
+func (m tuiModel) fitFrame(out string) string {
+	if m.vp.height < 1 || lipgloss.Height(out) <= m.vp.height {
+		return out
+	}
+	return strings.Join(strings.Split(out, "\n")[:m.vp.height], "\n")
 }
 
 func (m tuiModel) View() string {
-	var b strings.Builder
-	b.WriteString(m.banner())
-	b.WriteString("\n")
+	head := m.banner() + "\n"
 
 	if m.mode == modeHelp {
-		return b.String() + m.helpView()
+		return m.fitFrame(head + m.helpView())
 	}
 	if len(m.rows) == 0 {
 		empty := "no fleet hosts found\n" + th.dim.Render(
 			"run `fleet discover` to see adoptable ssh-config hosts, then `fleet add <alias>`")
-		return b.String() + th.panel.Width(m.panelWidth()).Render(empty) + "\n"
+		return m.fitFrame(head + m.wrapPanel(th.panel, empty) + "\n")
 	}
 
+	body := head + m.listPanel() + "\n"
+	tail := "\n" + m.statusView()
+
+	if !m.logOpen {
+		return m.fitFrame(body + tail)
+	}
+
+	// A blank line separates the log pane from the status bar, as it does when
+	// the pane is hidden.
+	compose := func(rows int) string { return body + m.logViewN(rows) + "\n" + tail }
+
+	// The log pane is the elastic block, so it gets whatever the fixed blocks
+	// leave rather than a predicted share. Every other height in this file has
+	// drifted at least once — the banner grew a row, the panels grew borders —
+	// and measuring what is already rendered cannot drift.
+	rows := m.logHeight()
+	out := compose(rows)
+
+	// One corrective pass lands on the exact fit; four is slack for a pane that
+	// has fewer lines than the budget and so stops growing.
+	for i, prev := 0, -1; i < 4; i++ {
+		h := lipgloss.Height(out)
+		if h == m.vp.height || h == prev {
+			break
+		}
+		next := max0(rows + m.vp.height - h)
+		if next == rows {
+			break
+		}
+		prev, rows = h, next
+		out = compose(rows)
+	}
+
+	// Belt and braces. bubbletea's renderer drops lines from the TOP of a frame
+	// that is too tall, so overflow is paid for with the banner — the one thing
+	// on screen that must never move. Hand back log rows until it fits: losing
+	// a line of output is always the better trade.
+	for rows > 0 {
+		over := lipgloss.Height(out) - m.vp.height
+		if over <= 0 {
+			break
+		}
+		rows = max0(rows - over)
+		out = compose(rows)
+	}
+	// An open answers form or confirm gate is a whole framed dialog where the
+	// status bar normally sits, and on a short terminal it can outgrow what the
+	// log pane has left to give. The pane is the thing to spend: the dialog is
+	// what the operator is answering, and its idle hint says nothing.
+	if lipgloss.Height(out) > m.vp.height {
+		out = body + tail
+	}
+	return m.fitFrame(out)
+}
+
+// listPanel is the framed host table: column header plus the visible slice of
+// rows, ending without a trailing newline like every other panel.
+func (m tuiModel) listPanel() string {
 	var list strings.Builder
 	// The header carries the SAME prefix width as a row (cursor + dot + space),
 	// or every column label sits four cells left of the data under it.
@@ -118,15 +187,9 @@ func (m tuiModel) View() string {
 		end = len(m.rows)
 	}
 	for i := m.vp.top; i < end; i++ {
-		list.WriteString(trunc(m.rowView(i), m.panelWidth()) + "\n")
+		list.WriteString(trunc(m.rowView(i), m.panelInner()) + "\n")
 	}
-	b.WriteString(th.panel.Width(m.panelWidth()).Render(strings.TrimRight(list.String(), "\n")) + "\n")
-
-	if m.logOpen {
-		b.WriteString(m.logView() + "\n")
-	}
-	b.WriteString("\n" + m.statusView())
-	return b.String()
+	return m.renderPanel(th.panel, strings.TrimRight(list.String(), "\n"))
 }
 
 // logView is the framed streaming pane. It sits BELOW the host list rather
@@ -166,19 +229,35 @@ func shortWhat(s string) string {
 	return s
 }
 
-func (m tuiModel) logView() string {
-	h := m.logHeight()
+// logView renders the pane at its predicted height. View() calls logViewN
+// with a measured budget instead; this shorthand keeps the pane renderable on
+// its own (tests, and any caller that only wants the section).
+func (m tuiModel) logView() string { return m.logViewN(m.logHeight()) }
+
+// logPanelChrome is what the log pane costs before a single line of output:
+// its two border rows plus the title/mode/keys row.
+const logPanelChrome = 3
+
+func (m tuiModel) logViewN(h int) string {
+	if h < 0 {
+		h = 0
+	}
 	var body strings.Builder
 
 	live := m.liveAliases()
-	title := "logs"
+	// The label is styled, the aliases keep their OWN colours, and the two are
+	// concatenated — never nested. lipgloss re-styles a string character by
+	// character, so wrapping already-rendered text strands its escape bytes:
+	// the pane printed a literal "[38;5;33mhost-nano[0m" and the orphaned
+	// codes counted as visible cells, which is what pushed the title onto a
+	// second row once several hosts were streaming at once.
+	title := th.header.Render("logs")
 	if len(live) > 0 {
-		// The legend is coloured to match the lines, so it doubles as a key.
 		coloured := make([]string, 0, len(live))
 		for _, a := range live {
 			coloured = append(coloured, m.hostStyle(a).Render(a))
 		}
-		title = "logs — streaming: " + strings.Join(coloured, ", ")
+		title = th.header.Render("logs — streaming:") + " " + strings.Join(coloured, ", ")
 	}
 	mode := "following"
 	if !m.logFollow {
@@ -193,12 +272,12 @@ func (m tuiModel) logView() string {
 			keys += th.dim.Render("   /" + m.logSearch.input)
 		}
 	}
-	body.WriteString(th.header.Render(title) + th.dim.Render("   "+mode+"   ") + keys + "\n")
+	body.WriteString(title + th.dim.Render("   "+mode+"   ") + keys + "\n")
 
 	if !m.logActive() {
 		// Collapsed to a single framed line: still visibly its own section, but
 		// it must not cost the fleet view a fifth of the screen to say nothing.
-		return th.panel.Width(m.panelWidth()).Render(
+		return m.renderPanel(th.panel,
 			th.dim.Render("📜 logs: idle — output appears here during an update  (l: hide)"))
 	}
 
@@ -221,7 +300,7 @@ func (m tuiModel) logView() string {
 			m.hostStyle(e.alias).Render(fmt.Sprintf("%-14s│", trunc(e.alias, 14))),
 			text)
 	}
-	return th.panel.Width(m.panelWidth()).Render(strings.TrimRight(body.String(), "\n"))
+	return m.renderPanel(th.panel, strings.TrimRight(body.String(), "\n"))
 }
 
 // logStart is the first visible line: pinned to the tail while following, so
@@ -251,16 +330,18 @@ func (m tuiModel) logStart(h int) int {
 	return m.logTop
 }
 
-// logGutter is the timestamp + host columns and their separators.
-const logGutter = 8 + 1 + 14 + 1 + 1 + 1
+// logGutter is everything a log line prints before the text, summed from the
+// same numbers as the Fprintf in logViewN:
+//
+//	8 stamp + 1 space + 14 alias + 1 separator + 1 space
+//
+// Keep it in sync with that format string.
+const logGutter = 8 + 1 + 14 + 1 + 1
 
-func (m tuiModel) logWidth() int {
-	w := m.vp.width - 4
-	if w < 40 {
-		w = 40
-	}
-	return w
-}
+// logWidth is the room a log line has: the panel's real content width, not the
+// terminal's. A line budgeted against anything wider wraps inside the frame
+// and silently costs the pane an extra row.
+func (m tuiModel) logWidth() int { return m.panelInner() }
 
 // liveAliases names the hosts currently streaming, so the pane header says
 // whose output is arriving when several run at once.
@@ -433,7 +514,7 @@ const rowPrefixWidth = 3 + 1 + aliasColWidth + 1 + 9 + 1 + branchColWidth + 1 + 
 // PANEL's inner width, not the raw terminal: rows are framed now, so the
 // border and padding are not available to the row.
 func (m tuiModel) failWidth() int {
-	return m.panelWidth() - rowPrefixWidth - len(failPrefix)
+	return m.panelInner() - rowPrefixWidth - len(failPrefix)
 }
 
 func truncate(s string, n int) string {
@@ -513,17 +594,58 @@ func (m tuiModel) answersView() string {
 	// "up" would silently select the wrong answer. Arrows are the idiom the
 	// host list already uses.
 	b.WriteString("\n" + th.dim.Render("↑/↓ or tab: field   letters set the answer   enter: next   esc: cancel"))
-	return th.panel.Width(m.panelWidth()).Render(b.String())
+	return m.wrapPanel(th.panel, b.String())
 }
 
-// panelWidth is the inner width every framed section shares, so their borders
-// line up into a single column instead of a ragged stack.
+// panelWidth is the width every framed section declares, so their borders line
+// up into a single column instead of a ragged stack. It is what lipgloss is
+// told, NOT what content gets: see panelInner.
 func (m tuiModel) panelWidth() int {
 	w := m.vp.width - 4
 	if w < 20 {
 		w = 20
 	}
 	return w
+}
+
+// panelPad is the horizontal padding on both framed styles (Padding(0, 1)).
+const panelPad = 2
+
+// panelInner is the width actually available to a panel's CONTENT.
+//
+// lipgloss counts horizontal padding INSIDE Style.Width, so a panel declared
+// Width(n) with Padding(0, 1) leaves n-2 cells for text. Treating panelWidth
+// as the content budget is what let a log line land in those last two cells,
+// wrap onto a second row, and push the whole frame past the terminal height —
+// at which point bubbletea drops lines from the TOP and the banner vanishes.
+func (m tuiModel) panelInner() int { return max0(m.panelWidth() - panelPad) }
+
+// tailHeight is the blank line plus the status block at the foot of the frame.
+// It is MEASURED because the status block is not always one line: the answers
+// form and the confirm gate render there as full framed dialogs.
+func (m tuiModel) tailHeight() int { return 1 + lipgloss.Height(m.statusView()) }
+
+// renderPanel frames content one screen row per content line, hard-clamping
+// each to panelInner first. Clamping here rather than at each call site is the
+// point: a panel whose height is BUDGETED — the banner, the host list, the log
+// pane — can then never grow a row, whatever a future section forgets to
+// truncate.
+func (m tuiModel) renderPanel(style lipgloss.Style, content string) string {
+	w := m.panelInner()
+	lines := strings.Split(content, "\n")
+	for i, l := range lines {
+		lines[i] = trunc(l, w)
+	}
+	return style.Width(m.panelWidth()).Render(strings.Join(lines, "\n"))
+}
+
+// wrapPanel frames prose, letting lipgloss wrap it. The dialogs are the one
+// place where losing the tail of a line is worse than spending a row on it —
+// the force-reset warning names the branch the operator's work is saved to.
+// Their height is measured, not budgeted, so wrapping costs the log pane a row
+// rather than the banner.
+func (m tuiModel) wrapPanel(style lipgloss.Style, content string) string {
+	return style.Width(m.panelWidth()).Render(content)
 }
 
 // confirmView is the gate before anything runs. Each thing the operator needs
@@ -564,17 +686,46 @@ func (m tuiModel) confirmView() string {
 	b.WriteString(th.dim.Render("   ⏎ enter: ") + th.statusBar.Render("update") +
 		th.dim.Render("     ✏️ e: edit answers     ⎋ esc: cancel"))
 
-	return th.panel.Width(m.panelWidth()).Render(b.String())
+	return m.wrapPanel(th.panel, b.String())
 }
 
+// helpView lists every key. It is budgeted like the log pane rather than left
+// to run off the bottom: an overlay taller than the terminal is scrolled from
+// the TOP by bubbletea, which would hide the "❓ keys" heading and the first
+// keys — the half a reader looks at first.
 func (m tuiModel) helpView() string {
+	// title + blank + [keys] + blank + footer, inside two border rows, under
+	// the banner the overlay is drawn below.
+	// A zero height is "we have not been told the terminal size yet" (no
+	// WindowSizeMsg has arrived), not "no room" — clamping there would hide
+	// keys on a terminal that has plenty of space.
+	room := len(keyHelp)
+	if m.vp.height > 0 {
+		room = m.vp.height - bannerHeight - 2 - 4
+		if room < len(keyHelp) {
+			room-- // the "… N more" line costs a row of its own
+		}
+	}
+	shown := keyHelp
+	var more string
+	if room < len(shown) {
+		if room < 1 {
+			room = 1
+		}
+		shown = keyHelp[:room]
+		more = fmt.Sprintf("  … %d more — make the window taller to see them", len(keyHelp)-room)
+	}
+
 	var b strings.Builder
 	b.WriteString(th.header.Render("❓ keys") + "\n\n")
-	for _, k := range keyHelp {
+	for _, k := range shown {
 		fmt.Fprintf(&b, "  %s %-18s %s\n", k.icon, k.keys, th.dim.Render(k.what))
 	}
+	if more != "" {
+		b.WriteString(th.dim.Render(more) + "\n")
+	}
 	b.WriteString("\n" + th.dim.Render("any key to close"))
-	return th.panel.Width(m.panelWidth()).Render(strings.TrimRight(b.String(), "\n"))
+	return m.renderPanel(th.panel, strings.TrimRight(b.String(), "\n"))
 }
 
 func max0(n int) int {


### PR DESCRIPTION
## What

Fixes the `fleet tui` dashboard appearing to shift up one or two lines and cut off the banner during a multi-host update.

bubbletea's standard renderer keeps only the **last** `vp.height` lines of an over-tall frame and drops the rest **from the top** — `standard_renderer.go:184`, *"we can't navigate the cursor into the terminal's scrollback buffer"*. So a single row of overflow silently walks the header off the screen. Three independent defects made the frame too tall, and all three only bite once an update is streaming.

**1. Panel content was budgeted two cells too wide.** lipgloss counts horizontal padding *inside* `Style.Width`, so a panel declared `Width(96)` with `Padding(0, 1)` gives content only 94 cells. `logWidth()` budgeted against 96, so any log line reaching those last two cells wrapped onto a second row. This is the line-wrap trigger from the report, and the dominant contributor.

**2. `logHeight()` reserved three lines too few.** It used `vp.height - listHeight() - 10`, but the real chrome is 13. The banner had gained a row and both panels had gained borders since that constant was written.

**3. The streaming legend nested styles.** `th.header.Render()` was applied to a title that already carried per-host colour codes. lipgloss re-styles character by character, so the inner escape bytes were stranded, printed as a literal `[38;5;33mhost-nano[0m`, and counted as visible width. That is why the symptom needed *several* hosts to show up.

Measured overflow at 100x40 with five hosts and the log pane open:

| State | Rendered | Terminal | Over |
| :-- | --: | --: | --: |
| short log lines | 42 | 40 | +2 |
| five hosts streaming | 43 | 40 | +3 |
| wrapping log lines | 66 | 40 | +26 |

## Why

The geometry was arithmetic scattered across call sites, and it had already drifted at least twice. `AGENTS.md` records the same class of bug for row *width* ("Row width is derived, not guessed" — adding the BRANCH column overflowed the row). This PR makes the *height* structural instead, so the next section added to the view cannot reintroduce it.

`TestDemoFrames` had a width guard and no height guard. That asymmetry is why this shipped.

## Impact

- The frame now fits the terminal in every state, so the banner stops moving.
- `panelInner()` is the real content width; `renderPanel()` hard-clamps every line to it before framing, so a **budgeted** panel can no longer grow a row even if a future caller forgets to truncate.
- `View()` measures the already-rendered banner, list and status blocks and gives the log pane the remainder rather than predicting it. It then *verifies*: hands log rows back until the frame fits, drops the pane for a dialog that outgrows it, and `fitFrame()` clips the **bottom** as a last resort so the header is never what is lost.
- Prose dialogs keep wrapping via `wrapPanel()`. Clamping them was cutting the force-reset warning that names the branch a host's work is saved to. Their height is measured, so they cost the log pane a row rather than the banner.
- The help overlay is budgeted too, and names how many keys it hid instead of running off the bottom.
- Visible behaviour change: on a short terminal the log pane and the help overlay now show less rather than overflowing. The log title truncates with an ellipsis when many hosts stream, instead of wrapping.

## Testing

| Check | Result |
| :-- | :-- |
| `TestViewNeverExceedsTerminalHeight` | failed on **20** state-and-size combinations before the fix, passes now |
| `TestViewFitsAcrossEveryTerminalSize` | sweeps **1219** terminal sizes with wrapping multi-host output |
| `TestLogTitleNeverNestsStyles` | pins the no-nested-`Render` rule under the ANSI256 profile |
| `TestHelpOverlayOnAShortTerminalSaysWhatItHidRatherThanOverflowing` | pins the clamp, including that the bottom border survives |
| `TestDemoFrames` | gains a height guard, the twin of the existing width guard |
| `go test ./...`, `go vet`, `golangci-lint run` | clean |
| `cmd` coverage | 64.6%, above the 60% floor in `scripts/test.sh` |

Verified through the real `View()`, not a stub. Not exercised against a live fleet: the sweep drives the actual model and renderer deterministically, and a live run would add network calls without adding evidence about layout.

## Reviewer note on the changed fixtures

Three existing test fixtures move to taller terminals, and a changed fixture deserves a second look because it can hide a weakened assertion. In each case the old height only ever "fit" because the frame overflowed, so the assertion was passing against scrolled output:

- `tui_demo_test.go` — `16 → 20`. At 16 rows only 3 of the 5 demo hosts render, so the `unreachable` and `FAIL` frame assertions had nothing to match.
- `tui_logpane_test.go` — `12 → 16`. 13 rows are chrome, so a 12-row terminal cannot give the list and the log pane one row each.
- `tui_model_test.go` — `13 → 16`, keeping the 6 list rows that test's half-page assertion is written against.

No assertion was relaxed. `TestHelpOverlayRendersEveryKeyAndClosesOnAnyKey` now sets an explicit window size instead of relying on the model's default, and a second test covers the clamped path.

Closes the "window shifts up and eats the header during updates" report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSVhNzBE2n3s8qgRJXDnaY
