### PR TITLE
test(fleet): sample the deterministic-pick guard properly (fixes red main)

### DIFF
--- a/sdk/fleet/cmd/local_test.go
+++ b/sdk/fleet/cmd/local_test.go
@@ -126,11 +126,14 @@ func TestLocalAliasIsDeterministicWhenTwoBlocksMatch(t *testing.T) {
 		m.setLocal(localHost{Name: "box"})
 		return m.localAlias
 	}
-	if got := build(); got != "alpha" {
-		t.Fatalf("localAlias = %q, want alpha (first in row order)", got)
-	}
-	if build() != build() {
-		t.Fatal("the local pick must not vary between runs")
+	// Sampled repeatedly ON PURPOSE. The failure this guards against is Go's
+	// randomised map iteration order, and a single pair of runs would only
+	// catch that by luck — `alpha` has to win EVERY time, not merely twice in
+	// a row.
+	for i := range 50 {
+		if got := build(); got != "alpha" {
+			t.Fatalf("run %d: localAlias = %q, want alpha (first in row order)", i, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

One test change in `sdk/fleet/cmd/local_test.go`, replacing a `build() != build()` comparison with a 50-run sampled loop.

## Why

**`main` is currently red.** #309 merged with a staticcheck violation that its own Go Lint job had already caught:

```
sdk/fleet/cmd/local_test.go:132:5: SA4000: identical expressions on the left
and right side of the '!=' operator (staticcheck)
	if build() != build() {
```

`make lint-go` fails in `sdk/fleet`, which fails the Docker Image CI workflow on `main`.

staticcheck is right that the expression reads as a tautology. But the assertion was weak on its own terms too, which is the more interesting half: the failure it guards against is Go's **randomised map iteration order**, and two samples catch that only by luck. Requiring `alpha` to win on all fifty runs is both the stronger guard and lint-clean — so this is a genuine improvement, not a lint appeasement.

## Impact

Test-only. No production code touched, no behaviour change. `TestLocalAliasIsDeterministicWhenTwoBlocksMatch` keeps the same contract (the local-host pick must be stable across runs) and asserts it harder.

## Testing

- `make lint-go` exits 0 across all 8 sdk modules (was failing in `sdk/fleet`)
- `go vet ./...` clean, `gofmt` clean
- full `sdk/fleet` suite green

## Process note

This slipped through because the pre-push check on #309 ran `go vet`, `make lint-shell` and `make lint-portability` but **not** `make lint-go` — the one gate that would have caught it. `make lint-go` belongs in the pre-push routine for any Go change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVkqKxuiTYCFtwoZwDVJki