### PR TITLE
fleet history: read back update captures, and point at what actually broke

### DIFF
--- a/sdk/fleet/AGENTS.md
+++ b/sdk/fleet/AGENTS.md
@@ -469,15 +469,19 @@ I/O are all injected), so the decision surface is unit-tested without opening a 
   stderr loudest-first, and collapses repeats to one entry with a count. Colour is stripped
   BEFORE matching, not just before printing: a leading escape sequence hid the `WARNING:`
   prefix from the matcher, so a coloured warning was not merely grouped separately, it was
-  not recognised at all. Pinned by `TestProblemsLeadWithTheAuthoredDiagnosis`,
-  `TestProblemsCollapseRepeats`, `TestProblemsStripColourBeforeGrouping`.
+  not recognised at all — and `Read`'s WARN count strips through the SAME `clean` helper,
+  or the table and the digest disagree on precisely the colourised lines. Pinned by
+  `TestProblemsLeadWithTheAuthoredDiagnosis`, `TestProblemsCollapseRepeats`,
+  `TestProblemsStripColourBeforeGrouping`,
+  `TestColouredBenignStderrIsNotCountedAsAWarning`.
 - **The digest CLASSIFIES; it never hides.** Every line still appears — advisories are
   labelled and sorted last, not suppressed, because a filter that hides is a filter that can
   hide the one line that mattered. Three reductions, all structural rather than selective:
   continuation lines attach to their parent as detail (an unfinished sentence ending `,` `:`
   `\`, a line indented **two** spaces past its severity tag, or the same tool tag at the same
   timestamp), near-duplicates differing only by an identifier collapse to one entry with a
-  count and an elided middle (`9× WARNING: ollama create teams-… failed`), and repeats
+  count and an elided middle (`9× WARNING: ollama create teams-… failed`, cut on rune
+  boundaries and carrying every merged entry's detail with it), and repeats
   collapse by count. Together those took a healthy host from 34 "problems" to 8.
   Each rule is deliberately shallow — a miss costs tidiness, never information.
   **Two traps found by real captures, both now pinned:** the tool-tag rule needs the same
@@ -613,7 +617,13 @@ I/O are all injected), so the decision surface is unit-tested without opening a 
   note that is indistinguishable in `fleet history` from a step that produced no output at
   all, which is exactly how a broken-sudo run and the successful re-run that fixed it came
   to look identical. Capturing it for real needs a pty proxy; naming the gap costs one
-  line. Pinned by `TestInteractiveStepSaysItsOutputWentToTheTerminal`.
+  line. **The note describes the LANE, not the plan flag.** `Background` (the TUI) runs an
+  `interactive: true` run step as Batch and tees every line into the capture, so writing
+  the note there would stamp "output went to the terminal" onto a file holding the whole
+  run — and `histindex` reads that as "never observed" and refuses to call the host clean,
+  inverting the exact signal the note exists to give. Pinned by
+  `TestInteractiveStepSaysItsOutputWentToTheTerminal` and
+  `TestBackgroundLaneDoesNotClaimAnInteractiveGap`.
 - **A `timed out` step is "we stopped waiting", not "it stopped".** The deadline kills the
   local `ssh`; the remote command keeps running (an `install.sh` in the middle of `apt` will
   finish on its own). Check the host before re-running, and list `timeout` in `retry.on` only

--- a/sdk/fleet/AGENTS.md
+++ b/sdk/fleet/AGENTS.md
@@ -471,6 +471,33 @@ I/O are all injected), so the decision surface is unit-tested without opening a 
   prefix from the matcher, so a coloured warning was not merely grouped separately, it was
   not recognised at all. Pinned by `TestProblemsLeadWithTheAuthoredDiagnosis`,
   `TestProblemsCollapseRepeats`, `TestProblemsStripColourBeforeGrouping`.
+- **The digest CLASSIFIES; it never hides.** Every line still appears — advisories are
+  labelled and sorted last, not suppressed, because a filter that hides is a filter that can
+  hide the one line that mattered. Three reductions, all structural rather than selective:
+  continuation lines attach to their parent as detail (an unfinished sentence ending `,` `:`
+  `\`, a line indented **two** spaces past its severity tag, or the same tool tag at the same
+  timestamp), near-duplicates differing only by an identifier collapse to one entry with a
+  count and an elided middle (`9× WARNING: ollama create teams-… failed`), and repeats
+  collapse by count. Together those took a healthy host from 34 "problems" to 8.
+  Each rule is deliberately shallow — a miss costs tidiness, never information.
+  **Two traps found by real captures, both now pinned:** the tool-tag rule needs the same
+  TIMESTAMP or a tool's independent remarks merge (`install_herdr:` says two unrelated
+  things); and the indentation rule needs **two** spaces, since `WARNING: text` always has
+  one and a single-space test folded the entire list into its first entry. A line already
+  recorded as a problem is a REPEAT, not a continuation — checked first, or a repeated
+  tagged line folds into itself and loses its count. Pinned by
+  `TestContinuationLinesFoldIntoTheirParent`, `TestSeverityTagIsNotATagForFolding`,
+  `TestNearDuplicatesCollapseIntoOne`, `TestDistinctFailuresAreNotMerged`.
+- **Class is decided by CONTENT, not by stream.** `install.sh` sends some of its own
+  warnings to stdout and others to stderr — on one host every install failure arrived on
+  stdout, on another every one arrived on stderr — so keying the class off the stream left
+  the `failures` group empty on exactly the hosts that had failures. An explicit
+  `WARNING:`/`ERROR:` marker is a failure wherever it was written; the stream only decides
+  the remainder, where an unrecognised stderr line is cause-level evidence. Advisories
+  (`npm warn`, `[notice]`, gcloud's component notice, pip's root-user warning) are matched
+  by a short, specific list — an unrecognised line stays a failure, the same conservative
+  default `Benign` uses. Pinned by `TestFailureIsDecidedByContentNotStream`,
+  `TestAdvisoriesAreClassifiedNotHidden`.
 - **An empty digest is "clean" ONLY if the run was observed.** An interactive run captures
   none of `install.sh`'s output, so it digests to nothing for the same reason a perfect run
   does; reporting that as clean would mark a host verified on the strength of a file known

--- a/sdk/fleet/AGENTS.md
+++ b/sdk/fleet/AGENTS.md
@@ -446,6 +446,22 @@ I/O are all injected), so the decision surface is unit-tested without opening a 
 - **The persistence path is INJECTED (`tuiModel.ansPath`), never resolved inside the model.**
   A model that called `answersPath()` itself made every test write to the developer's real
   `~/.config/fleet`. Empty path = no persistence, which is what tests get.
+- **So is the CAPTURE path — same rule, learned the same way twice.** `runUpdateWith`
+  injected its writer and its runner but resolved the capture itself via
+  `newRunLogOutput()`, so every test driving the real CLI path wrote a file into the
+  operator's own `~/.local/state/fleet/logs`; a plain `go test ./...` left three there per
+  run, and 351 of the 384 files accumulated were named after test fixtures (`h`, `host-a`,
+  `alpha`). The capture is now a parameter — production passes `newRunLogOutput()`, tests
+  pass `updexec.Discard{}` — and `libs/log` no longer resolves a directory of its own
+  (`CaptureOptions` has no `Tool` field and an empty `Dir` means no capture at all), so
+  neither layer can invent a location. Pinned by `TestUpdateCapturesOnlyWhereTheCallerNamed`,
+  `TestZeroValueCaptureOutputWritesNothing`, and `libs/log`'s `TestEmptyDirMeansNoCapture`.
+- **Captures are kept 50 per HOST** (`captureKeep`), not globally. `libs/log` defaults to
+  200, which is far more scrollback than an operator reads; 50 answers "what changed since
+  this host last worked" while keeping the directory listable. Pruning is per subject and
+  runs inside `NewCapture`, so a host updated once a month never has its history evicted by
+  one updated hourly — and equally, a RETIRED host's 50 files are never reclaimed, because
+  nothing new is ever captured for it. Pinned by `TestCaptureKeepsFiftyRunsPerHost`.
 - **Branch costs no extra round-trip.** The live checked-out branch rides in the *same*
   remote command as the stamp read, split on `probeDelim`. A second dial per host would
   double the poll for one column. Pinned by `TestBranchCostsNoExtraRoundTrip`.

--- a/sdk/fleet/AGENTS.md
+++ b/sdk/fleet/AGENTS.md
@@ -27,6 +27,7 @@ facts. `opt/scripts/system/install-stamp.sh` now records the second one; this to
 | `fleet config pull\|push\|diff` | one-way ssh-config transfer: import FROM one host, publish TO hosts, or compare without changing anything |
 | `fleet wake [host...]` | rouse hosts asleep at layer 2: ladder `retry → local-prime → peer-relay`, printed rung by rung; `--json`; exits non-zero if any target stayed down |
 | `fleet history [host]` | list the captures past updates left behind (newest first: when · host · finished/unfinished · ⚠N · size); naming a host narrows to it. `--show` prints a run (`--run N`, 1 = newest), `--errors` keeps only stderr, `--grep RE` filters lines, `--limit N`, `--json` |
+| `fleet history --problems` | the digest: what actually went wrong, deduped — the installer's own `WARNING:`/`ERROR:` lines first, then non-benign stderr with repeats collapsed (`37× sudo: a password is required`). With no host it reports the NEWEST run of every host, so one command answers "what is broken across the fleet" |
 
 ## Layout
 
@@ -458,6 +459,29 @@ I/O are all injected), so the decision surface is unit-tested without opening a 
   (`CaptureOptions` has no `Tool` field and an empty `Dir` means no capture at all), so
   neither layer can invent a location. Pinned by `TestUpdateCapturesOnlyWhereTheCallerNamed`,
   `TestZeroValueCaptureOutputWritesNothing`, and `libs/log`'s `TestEmptyDirMeansNoCapture`.
+- **The digest cannot be built on the stdout/stderr split.** `install.sh` writes its own
+  explanation of what broke to STDOUT (`WARNING: could not install these apt packages: …`)
+  because it is a message to the operator; stderr carries the mechanical cause underneath.
+  On a host whose sudo was broken, stderr held 79 lines that were two distinct messages
+  repeated 37 times each, while the five lines naming what the machine was now MISSING were
+  all stdout — so `--errors` showed the mechanism and hid the consequence. `Problems()`
+  reads both, leads with the authored lines in the order they were written, then non-benign
+  stderr loudest-first, and collapses repeats to one entry with a count. Colour is stripped
+  BEFORE matching, not just before printing: a leading escape sequence hid the `WARNING:`
+  prefix from the matcher, so a coloured warning was not merely grouped separately, it was
+  not recognised at all. Pinned by `TestProblemsLeadWithTheAuthoredDiagnosis`,
+  `TestProblemsCollapseRepeats`, `TestProblemsStripColourBeforeGrouping`.
+- **An empty digest is "clean" ONLY if the run was observed.** An interactive run captures
+  none of `install.sh`'s output, so it digests to nothing for the same reason a perfect run
+  does; reporting that as clean would mark a host verified on the strength of a file known
+  to be missing the only part that mattered — the same unearned success fleet exists to
+  catch. `Capture.Observed` is false when a `run` step's banner is followed by no output,
+  or when the capture carries `updexec.InteractiveNote`. The STRUCTURAL rule is the load-
+  bearing one: the note is recent and every capture already on disk predates it, which is
+  exactly the set of past runs someone opens this tool to investigate. A genuinely silent
+  batch step reads as unobserved too — the conservative direction. Pinned by
+  `TestUncapturedRunIsNotReportedAsProblemFree`, `TestARunStepWithNoOutputIsUnobserved`,
+  `TestARunStepWithOutputIsObserved`, `TestUncapturedRunIsNotCalledClean`.
 - **`history` reads the capture; it never claims an exit code.** A capture records
   OUTPUT, not a status, so the listing's RESULT column says `finished` / `unfinished` —
   whether the run reached its footer — and never `ok` / `failed`, which the file cannot
@@ -554,6 +578,15 @@ I/O are all injected), so the decision surface is unit-tested without opening a 
   `fleet update init` always writes the starter plan and never updates a host called `init`.
   Deliberate: a plan-authoring verb needs a stable name more than that hostname needs
   protecting. Rename the host, or drive it from `fleet tui`.
+- **An interactive step's output is NOT in the capture — the capture says so.** `ssh -t`
+  hands the terminal to the remote command, so not one byte of an `interactive: true` step
+  (the default plan's `./install.sh`) passes through this process. The capture holds the
+  step banner, the `(interactive step: output went to the terminal …)` note, and nothing
+  else — a two-minute install that did the entire job leaves a ~570-byte file. Without the
+  note that is indistinguishable in `fleet history` from a step that produced no output at
+  all, which is exactly how a broken-sudo run and the successful re-run that fixed it came
+  to look identical. Capturing it for real needs a pty proxy; naming the gap costs one
+  line. Pinned by `TestInteractiveStepSaysItsOutputWentToTheTerminal`.
 - **A `timed out` step is "we stopped waiting", not "it stopped".** The deadline kills the
   local `ssh`; the remote command keeps running (an `install.sh` in the middle of `apt` will
   finish on its own). Check the host before re-running, and list `timeout` in `retry.on` only

--- a/sdk/fleet/AGENTS.md
+++ b/sdk/fleet/AGENTS.md
@@ -26,6 +26,7 @@ facts. `opt/scripts/system/install-stamp.sh` now records the second one; this to
 | `fleet keys list\|sync\|prune` | audit / authorize / remove authorized keys |
 | `fleet config pull\|push\|diff` | one-way ssh-config transfer: import FROM one host, publish TO hosts, or compare without changing anything |
 | `fleet wake [host...]` | rouse hosts asleep at layer 2: ladder `retry → local-prime → peer-relay`, printed rung by rung; `--json`; exits non-zero if any target stayed down |
+| `fleet history [host]` | list the captures past updates left behind (newest first: when · host · finished/unfinished · ⚠N · size); naming a host narrows to it. `--show` prints a run (`--run N`, 1 = newest), `--errors` keeps only stderr, `--grep RE` filters lines, `--limit N`, `--json` |
 
 ## Layout
 
@@ -44,6 +45,7 @@ facts. `opt/scripts/system/install-stamp.sh` now records the second one; this to
 | `internal/cfgplan` | plan a ONE-WAY ssh-config transfer (pure): `Build` + `Apply` |
 | `internal/lanscan` | sweep a subnet for a listening port (injected dialer — no nmap, no socket in tests) |
 | `internal/keys` | authorized_keys diff (reports removals, never applies them) |
+| `internal/histindex` | read past captures (pure but for the file open): `Scan` decodes `<UTC>__<host>.log` positionally, `Read` splits header/body/footer and decodes the `!! ` mark, `Summarize` adds finished + warning count |
 | `internal/reach` | the wake ladder: rung order, peer ranking, provenance (pure; every impure edge injected via `Deps`) |
 | `cmd/answers_store.go` | the non-secret prompt preferences on disk (`0600`); the on-disk type has no credential field |
 | `internal/runner` | the **only** seam that touches a remote host (`Exec` real, `Fake` for tests); `RunStreamCtx` is the deadline-aware path |
@@ -456,6 +458,16 @@ I/O are all injected), so the decision surface is unit-tested without opening a 
   (`CaptureOptions` has no `Tool` field and an empty `Dir` means no capture at all), so
   neither layer can invent a location. Pinned by `TestUpdateCapturesOnlyWhereTheCallerNamed`,
   `TestZeroValueCaptureOutputWritesNothing`, and `libs/log`'s `TestEmptyDirMeansNoCapture`.
+- **`history` reads the capture; it never claims an exit code.** A capture records
+  OUTPUT, not a status, so the listing's RESULT column says `finished` / `unfinished` —
+  whether the run reached its footer — and never `ok` / `failed`, which the file cannot
+  prove. The warning count and the `--errors` projection go through `updexec.Benign`, the
+  SAME classifier the TUI's error pane uses, so the CLI and the dashboard cannot disagree
+  about what an error is; `internal/updexec.StderrMark` is exported for the same reason —
+  the reader must strip exactly what the writer wrote, and two copies of `"!! "` would
+  drift. The log directory and the timezone are both PARAMETERS of `runHistory` (see the
+  injected-capture invariant above). Pinned by `TestHistoryListsNewestFirstWithOutcome`,
+  `TestHistoryErrorsShowsOnlyStderr`, `TestHistoryUnknownHostNamesWhatExists`.
 - **Captures are kept 50 per HOST** (`captureKeep`), not globally. `libs/log` defaults to
   200, which is far more scrollback than an operator reads; 50 answers "what changed since
   this host last worked" while keeping the directory listable. Pruning is per subject and

--- a/sdk/fleet/README.md
+++ b/sdk/fleet/README.md
@@ -687,6 +687,36 @@ $ fleet history
 read one with: fleet history db-01 --show --run N
 ```
 
+**Finding what went wrong** — `--problems` is the digest:
+
+```sh
+fleet history --problems            # newest run of every host: what is broken, where
+fleet history pi-01 --problems      # one host
+```
+
+It reads **both** streams. `install.sh` writes its own diagnosis to stdout
+(`WARNING: could not install these apt packages: …`) while stderr carries the
+mechanical cause underneath — so a stderr-only filter shows the mechanism and
+hides the consequence. Authored lines lead, repeats collapse:
+
+```console
+$ fleet history web-01 --problems --run 2
+web-01  2026-09-08 20:47  11 problems
+  ! WARNING: GitHub CLI apt repo setup failed; gh will fall back to the distro version.
+  ! WARNING: apt-get update failed; installs may be incomplete.
+  ! WARNING: grouped install failed; retrying packages individually...
+  ! WARNING: could not install these apt packages: git gh git-lfs jq vim tmux zsh ...
+    37× sudo: a terminal is required to read the password; either use the -S option ...
+    37× sudo: a password is required
+```
+
+That run's raw log is 79 stderr lines, 74 of which are those two messages.
+
+- **An empty digest reads `clean` only if the run was observed.** An interactive
+  run captures none of `install.sh`'s output, so it digests to nothing for the
+  same reason a perfect run does. Those report `not captured (interactive run)`
+  instead — a host nobody saw must never look verified.
+
 - **`RESULT` says `finished` / `unfinished`, never `ok` / `failed`.** A capture
   records output, not an exit code. `unfinished` means the file has no footer —
   the run was killed or is still going — which is a different fact from a run

--- a/sdk/fleet/README.md
+++ b/sdk/fleet/README.md
@@ -661,6 +661,43 @@ fleet keys prune                   # remove foreign keys — diff-first, confirm
   `authorized_keys` from local state.
 - Per-host failures are named and rolled into the exit code, never swallowed.
 
+### `fleet history [host]`
+
+Every `fleet update` — from the CLI or the dashboard — is captured to a per-host
+file under `~/.local/state/fleet/logs`. `history` is how you read them back.
+
+```sh
+fleet history                      # every run, newest first
+fleet history pi-01                # just this host's runs
+fleet history pi-01 --show         # print the newest run
+fleet history pi-01 --show --run 3 # the third-newest
+fleet history pi-01 --show --errors        # only what the host wrote to stderr
+fleet history pi-01 --show --grep 'sudo:'  # only matching lines
+fleet history --json | jq .
+```
+
+```console
+$ fleet history
+#  WHEN              HOST     RESULT    WARN  SIZE
+1  2026-09-08 20:47  db-01    finished  ⚠11   20.3K
+2  2026-09-08 20:47  nano-01  finished  ⚠19   29.5K
+3  2026-09-08 20:47  pi-01    finished  ⚠35   29.9K
+4  2026-09-08 20:47  web-01   finished  ⚠79   28.0K
+
+read one with: fleet history db-01 --show --run N
+```
+
+- **`RESULT` says `finished` / `unfinished`, never `ok` / `failed`.** A capture
+  records output, not an exit code. `unfinished` means the file has no footer —
+  the run was killed or is still going — which is a different fact from a run
+  that completed badly, and the table will not merge them.
+- **`WARN` counts non-benign stderr only.** `git` writes its entire fetch
+  progress to stderr, so counting raw stderr would badge every healthy run. The
+  classifier is the same one the dashboard's error pane uses, so the two views
+  can never disagree.
+- **Retention is 50 runs per host**, pruned as each new capture opens. A host
+  updated once a month never has its history evicted by one updated hourly.
+
 ### `fleet version`
 
 ```sh

--- a/sdk/fleet/README.md
+++ b/sdk/fleet/README.md
@@ -700,15 +700,36 @@ mechanical cause underneath — so a stderr-only filter shows the mechanism and
 hides the consequence. Authored lines lead, repeats collapse:
 
 ```console
-$ fleet history web-01 --problems --run 2
-web-01  2026-09-08 20:47  11 problems
-  ! WARNING: GitHub CLI apt repo setup failed; gh will fall back to the distro version.
-  ! WARNING: apt-get update failed; installs may be incomplete.
-  ! WARNING: grouped install failed; retrying packages individually...
-  ! WARNING: could not install these apt packages: git gh git-lfs jq vim tmux zsh ...
-    37× sudo: a terminal is required to read the password; either use the -S option ...
-    37× sudo: a password is required
+$ fleet history pi-01 --problems
+pi-01  2026-09-08 13:47  4 failures · 2 stderr · 2 advisories
+  failures
+    WARNING: cannot detect the focused window on this wayland session.
+    WARNING: Wayland needs the keyd GNOME extension:
+        WARNING:   ln -s /usr/local/share/keyd/gnome-extension-45 \
+        WARNING:         ~/.local/share/gnome-shell/extensions/keyd
+    WARNING: REFUSING to install the keyd config: without per-app overrides,
+        WARNING: Cmd+C in a terminal would send SIGINT instead of copying.
+    9× WARNING: ollama create teams-… failed (base model 'qwen3.8:27b' likely not pulled)
+  stderr
+    5× WARN: skipping '….md' — a host-local memory of the same name exists
+  advisories
+    Updates are available for some Google Cloud CLI components.  To install them,
+        please run:
+        $ gcloud components update
 ```
+
+That host's raw log lists **34** separate problems. Nothing here is hidden —
+advisories are labelled and sorted last, continuation lines are attached to
+their parent, and lines differing only by an identifier collapse to one entry
+with a count and an elided middle.
+
+- **Class comes from content, not the stream.** `install.sh` writes some of its
+  own warnings to stdout and others to stderr, so an explicit `WARNING:` /
+  `ERROR:` marker is a failure wherever it appears; the stream only decides the
+  rest, where an unrecognised stderr line is cause-level evidence.
+- **Advisories are classified, never suppressed** — `npm warn`, `[notice]`,
+  gcloud's component notice. The list is short and specific: an unrecognised
+  line stays a failure.
 
 That run's raw log is 79 stderr lines, 74 of which are those two messages.
 

--- a/sdk/fleet/cmd/history.go
+++ b/sdk/fleet/cmd/history.go
@@ -15,11 +15,12 @@ import (
 )
 
 var (
-	flagHistoryShow   bool
-	flagHistoryRun    int
-	flagHistoryErrors bool
-	flagHistoryGrep   string
-	flagHistoryLimit  int
+	flagHistoryShow     bool
+	flagHistoryRun      int
+	flagHistoryErrors   bool
+	flagHistoryGrep     string
+	flagHistoryLimit    int
+	flagHistoryProblems bool
 )
 
 // historyDefaultLimit caps the default listing. Retention keeps 50 runs per
@@ -79,6 +80,9 @@ func runHistory(w io.Writer, args []string, dir string, loc *time.Location) erro
 		}
 	}
 
+	if flagHistoryProblems {
+		return digestProblems(w, sel, len(args) == 1, loc)
+	}
 	if flagHistoryShow {
 		return showRun(w, sel)
 	}
@@ -227,5 +231,88 @@ func init() {
 	historyCmd.Flags().BoolVar(&flagHistoryErrors, "errors", false, "with --show, keep only stderr lines")
 	historyCmd.Flags().StringVar(&flagHistoryGrep, "grep", "", "with --show, keep only lines matching this regexp")
 	historyCmd.Flags().IntVar(&flagHistoryLimit, "limit", historyDefaultLimit, "maximum rows to list (0 = all)")
+	historyCmd.Flags().BoolVar(&flagHistoryProblems, "problems", false,
+		"digest what went wrong: the installer's own diagnosis first, then non-benign stderr, repeats collapsed (no host = newest run of every host)")
 	rootCmd.AddCommand(historyCmd)
+}
+
+// digestProblems prints what actually went wrong, deduped.
+//
+// With no host named it reports each host's NEWEST run only: older runs are
+// history, not current state, and a fleet-wide answer to "what is broken"
+// must not resurrect a problem that a later run already fixed. With a host
+// named it digests that host's selected run (--run, default newest).
+//
+// A host whose newest run is clean is SAID to be clean rather than omitted.
+// Silence is ambiguous — it reads identically to a host that was never
+// checked — and the point of the view is to be able to trust it.
+func digestProblems(w io.Writer, runs []histindex.Run, oneHost bool, loc *time.Location) error {
+	sel := runs
+	if !oneHost {
+		sel = newestPerHost(runs)
+	} else {
+		n := flagHistoryRun
+		if n <= 0 {
+			n = 1
+		}
+		if n > len(runs) {
+			return fmt.Errorf("--run %d: only %d capture(s) available", n, len(runs))
+		}
+		sel = runs[n-1 : n]
+	}
+
+	for _, r := range sel {
+		c, err := histindex.Read(r.Path)
+		if err != nil {
+			fmt.Fprintf(w, "%s  %s  unreadable: %v\n", r.Host, r.At.In(loc).Format("2006-01-02 15:04"), err)
+			continue
+		}
+		ps := c.Problems()
+		when := r.At.In(loc).Format("2006-01-02 15:04")
+		if len(ps) == 0 {
+			// "No problems found" and "I could not see what happened"
+			// produce the SAME empty digest. Collapsing them would report a
+			// host as verified on the strength of a capture we know is
+			// missing the only part that mattered.
+			state := "clean"
+			if !c.Observed {
+				state = "not captured (interactive run — output went to the terminal)"
+			}
+			fmt.Fprintf(w, "%s  %s  %s\n", r.Host, when, state)
+			continue
+		}
+		fmt.Fprintf(w, "%s  %s  %s\n", r.Host, when, plural(len(ps), "problem"))
+		for _, p := range ps {
+			// The multiplier replaces the repetition: one failure seen 37
+			// times is one line, which is the entire reason this view exists.
+			count := ""
+			if p.Count > 1 {
+				count = fmt.Sprintf("%d× ", p.Count)
+			}
+			// "!" marks the installer's own diagnosis — the actionable line —
+			// apart from the raw stderr underneath it.
+			mark := " "
+			if p.Authored {
+				mark = "!"
+			}
+			fmt.Fprintf(w, "  %s %s%s\n", mark, count, p.Text)
+		}
+		fmt.Fprintln(w)
+	}
+	return nil
+}
+
+// newestPerHost keeps the first (newest — Scan sorts descending) run of each
+// host, preserving that order.
+func newestPerHost(runs []histindex.Run) []histindex.Run {
+	seen := map[string]bool{}
+	var out []histindex.Run
+	for _, r := range runs {
+		if seen[r.Host] {
+			continue
+		}
+		seen[r.Host] = true
+		out = append(out, r)
+	}
+	return out
 }

--- a/sdk/fleet/cmd/history.go
+++ b/sdk/fleet/cmd/history.go
@@ -1,0 +1,231 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/histindex"
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagHistoryShow   bool
+	flagHistoryRun    int
+	flagHistoryErrors bool
+	flagHistoryGrep   string
+	flagHistoryLimit  int
+)
+
+// historyDefaultLimit caps the default listing. Retention keeps 50 runs per
+// host, so an unbounded list on a five-host fleet is 250 rows — past the
+// point where scrolling beats filtering.
+const historyDefaultLimit = 20
+
+var historyCmd = &cobra.Command{
+	Use:   "history [host]",
+	Short: "List and read the captures past updates left behind",
+	Long: `Every ` + "`fleet update`" + ` — from the CLI or the dashboard — is captured to a
+per-host file under the state directory. history lists those runs and prints them.
+
+Naming a host narrows the list to that host. --show prints a run's content
+instead of listing (--run picks which, 1 = newest), --errors keeps only the
+lines the remote wrote to STDERR, and --grep keeps only lines matching a
+regular expression.
+
+The stderr projection and the warning counts use the SAME classifier the
+dashboard's error pane does, so the two can never disagree about what counts
+as an error: git writes its whole fetch progress to stderr, and those lines
+are shown but not counted.`,
+	Args:          cobra.MaximumNArgs(1),
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runHistory(cmd.OutOrStdout(), args, fleetLogDir(), time.Local)
+	},
+}
+
+// runHistory is the whole verb with its writer, its DIRECTORY and its
+// timezone injected. The directory is a parameter for the same reason the
+// capture itself is one (see runUpdateWith): a test must never depend on —
+// or write to — the operator's real state directory. The location is a
+// parameter because rendering a timestamp is otherwise impure, and a test
+// that formatted in the developer's zone would pass in one country only.
+func runHistory(w io.Writer, args []string, dir string, loc *time.Location) error {
+	runs, err := histindex.Scan(dir)
+	if err != nil {
+		return err
+	}
+	if len(runs) == 0 {
+		fmt.Fprintln(w, "no update captures yet — a `fleet update` writes one per host per run")
+		return nil
+	}
+
+	sel := runs
+	if len(args) == 1 {
+		sel = filterHost(runs, args[0])
+		if len(sel) == 0 {
+			// Naming the hosts that DO have history turns a typo into a
+			// one-line fix, instead of looking exactly like "this host has
+			// never been updated".
+			fmt.Fprintf(w, "no captures for %q; hosts with history: %s\n",
+				args[0], strings.Join(hostsOf(runs), ", "))
+			return nil
+		}
+	}
+
+	if flagHistoryShow {
+		return showRun(w, sel)
+	}
+	return listRuns(w, sel, loc)
+}
+
+// filterHost keeps one host's runs, matched exactly — a prefix match would
+// make "pi" ambiguous the moment a "pi2" joined the fleet.
+func filterHost(runs []histindex.Run, host string) []histindex.Run {
+	var out []histindex.Run
+	for _, r := range runs {
+		if r.Host == host {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// hostsOf lists the distinct hosts with history, alphabetically.
+func hostsOf(runs []histindex.Run) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, r := range runs {
+		if !seen[r.Host] {
+			seen[r.Host] = true
+			out = append(out, r.Host)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// listRuns renders the table. RESULT reports what the capture actually
+// PROVES — whether the run reached its footer — not whether it succeeded: a
+// capture records output, not an exit code, and a row claiming "ok" on that
+// evidence would be inventing a fact.
+func listRuns(w io.Writer, runs []histindex.Run, loc *time.Location) error {
+	if flagHistoryLimit > 0 && len(runs) > flagHistoryLimit {
+		runs = runs[:flagHistoryLimit]
+	}
+
+	sums := make([]histindex.Summary, 0, len(runs))
+	for _, r := range runs {
+		s, err := histindex.Summarize(r)
+		if err != nil {
+			// One unreadable file must not cost the whole listing.
+			s = histindex.Summary{Run: r}
+		}
+		sums = append(sums, s)
+	}
+
+	if flagJSON {
+		return json.NewEncoder(w).Encode(sums)
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "#\tWHEN\tHOST\tRESULT\tWARN\tSIZE")
+	for i, s := range sums {
+		result := "finished"
+		if !s.Finished {
+			result = "unfinished"
+		}
+		warn := "-"
+		if s.Warnings > 0 {
+			warn = fmt.Sprintf("⚠%d", s.Warnings)
+		}
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\n",
+			i+1, s.At.In(loc).Format("2006-01-02 15:04"), s.Host, result, warn, size(s.Size))
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if len(runs) > 0 {
+		fmt.Fprintf(w, "\nread one with: fleet history %s --show --run N\n", runs[0].Host)
+	}
+	return nil
+}
+
+// showRun prints one run's content. --run indexes the SELECTION, so
+// `fleet history nano --show --run 2` is nano's second-newest — the number
+// means the same thing as the # column just listed.
+func showRun(w io.Writer, runs []histindex.Run) error {
+	n := flagHistoryRun
+	if n <= 0 {
+		n = 1
+	}
+	if n > len(runs) {
+		return fmt.Errorf("--run %d: only %d capture(s) available", n, len(runs))
+	}
+	r := runs[n-1]
+
+	c, err := histindex.Read(r.Path)
+	if err != nil {
+		return err
+	}
+
+	var re *regexp.Regexp
+	if flagHistoryGrep != "" {
+		if re, err = regexp.Compile(flagHistoryGrep); err != nil {
+			return fmt.Errorf("--grep: %w", err)
+		}
+	}
+
+	lines := c.Lines
+	if flagHistoryErrors {
+		lines = c.Stderr()
+	}
+
+	fmt.Fprintf(w, "# %s\n# %s\n\n", r.Path, c.Header)
+	shown := 0
+	for _, l := range lines {
+		if re != nil && !re.MatchString(l.Text) {
+			continue
+		}
+		// The stderr mark is decoded into a column rather than reprinted:
+		// "!! " is the on-disk encoding, not something an operator reads.
+		mark := " "
+		if l.Stderr {
+			mark = "!"
+		}
+		fmt.Fprintf(w, "%s %s %s\n", l.Time, mark, l.Text)
+		shown++
+	}
+	if shown == 0 {
+		fmt.Fprintln(w, "(no lines matched)")
+	}
+	return nil
+}
+
+// size renders a byte count compactly.
+func size(n int64) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1fM", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1fK", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}
+
+func init() {
+	historyCmd.Flags().BoolVar(&flagHistoryShow, "show", false, "print a run's content instead of listing")
+	historyCmd.Flags().IntVar(&flagHistoryRun, "run", 1, "which run to show (1 = newest)")
+	historyCmd.Flags().BoolVar(&flagHistoryErrors, "errors", false, "with --show, keep only stderr lines")
+	historyCmd.Flags().StringVar(&flagHistoryGrep, "grep", "", "with --show, keep only lines matching this regexp")
+	historyCmd.Flags().IntVar(&flagHistoryLimit, "limit", historyDefaultLimit, "maximum rows to list (0 = all)")
+	rootCmd.AddCommand(historyCmd)
+}

--- a/sdk/fleet/cmd/history.go
+++ b/sdk/fleet/cmd/history.go
@@ -281,21 +281,40 @@ func digestProblems(w io.Writer, runs []histindex.Run, oneHost bool, loc *time.L
 			fmt.Fprintf(w, "%s  %s  %s\n", r.Host, when, state)
 			continue
 		}
-		fmt.Fprintf(w, "%s  %s  %s\n", r.Host, when, plural(len(ps), "problem"))
-		for _, p := range ps {
-			// The multiplier replaces the repetition: one failure seen 37
-			// times is one line, which is the entire reason this view exists.
-			count := ""
-			if p.Count > 1 {
-				count = fmt.Sprintf("%d× ", p.Count)
+		// Counts per class in the headline, so a host can be triaged
+		// without reading its list: "3 failures" is a different morning
+		// from "3 advisories".
+		byClass := map[histindex.Class][]histindex.Problem{}
+		var order []histindex.Class
+		for _, pr := range ps {
+			if _, ok := byClass[pr.Class]; !ok {
+				order = append(order, pr.Class)
 			}
-			// "!" marks the installer's own diagnosis — the actionable line —
-			// apart from the raw stderr underneath it.
-			mark := " "
-			if p.Authored {
-				mark = "!"
+			byClass[pr.Class] = append(byClass[pr.Class], pr)
+		}
+		var counts []string
+		for _, cl := range order {
+			counts = append(counts, cl.Label(len(byClass[cl])))
+		}
+		fmt.Fprintf(w, "%s  %s  %s\n", r.Host, when, strings.Join(counts, " · "))
+
+		for _, cl := range order {
+			fmt.Fprintf(w, "  %s\n", cl)
+			for _, pr := range byClass[cl] {
+				// The multiplier replaces the repetition: one failure seen
+				// 37 times is one line, which is the entire reason this
+				// view exists.
+				count := ""
+				if pr.Count > 1 {
+					count = fmt.Sprintf("%d× ", pr.Count)
+				}
+				fmt.Fprintf(w, "    %s%s\n", count, strings.TrimSpace(pr.Text))
+				// Continuation lines are shown, indented under their parent
+				// — classified, never hidden.
+				for _, d := range pr.Detail {
+					fmt.Fprintf(w, "        %s\n", strings.TrimSpace(d))
+				}
 			}
-			fmt.Fprintf(w, "  %s %s%s\n", mark, count, p.Text)
 		}
 		fmt.Fprintln(w)
 	}

--- a/sdk/fleet/cmd/history.go
+++ b/sdk/fleet/cmd/history.go
@@ -247,7 +247,9 @@ func init() {
 // Silence is ambiguous — it reads identically to a host that was never
 // checked — and the point of the view is to be able to trust it.
 func digestProblems(w io.Writer, runs []histindex.Run, oneHost bool, loc *time.Location) error {
-	sel := runs
+	// Declared without an initialiser: both branches assign it, so seeding
+	// it with runs was dead (ineffassign).
+	var sel []histindex.Run
 	if !oneHost {
 		sel = newestPerHost(runs)
 	} else {

--- a/sdk/fleet/cmd/history_test.go
+++ b/sdk/fleet/cmd/history_test.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeCapture drops a capture file into dir the way libs/log names them.
+func writeCapture(t *testing.T, dir, stamp, host, body string) {
+	t.Helper()
+	name := stamp + "__" + host + ".log"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const capOK = `# fleet update — host=pi started=x
+03:47:14 === step dotfiles.sync (sync) ===
+03:47:16 !! From github.com:sfc-gh-eraigosa/dotfiles
+03:47:16 Already up to date.
+# 2026-09-09T03:50:36Z finished
+`
+
+const capBad = `# fleet update — host=nano started=x
+04:10:00 === step dotfiles.sync (sync) ===
+04:10:01 !! fatal: could not read Username
+04:10:01 !! error: failed to fetch
+# 2026-09-09T04:10:02Z finished
+`
+
+const capCut = `# fleet update — host=spark started=x
+05:00:00 working
+`
+
+func historyFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeCapture(t, dir, "20260909T034714Z", "pi", capOK)
+	writeCapture(t, dir, "20260909T041000Z", "nano", capBad)
+	writeCapture(t, dir, "20260909T050000Z", "spark", capCut)
+	return dir
+}
+
+// TestHistoryListsNewestFirstWithOutcome pins the default listing: every run,
+// newest first, with the two facts a filename cannot give — whether the run
+// finished, and how many non-benign stderr lines it produced. The benign
+// fetch header in capOK must NOT be counted, or every healthy run would carry
+// a warning and the column would mean nothing.
+func TestHistoryListsNewestFirstWithOutcome(t *testing.T) {
+	var buf strings.Builder
+	if err := runHistory(&buf, nil, historyFixture(t), time.UTC); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	out := buf.String()
+
+	iSpark := strings.Index(out, "spark")
+	iNano := strings.Index(out, "nano")
+	iPi := strings.Index(out, "pi ")
+	if iSpark < 0 || iNano < 0 || iPi < 0 {
+		t.Fatalf("every host must be listed:\n%s", out)
+	}
+	if !(iSpark < iNano && iNano < iPi) {
+		t.Errorf("want newest-first (spark, nano, pi):\n%s", out)
+	}
+
+	if !strings.Contains(out, "unfinished") {
+		t.Errorf("the capture with no footer must be marked unfinished:\n%s", out)
+	}
+	if !strings.Contains(out, "2") {
+		t.Errorf("nano's two non-benign stderr lines must be counted:\n%s", out)
+	}
+	if strings.Contains(out, "⚠1") {
+		t.Errorf("pi's only stderr line is a benign fetch header and must not count:\n%s", out)
+	}
+}
+
+// TestHistoryFiltersToOneHost pins the by-host navigation: naming a host
+// shows only that host's runs.
+func TestHistoryFiltersToOneHost(t *testing.T) {
+	var buf strings.Builder
+	if err := runHistory(&buf, []string{"nano"}, historyFixture(t), time.UTC); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "nano") {
+		t.Errorf("want nano's run:\n%s", out)
+	}
+	if strings.Contains(out, "spark") || strings.Contains(out, "pi ") {
+		t.Errorf("naming a host must exclude the others:\n%s", out)
+	}
+}
+
+// TestHistoryShowPrintsTheRunsContent pins --show: the capture body, with the
+// "!! " mark decoded rather than printed literally.
+func TestHistoryShowPrintsTheRunsContent(t *testing.T) {
+	old := flagHistoryShow
+	flagHistoryShow = true
+	t.Cleanup(func() { flagHistoryShow = old })
+
+	var buf strings.Builder
+	if err := runHistory(&buf, []string{"nano"}, historyFixture(t), time.UTC); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "fatal: could not read Username") {
+		t.Errorf("want the run's content:\n%s", out)
+	}
+	if strings.Contains(out, "!! ") {
+		t.Errorf("the stderr mark is structure, not text — it must not be printed raw:\n%s", out)
+	}
+}
+
+// TestHistoryErrorsShowsOnlyStderr pins --errors: the same projection the
+// TUI's stderr pane shows.
+func TestHistoryErrorsShowsOnlyStderr(t *testing.T) {
+	oldS, oldE := flagHistoryShow, flagHistoryErrors
+	flagHistoryShow, flagHistoryErrors = true, true
+	t.Cleanup(func() { flagHistoryShow, flagHistoryErrors = oldS, oldE })
+
+	var buf strings.Builder
+	if err := runHistory(&buf, []string{"nano"}, historyFixture(t), time.UTC); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "fatal: could not read Username") {
+		t.Errorf("want the stderr lines:\n%s", out)
+	}
+	if strings.Contains(out, "=== step dotfiles.sync") {
+		t.Errorf("--errors must exclude stdout:\n%s", out)
+	}
+}
+
+// TestHistoryGrepFiltersLines pins --grep against the same content.
+func TestHistoryGrepFiltersLines(t *testing.T) {
+	oldS, oldG := flagHistoryShow, flagHistoryGrep
+	flagHistoryShow, flagHistoryGrep = true, "Username"
+	t.Cleanup(func() { flagHistoryShow, flagHistoryGrep = oldS, oldG })
+
+	var buf strings.Builder
+	if err := runHistory(&buf, []string{"nano"}, historyFixture(t), time.UTC); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "could not read Username") {
+		t.Errorf("want the matching line:\n%s", out)
+	}
+	if strings.Contains(out, "failed to fetch") {
+		t.Errorf("--grep must drop non-matching lines:\n%s", out)
+	}
+}
+
+// TestHistoryEmptyIsSaidNotFailed pins that a machine which has never run an
+// update gets a sentence, not an error and not a bare empty table — the same
+// rule fleet applies to a missing ~/.ssh/config.
+func TestHistoryEmptyIsSaidNotFailed(t *testing.T) {
+	var buf strings.Builder
+	if err := runHistory(&buf, nil, t.TempDir(), time.UTC); err != nil {
+		t.Fatalf("an empty history must not be an error: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(buf.String()), "no ") {
+		t.Errorf("want a sentence explaining there is nothing yet, got:\n%q", buf.String())
+	}
+}
+
+// TestHistoryUnknownHostNamesWhatExists pins that a typo does not look like
+// "this host has never been updated": the message lists the hosts that DO
+// have history.
+func TestHistoryUnknownHostNamesWhatExists(t *testing.T) {
+	var buf strings.Builder
+	if err := runHistory(&buf, []string{"nope"}, historyFixture(t), time.UTC); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "nano") || !strings.Contains(out, "spark") {
+		t.Errorf("an unknown host must name the hosts that do have captures:\n%s", out)
+	}
+}

--- a/sdk/fleet/cmd/history_test.go
+++ b/sdk/fleet/cmd/history_test.go
@@ -64,7 +64,7 @@ func TestHistoryListsNewestFirstWithOutcome(t *testing.T) {
 	if iSpark < 0 || iNano < 0 || iPi < 0 {
 		t.Fatalf("every host must be listed:\n%s", out)
 	}
-	if !(iSpark < iNano && iNano < iPi) {
+	if iSpark >= iNano || iNano >= iPi {
 		t.Errorf("want newest-first (spark, nano, pi):\n%s", out)
 	}
 

--- a/sdk/fleet/cmd/history_test.go
+++ b/sdk/fleet/cmd/history_test.go
@@ -278,3 +278,47 @@ func TestUncapturedRunIsNotCalledClean(t *testing.T) {
 		t.Errorf("it must say the output was not captured:\n%s", out)
 	}
 }
+
+// TestDigestGroupsByClassAndKeepsEverything pins the rendering contract the
+// operator asked for: classify, never hide. Advisories are labelled and put
+// last so triage reads top-down, but they are still printed, and a
+// continuation line is still shown as detail under its parent.
+func TestDigestGroupsByClassAndKeepsEverything(t *testing.T) {
+	old := flagHistoryProblems
+	flagHistoryProblems = true
+	t.Cleanup(func() { flagHistoryProblems = old })
+
+	dir := t.TempDir()
+	writeCapture(t, dir, "20260909T034714Z", "gig",
+		"# fleet update — host=gig started=x\n"+
+			"03:47:18 WARNING: could not install these apt packages: git jq\n"+
+			"03:47:19 !! npm warn install-scripts 2 packages have install scripts\n"+
+			"03:47:20 !! Updates are available for some Google Cloud CLI components. To install them,\n"+
+			"03:47:20 !! please run:\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+
+	var buf strings.Builder
+	if err := runHistory(&buf, []string{"gig"}, dir, time.UTC); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "failures") || !strings.Contains(out, "advisories") {
+		t.Errorf("output must label the classes:\n%s", out)
+	}
+	// nothing is hidden
+	for _, want := range []string{
+		"could not install these apt packages",
+		"npm warn install-scripts",
+		"Updates are available for some Google Cloud CLI components",
+		"please run:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("every line must still appear; missing %q:\n%s", want, out)
+		}
+	}
+	// failures lead advisories
+	if strings.Index(out, "could not install") > strings.Index(out, "npm warn") {
+		t.Errorf("failures must be listed before advisories:\n%s", out)
+	}
+}

--- a/sdk/fleet/cmd/history_test.go
+++ b/sdk/fleet/cmd/history_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
 )
 
 // writeCapture drops a capture file into dir the way libs/log names them.
@@ -176,5 +178,103 @@ func TestHistoryUnknownHostNamesWhatExists(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "nano") || !strings.Contains(out, "spark") {
 		t.Errorf("an unknown host must name the hosts that do have captures:\n%s", out)
+	}
+}
+
+// TestProblemsDigestsNewestRunPerHost pins the fleet-wide answer to "what is
+// broken and where". With no host named it walks each host's NEWEST run only
+// — older runs are history, not the current state — and prints that run's
+// digest, so one command replaces reading four logs.
+func TestProblemsDigestsNewestRunPerHost(t *testing.T) {
+	old := flagHistoryProblems
+	flagHistoryProblems = true
+	t.Cleanup(func() { flagHistoryProblems = old })
+
+	dir := t.TempDir()
+	writeCapture(t, dir, "20260909T034714Z", "gig", capBad)
+	writeCapture(t, dir, "20260909T034715Z", "pi", capOK)
+	// an OLDER broken run for pi, which must NOT be reported: pi's newest is clean
+	writeCapture(t, dir, "20260901T000000Z", "pi", capBad)
+
+	var buf strings.Builder
+	if err := runHistory(&buf, nil, dir, time.UTC); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "could not read Username") {
+		t.Errorf("gig's problem must be reported:\n%s", out)
+	}
+	if !strings.Contains(out, "clean") {
+		t.Errorf("a host whose newest run is clean must be SAID to be clean, not omitted:\n%s", out)
+	}
+	if strings.Count(out, "could not read Username") != 1 {
+		t.Errorf("only the newest run per host is digested; pi's older broken run must not appear:\n%s", out)
+	}
+}
+
+// TestProblemsCollapseRepeatsInOutput pins that the rendered digest carries
+// the multiplier rather than repeating a line — the whole reason to have a
+// digest instead of `--errors`.
+func TestProblemsCollapseRepeatsInOutput(t *testing.T) {
+	old := flagHistoryProblems
+	flagHistoryProblems = true
+	t.Cleanup(func() { flagHistoryProblems = old })
+
+	dir := t.TempDir()
+	writeCapture(t, dir, "20260909T034714Z", "gig", `# fleet update — host=gig started=x
+03:47:18 !! sudo: a password is required
+03:47:18 !! sudo: a password is required
+03:47:18 !! sudo: a password is required
+03:47:19 WARNING: could not install these apt packages: git gh jq
+# 2026-09-09T03:50:36Z finished
+`)
+
+	var buf strings.Builder
+	if err := runHistory(&buf, []string{"gig"}, dir, time.UTC); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "3×") {
+		t.Errorf("a repeated failure must render with its multiplier:\n%s", out)
+	}
+	if strings.Count(out, "sudo: a password is required") != 1 {
+		t.Errorf("the repeated line must appear once, not three times:\n%s", out)
+	}
+	if !strings.Contains(out, "could not install these apt packages") {
+		t.Errorf("the authored diagnosis must be shown:\n%s", out)
+	}
+}
+
+// TestUncapturedRunIsNotCalledClean pins the fleet-wide view's honesty. An
+// interactive run captures none of install.sh's output, so its digest is
+// empty for the same reason a perfect run's is. Printing "clean" there would
+// report a host as verified on the strength of a file we know is missing the
+// only part that mattered — the same "reported success it never earned"
+// failure fleet exists to catch.
+func TestUncapturedRunIsNotCalledClean(t *testing.T) {
+	old := flagHistoryProblems
+	flagHistoryProblems = true
+	t.Cleanup(func() { flagHistoryProblems = old })
+
+	dir := t.TempDir()
+	writeCapture(t, dir, "20260909T043222Z", "gig",
+		"# fleet update — host=gig started=x\n"+
+			"04:32:23 === step dotfiles.install (run) ===\n"+
+			"04:32:23 "+updexec.InteractiveNote+"\n"+
+			"# 2026-09-09T04:34:20Z finished\n")
+
+	var buf strings.Builder
+	if err := runHistory(&buf, nil, dir, time.UTC); err != nil {
+		t.Fatalf("runHistory: %v", err)
+	}
+	out := buf.String()
+
+	if strings.Contains(out, "clean") {
+		t.Errorf("an unobserved run must never be reported clean:\n%s", out)
+	}
+	if !strings.Contains(out, "not captured") {
+		t.Errorf("it must say the output was not captured:\n%s", out)
 	}
 }

--- a/sdk/fleet/cmd/logging.go
+++ b/sdk/fleet/cmd/logging.go
@@ -12,6 +12,14 @@ const logTool = "fleet"
 
 func init() { applog.SetDefaultTool(logTool) }
 
+// captureKeep is how many captures are retained PER HOST. libs/log defaults
+// to 200, which is far more scrollback than an operator ever reads and is how
+// ~/.local/state/fleet/logs reached several hundred files; 50 runs answers
+// "what changed since this host last worked" while keeping the directory
+// listable. Retention is per subject, so a rarely-updated host never has its
+// history evicted by a busy one.
+const captureKeep = 50
+
 // fleetLogDir is where per-run install captures go. The precedence is the
 // driver's, so fleet's logs sit beside every other tool's.
 func fleetLogDir() string {

--- a/sdk/fleet/cmd/review_test.go
+++ b/sdk/fleet/cmd/review_test.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/runner"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updplan"
 )
 
@@ -58,7 +59,7 @@ func TestJSONOutputStillExitsNonZeroOnFailure(t *testing.T) {
 
 	r := runner.Fake{Err: map[string]error{"alpha": fmt.Errorf("boom")}}
 	var buf strings.Builder
-	err := runUpdateWith(&buf, []string{"alpha"}, r)
+	err := runUpdateWith(&buf, []string{"alpha"}, r, updexec.Discard{})
 	if err == nil {
 		t.Fatalf("a failed host under --json must still return a non-nil error, output:\n%s", buf.String())
 	}
@@ -156,7 +157,7 @@ func TestHeadlessCaptureContainsRemoteOutput(t *testing.T) {
 
 	r := runner.Fake{Out: map[string]string{"alpha": "state=clean branch=main\nfatal: unable to access remote"}}
 	var buf strings.Builder
-	if err := runUpdateWith(&buf, []string{"alpha"}, r); err != nil {
+	if err := runUpdateWith(&buf, []string{"alpha"}, r, newRunLogOutput()); err != nil {
 		t.Fatalf("unexpected error: %v\noutput:\n%s", err, buf.String())
 	}
 

--- a/sdk/fleet/cmd/update.go
+++ b/sdk/fleet/cmd/update.go
@@ -69,13 +69,20 @@ func buildExecutor(r runner.Runner, out updexec.Output, local updplan.Local) upd
 // runUpdate resolves the plan and flags, then runs every host serially
 // (interactive steps cannot share a terminal) through the plan executor.
 func runUpdate(cmd *cobra.Command, hosts []string) error {
-	return runUpdateWith(cmd.OutOrStdout(), hosts, runner.Exec{})
+	return runUpdateWith(cmd.OutOrStdout(), hosts, runner.Exec{}, newRunLogOutput())
 }
 
-// runUpdateWith is runUpdate with its output writer and runner injected, so
-// a test can drive the whole CLI path — plan resolution, the executor, the
-// headless capture, the report — without a cobra.Command or a real ssh.
-func runUpdateWith(out io.Writer, hosts []string, r runner.Runner) error {
+// runUpdateWith is runUpdate with its output writer, runner and CAPTURE
+// injected, so a test can drive the whole CLI path — plan resolution, the
+// executor, the headless capture, the report — without a cobra.Command, a
+// real ssh, or a write into the operator's own state directory.
+//
+// capture used to be resolved in here via newRunLogOutput(), which meant
+// every test driving this path wrote a real file under ~/.local/state/fleet
+// — the writer and the runner were injected but the one dependency that
+// touches the developer's home was not. Pass updexec.Discard{} for a test
+// that does not care; newRunLogOutput() is what production passes.
+func runUpdateWith(out io.Writer, hosts []string, r runner.Runner, capture updexec.Output) error {
 	local, err := resolveLocalPolicy(flagUpdateLocal, flagUpdateForce)
 	if err != nil {
 		return err
@@ -101,7 +108,6 @@ func runUpdateWith(out io.Writer, hosts []string, r runner.Runner) error {
 	// One capture value, reused across every host: it carries no per-host
 	// state (Open is keyed by the host/header arguments it is called with
 	// each time), so reconstructing it per host was pure churn.
-	capture := newRunLogOutput()
 	reports := make([]updexec.HostReport, 0, len(hosts))
 	for _, host := range hosts {
 		ex := buildExecutor(r, capture, local)

--- a/sdk/fleet/cmd/update_output.go
+++ b/sdk/fleet/cmd/update_output.go
@@ -18,10 +18,10 @@ type captureOutput struct{ dir string }
 
 func (c captureOutput) Open(host, header string) (updexec.LineWriter, string) {
 	cap := applog.NewCapture(applog.CaptureOptions{
-		Tool:    logTool,
 		Dir:     c.dir,
 		Subject: host,
 		Header:  header,
+		Keep:    captureKeep,
 		Now:     nowFn,
 	})
 	if cap == nil {

--- a/sdk/fleet/cmd/update_output_test.go
+++ b/sdk/fleet/cmd/update_output_test.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/runner"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
@@ -36,7 +38,7 @@ func TestHeadlessUpdateIsCaptured(t *testing.T) {
 
 	r := runner.Fake{Out: map[string]string{"alpha": "state=clean branch=main"}}
 	var buf strings.Builder
-	if err := runUpdateWith(&buf, []string{"alpha"}, r); err != nil {
+	if err := runUpdateWith(&buf, []string{"alpha"}, r, newRunLogOutput()); err != nil {
 		t.Fatalf("unexpected error: %v\noutput:\n%s", err, buf.String())
 	}
 
@@ -65,7 +67,7 @@ func TestAnUnusableCaptureDirDoesNotBreakTheCLIRun(t *testing.T) {
 
 	r := runner.Fake{Out: map[string]string{"alpha": "state=clean branch=main"}}
 	var buf strings.Builder
-	if err := runUpdateWith(&buf, []string{"alpha"}, r); err != nil {
+	if err := runUpdateWith(&buf, []string{"alpha"}, r, newRunLogOutput()); err != nil {
 		t.Fatalf("a lost capture must not fail the update: %v", err)
 	}
 }
@@ -139,5 +141,98 @@ func TestNewRunLogOutputIsReusableAcrossHosts(t *testing.T) {
 
 	if path1 == "" || path2 == "" || path1 == path2 {
 		t.Fatalf("expected two distinct capture paths, got %q and %q", path1, path2)
+	}
+}
+
+// countCaptures is how many capture files in dir belong to subject.
+func countCaptures(t *testing.T, dir, subject string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	n := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), "__"+subject+".log") {
+			n++
+		}
+	}
+	return n
+}
+
+// TestCaptureKeepsFiftyRunsPerHost pins fleet's retention: a host's 51st run
+// evicts its oldest capture, and no other host's history is touched. The
+// shared default is 200, which is far more scrollback than an operator ever
+// reads and made ~/.local/state/fleet/logs grow to hundreds of files; 50 runs
+// per host is enough to answer "what changed since it last worked" while
+// keeping the directory something you can actually list.
+func TestCaptureKeepsFiftyRunsPerHost(t *testing.T) {
+	dir := t.TempDir()
+
+	// Names are timestamped to the second, so each capture needs its own.
+	saved := nowFn
+	defer func() { nowFn = saved }()
+	at := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	nowFn = func() time.Time { at = at.Add(time.Second); return at }
+
+	out := captureOutput{dir: dir}
+	for i := 0; i < 51; i++ {
+		w, _ := out.Open("alpha", "run")
+		w.Close("done")
+	}
+	w, _ := out.Open("beta", "run")
+	w.Close("done")
+
+	if got := countCaptures(t, dir, "alpha"); got != 50 {
+		t.Errorf("alpha: kept %d captures, want 50", got)
+	}
+	if got := countCaptures(t, dir, "beta"); got != 1 {
+		t.Errorf("beta: kept %d captures, want 1 — pruning must not cross hosts", got)
+	}
+}
+
+// TestZeroValueCaptureOutputWritesNothing pins that a captureOutput with no
+// dir — the zero value every test-built Executor and tuiModel produces —
+// captures nothing rather than writing into the operator's real state
+// directory. It used to resolve to <state>/fleet/logs, so `go test ./...`
+// deposited three files in the developer's own ~/.local/state/fleet/logs on
+// every run; 351 of the 384 files found there were named after test fixtures
+// (h, host-a, alpha). Losing a capture is free (Open falls back to Discard);
+// writing one somewhere nobody named is not.
+func TestZeroValueCaptureOutputWritesNothing(t *testing.T) {
+	// A state dir IS in scope — this is exactly where a stray file would go.
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+
+	w, path := captureOutput{}.Open("alpha", "header")
+	w.Line("some output")
+	w.Close("done")
+
+	if path != "" {
+		t.Errorf("a dirless capture reported path %q; it must capture nothing", path)
+	}
+	if entries, err := os.ReadDir(filepath.Join(state, "fleet", "logs")); err == nil && len(entries) > 0 {
+		t.Errorf("wrote %d file(s) into the real state dir: %v", len(entries), entries)
+	}
+}
+
+// TestUpdateCapturesOnlyWhereTheCallerNamed pins that the CLI update path
+// writes captures ONLY to a directory its caller chose. runUpdateWith injects
+// its output writer and its runner but used to resolve the capture directory
+// itself via fleetLogDir(), so every test driving the real CLI path deposited
+// a file in the developer's own ~/.local/state/fleet/logs. This is the same
+// rule tuiModel.ansPath already follows: the persistence path is INJECTED,
+// never resolved inside the thing being tested.
+func TestUpdateCapturesOnlyWhereTheCallerNamed(t *testing.T) {
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+
+	withUpdateFile(t, updplan.DefaultYAML)
+	r := runner.Fake{Err: map[string]error{"alpha": fmt.Errorf("boom")}}
+	var buf strings.Builder
+	_ = runUpdateWith(&buf, []string{"alpha"}, r, updexec.Discard{})
+
+	if entries, err := os.ReadDir(filepath.Join(state, "fleet", "logs")); err == nil && len(entries) > 0 {
+		t.Fatalf("capture written to a directory the caller never named: %v", entries)
 	}
 }

--- a/sdk/fleet/internal/histindex/capture.go
+++ b/sdk/fleet/internal/histindex/capture.go
@@ -1,0 +1,146 @@
+package histindex
+
+import (
+	"os"
+	"strings"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
+)
+
+// timeWidth is the "HH:MM:SS" prefix libs/log stamps on every captured line.
+const timeWidth = 8
+
+// Line is one line of a capture, with the two things the file encodes as
+// text turned back into structure: the timestamp prefix and the "!! " stderr
+// mark. Keeping the mark in Text would make an error line grep, sort and
+// align differently from its stdout neighbours — the mark exists to carry a
+// distinction, so a reader has to decode it, not preserve it.
+type Line struct {
+	Time   string // "03:47:16"; empty for a line with no stamp
+	Text   string
+	Stderr bool
+}
+
+// Capture is one parsed run.
+type Capture struct {
+	Header string // the "# fleet update — host=… " preamble
+	Footer string // the "# <iso> finished" trailer, empty if the run was cut off
+	Lines  []Line
+	// Warnings counts NON-BENIGN stderr lines — the same number the TUI
+	// badges a row with. See Read.
+	Warnings int
+}
+
+// Stderr is the error projection: the same lines the TUI's stderr pane
+// shows, in wire order. It is a filter over the one tagged buffer rather
+// than a second parse, so the two views can never disagree.
+func (c Capture) Stderr() []Line {
+	out := make([]Line, 0, len(c.Lines))
+	for _, l := range c.Lines {
+		if l.Stderr {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// Read parses one capture file.
+//
+// Warnings counts only stderr lines updexec.Benign rejects. Counting raw
+// stderr would badge every healthy run: git writes its entire fetch progress
+// to stderr, so a clean update produces several stderr lines and no problem
+// at all. Benign is the classifier the TUI already uses — shared on purpose,
+// so `fleet history --errors` and the dashboard's error pane can never
+// disagree about what counts as an error.
+func Read(path string) (Capture, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Capture{}, err
+	}
+
+	var c Capture
+	raw := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	for i, ln := range raw {
+		// "# " marks the header (first line) and the footer (last).
+		if strings.HasPrefix(ln, "# ") {
+			text := strings.TrimPrefix(ln, "# ")
+			switch {
+			case i == 0:
+				c.Header = text
+			case i == len(raw)-1:
+				c.Footer = text
+			}
+			continue
+		}
+		c.Lines = append(c.Lines, parseLine(ln))
+	}
+
+	for _, l := range c.Lines {
+		if l.Stderr && !updexec.Benign(l.Text) {
+			c.Warnings++
+		}
+	}
+	return c, nil
+}
+
+// parseLine splits the timestamp prefix and the stderr mark off one body
+// line. A line without a stamp keeps its whole text — a remote command that
+// emitted a bare newline, or output written before the first stamp, must
+// survive rather than be dropped for not matching the shape.
+func parseLine(ln string) Line {
+	out := Line{Text: ln}
+	if len(ln) > timeWidth && ln[timeWidth] == ' ' && isClock(ln[:timeWidth]) {
+		out.Time = ln[:timeWidth]
+		out.Text = ln[timeWidth+1:]
+	}
+	if rest, ok := strings.CutPrefix(out.Text, updexec.StderrMark); ok {
+		out.Stderr = true
+		out.Text = rest
+	}
+	return out
+}
+
+// isClock reports whether s is "HH:MM:SS" — digits in the right places,
+// which is enough to tell a stamp from a line that merely starts with eight
+// characters and a space.
+func isClock(s string) bool {
+	for i, r := range s {
+		if i == 2 || i == 5 {
+			if r != ':' {
+				return false
+			}
+			continue
+		}
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// Summary is a Run plus the facts that require opening the file. Scan stays
+// filename-only so listing is cheap; a caller that wants these pays for them
+// explicitly, and only for the rows it is about to show.
+type Summary struct {
+	Run
+	Warnings int
+	Finished bool
+	Lines    int
+}
+
+// Summarize reads one run's file for its result. Finished is whether the
+// capture carries its "finished" footer: a run killed mid-flight (a timeout,
+// a closed laptop) leaves the file without one, which is a DIFFERENT outcome
+// from a run that completed with errors, and the listing must not merge them.
+func Summarize(r Run) (Summary, error) {
+	c, err := Read(r.Path)
+	if err != nil {
+		return Summary{}, err
+	}
+	return Summary{
+		Run:      r,
+		Warnings: c.Warnings,
+		Finished: c.Footer != "",
+		Lines:    len(c.Lines),
+	}, nil
+}

--- a/sdk/fleet/internal/histindex/capture.go
+++ b/sdk/fleet/internal/histindex/capture.go
@@ -2,6 +2,7 @@ package histindex
 
 import (
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
@@ -29,6 +30,15 @@ type Capture struct {
 	// Warnings counts NON-BENIGN stderr lines — the same number the TUI
 	// badges a row with. See Read.
 	Warnings int
+	// Observed is false when some of this run's output never reached the
+	// file — today, when it contains an interactive step whose output went
+	// to the terminal instead.
+	//
+	// It exists so a reader can tell "nothing went wrong" from "I could not
+	// see what happened". Both produce an empty problem digest, and
+	// presenting the second as the first would mark a host verified that was
+	// never actually observed.
+	Observed bool
 }
 
 // Stderr is the error projection: the same lines the TUI's stderr pane
@@ -75,6 +85,7 @@ func Read(path string) (Capture, error) {
 		c.Lines = append(c.Lines, parseLine(ln))
 	}
 
+	c.Observed = observed(c.Lines)
 	for _, l := range c.Lines {
 		if l.Stderr && !updexec.Benign(l.Text) {
 			c.Warnings++
@@ -143,4 +154,44 @@ func Summarize(r Run) (Summary, error) {
 		Finished: c.Footer != "",
 		Lines:    len(c.Lines),
 	}, nil
+}
+
+// runBanner matches the executor's step banner for a `run` step — the one
+// kind that can hand the terminal to the remote command.
+var runBanner = regexp.MustCompile(`^=== step .* \(run\)( |=)`)
+
+// stepBanner matches any step banner.
+var stepBanner = regexp.MustCompile(`^=== step `)
+
+// observed reports whether this capture holds everything the run produced.
+//
+// It is false when a `run` step's banner is followed by no output at all.
+// That is what an INTERACTIVE step leaves behind: ssh -t hands the terminal
+// to the remote command, so a two-minute ./install.sh that did the whole job
+// writes a banner and nothing else. Detecting it structurally rather than by
+// looking for InteractiveNote is deliberate — the note is recent, and every
+// capture already on disk predates it, which is precisely the set of past
+// runs someone would open this tool to investigate.
+//
+// A genuinely silent batch step reads the same way and is also reported
+// unobserved. That is the conservative direction: the cost is admitting we
+// cannot vouch for a run, versus vouching for one nobody saw.
+func observed(lines []Line) bool {
+	for i, l := range lines {
+		// The explicit marker, written by any executor new enough to emit
+		// it. Checked as well as the structural rule below, not instead of
+		// it: the note IS content, so a banner followed by the note looks
+		// "observed" to a purely structural test.
+		if l.Text == updexec.InteractiveNote {
+			return false
+		}
+		if !runBanner.MatchString(l.Text) {
+			continue
+		}
+		// Anything before the next banner counts as this step's output.
+		if i+1 >= len(lines) || stepBanner.MatchString(lines[i+1].Text) {
+			return false
+		}
+	}
+	return true
 }

--- a/sdk/fleet/internal/histindex/capture.go
+++ b/sdk/fleet/internal/histindex/capture.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
 )
 
@@ -87,12 +88,24 @@ func Read(path string) (Capture, error) {
 
 	c.Observed = observed(c.Lines)
 	for _, l := range c.Lines {
-		if l.Stderr && !updexec.Benign(l.Text) {
+		if l.Stderr && !updexec.Benign(clean(l.Text)) {
 			c.Warnings++
 		}
 	}
 	return c, nil
 }
+
+// clean strips terminal colour (and the trailing whitespace it leaves)
+// before ANY classification. install.sh colourises its own output, and a
+// leading escape sequence hides the "WARNING:" prefix — and the shape of a
+// benign git line — from every matcher.
+//
+// Read strips for the same reason Problems does: the listing's WARN column
+// and the --problems digest must agree about what counts as an error, and
+// one of them stripping while the other did not made them disagree on
+// precisely the colourised lines. The stripped text is used for MATCHING
+// only; Lines keeps what the host actually wrote, so --show is unchanged.
+func clean(s string) string { return strings.TrimRight(ansi.Strip(s), " \t") }
 
 // parseLine splits the timestamp prefix and the stderr mark off one body
 // line. A line without a stamp keeps its whole text — a remote command that

--- a/sdk/fleet/internal/histindex/histindex.go
+++ b/sdk/fleet/internal/histindex/histindex.go
@@ -1,0 +1,108 @@
+// Package histindex reads the update captures libs/log wrote — the
+// <UTC>__<subject>.log files under fleet's state directory — into values the
+// history command renders.
+//
+// It is pure text-in/struct-out apart from opening the files themselves: no
+// clock, no network, no ssh. That is what lets the whole history surface be
+// unit-tested from a temp directory.
+package histindex
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// nameLayout is the timestamp format libs/log's CaptureName writes. Decoding
+// depends on it being FIXED WIDTH — see decodeName.
+const nameLayout = "20060102T150405Z"
+
+// nameSep separates the timestamp from the subject in a capture filename.
+const nameSep = "__"
+
+// Run is one captured update of one host. Everything here is recovered from
+// the filename, so listing hundreds of runs costs one ReadDir and no file
+// opens at all.
+type Run struct {
+	Host string
+	At   time.Time
+	Path string
+	Size int64
+}
+
+// Scan lists every capture in dir, newest first. Ties break on host so the
+// order is total: a fleet-wide update writes several files in the same
+// second, and a listing that reshuffled them between runs would be unusable.
+//
+// A missing directory is an EMPTY history rather than an error — "no runs
+// yet" is the normal state on a machine that has never updated anything, and
+// the same rule fleet applies to a missing ~/.ssh/config.
+func Scan(dir string) ([]Run, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var runs []Run
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		host, at, ok := decodeName(e.Name())
+		if !ok {
+			continue // not a capture; never guess at a bogus row
+		}
+		var size int64
+		if info, err := e.Info(); err == nil {
+			size = info.Size()
+		}
+		runs = append(runs, Run{
+			Host: host,
+			At:   at,
+			Path: filepath.Join(dir, e.Name()),
+			Size: size,
+		})
+	}
+
+	sort.Slice(runs, func(i, j int) bool {
+		if runs[i].At.Equal(runs[j].At) {
+			return runs[i].Host < runs[j].Host
+		}
+		return runs[i].At.After(runs[j].At)
+	})
+	return runs, nil
+}
+
+// decodeName is the inverse of libs/log's CaptureName. It reads the
+// timestamp POSITIONALLY rather than splitting on nameSep: SafeName permits
+// underscores, so a host named "a__b" yields "<ts>__a__b.log" and a split on
+// the first separator would call that host "a", on the last "b". The
+// timestamp's width is fixed, so the boundary never has to be guessed.
+//
+// Anything that does not decode is reported as not-a-capture rather than
+// repaired — a stray file in the log directory must not become a row
+// claiming to be a run that never happened.
+func decodeName(name string) (string, time.Time, bool) {
+	body := strings.TrimSuffix(name, ".log")
+	if body == name {
+		return "", time.Time{}, false
+	}
+	if len(body) < len(nameLayout)+len(nameSep)+1 {
+		return "", time.Time{}, false
+	}
+	if body[len(nameLayout):len(nameLayout)+len(nameSep)] != nameSep {
+		return "", time.Time{}, false
+	}
+	at, err := time.Parse(nameLayout, body[:len(nameLayout)])
+	if err != nil {
+		return "", time.Time{}, false
+	}
+	return body[len(nameLayout)+len(nameSep):], at, true
+}

--- a/sdk/fleet/internal/histindex/histindex_test.go
+++ b/sdk/fleet/internal/histindex/histindex_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
 )
@@ -639,6 +640,75 @@ func TestClassLabelsAgreeWithTheirCount(t *testing.T) {
 	} {
 		if got := tc.class.Label(tc.n); got != tc.want {
 			t.Errorf("Label(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}
+
+// TestColouredBenignStderrIsNotCountedAsAWarning pins that the listing's
+// WARN column and the --problems digest classify the SAME text. Read used
+// to hand updexec.Benign the raw line while Problems stripped colour first,
+// so a colourised `Already on 'main'` — routine git checkout chatter — was
+// benign to the digest and a warning to the table. The two views then
+// disagreed on exactly the colourised lines, which is what the shared
+// classifier exists to prevent: `fleet history` showed ⚠1 on a host that
+// `--problems` called clean.
+func TestColouredBenignStderrIsNotCountedAsAWarning(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__gig.log",
+		"# fleet update — host=gig\n"+
+			"03:47:14 === step dotfiles.sync (sync) ===\n"+
+			"03:47:14 state=clean branch=main\n"+
+			"03:47:15 !! \x1b[32mAlready on 'main'\x1b[0m\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+
+	c, err := Read(filepath.Join(dir, "20260909T034714Z__gig.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Warnings != 0 {
+		t.Errorf("Warnings = %d, want 0 — colour must be stripped before Benign, exactly as Problems does", c.Warnings)
+	}
+	if got := len(c.Problems()); got != 0 {
+		t.Errorf("Problems() = %d, want 0 — the digest and the WARN column must agree", got)
+	}
+}
+
+// TestMergedNearDuplicatesKeepTheirDetail pins that collapsing two
+// near-identical failures into one counted entry does not delete the
+// continuation lines hanging off the second one. The elided middle already
+// costs the reader the identifier; silently dropping detail that nothing
+// else in the digest shows would make "classifies, never hides" false.
+func TestMergedNearDuplicatesKeepTheirDetail(t *testing.T) {
+	c := Capture{Lines: []Line{
+		{Time: "03:47:14", Text: "WARNING: ollama create teams-alpha failed to build"},
+		{Time: "03:47:14", Text: "WARNING:   base model alpha was never pulled"},
+		{Time: "03:47:15", Text: "WARNING: ollama create teams-bravo failed to build"},
+		{Time: "03:47:15", Text: "WARNING:   base model bravo was never pulled"},
+	}}
+
+	ps := c.Problems()
+	if len(ps) != 1 {
+		t.Fatalf("got %d problems, want the two to collapse into one: %+v", len(ps), ps)
+	}
+	if len(ps[0].Detail) != 2 {
+		t.Fatalf("Detail = %q, want both continuation lines to survive the merge", ps[0].Detail)
+	}
+}
+
+// TestElidedMiddleStaysValidUTF8 pins that the "…" elision cuts on rune
+// boundaries. Two different runes can share leading bytes ("…" is E2 80 A6,
+// "—" is E2 80 94), so a byte-exact prefix cut lands inside one and emits
+// half a rune — mojibake in the single line the digest exists to make
+// readable.
+func TestElidedMiddleStaysValidUTF8(t *testing.T) {
+	c := Capture{Lines: []Line{
+		{Time: "03:47:14", Text: "WARNING: could not reach the mirror … for repository alpha, skipping"},
+		{Time: "03:47:15", Text: "WARNING: could not reach the mirror — for repository bravo, skipping"},
+	}}
+
+	for _, p := range c.Problems() {
+		if !utf8.ValidString(p.Text) {
+			t.Errorf("digest line is not valid UTF-8: %q", p.Text)
 		}
 	}
 }

--- a/sdk/fleet/internal/histindex/histindex_test.go
+++ b/sdk/fleet/internal/histindex/histindex_test.go
@@ -236,8 +236,8 @@ func TestProblemsLeadWithTheAuthoredDiagnosis(t *testing.T) {
 	if !strings.Contains(ps[1].Text, "could not install these apt packages") {
 		t.Errorf("problem 1 = %q, want the second authored WARNING", ps[1].Text)
 	}
-	if !ps[0].Authored || ps[2].Authored {
-		t.Errorf("Authored must separate install.sh's diagnosis from raw stderr: %+v", ps)
+	if ps[0].Class != ClassFailure || ps[2].Class != ClassStderr {
+		t.Errorf("Class must separate install.sh's diagnosis from raw stderr: %+v", ps)
 	}
 }
 
@@ -403,5 +403,242 @@ func TestARunStepWithOutputIsObserved(t *testing.T) {
 	c, _ := Read(filepath.Join(dir, "20260909T043222Z__gig.log"))
 	if !c.Observed {
 		t.Error("a run step with output WAS observed")
+	}
+}
+
+// TestAdvisoriesAreClassifiedNotHidden pins that a tool announcing news
+// about ITSELF is separated from something that actually failed — and that
+// it is still reported. npm's install-scripts notice and pip's upgrade
+// notice mean nothing went wrong; grouping them with "could not install
+// these apt packages" is what made a healthy host show 34 problems. They are
+// classified rather than suppressed: a filter that hides is a filter that
+// can hide the one line that mattered, and an operator triaging a fleet
+// needs to see everything once and decide for themselves.
+func TestAdvisoriesAreClassifiedNotHidden(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__gig.log",
+		"# fleet update — host=gig started=x\n"+
+			"03:47:18 WARNING: could not install these apt packages: git jq\n"+
+			// npm, pip and gcloud all write these to STDERR — that is how
+			// they arrive in a real capture.
+			"03:47:19 !! npm warn install-scripts 2 packages have install scripts\n"+
+			"03:47:20 !! [notice] A new release of pip is available: 26.0.1 -> 26.2.1\n"+
+			"03:47:21 !! WARNING: Running pip as the 'root' user can result in broken permissions\n"+
+			"03:47:22 !! Updates are available for some Google Cloud CLI components.\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+
+	c, _ := Read(filepath.Join(dir, "20260909T034714Z__gig.log"))
+	ps := c.Problems()
+
+	if len(ps) != 5 {
+		t.Fatalf("every line must still be reported, got %d: %+v", len(ps), ps)
+	}
+
+	byClass := map[Class]int{}
+	for _, p := range ps {
+		byClass[p.Class]++
+	}
+	if byClass[ClassFailure] != 1 {
+		t.Errorf("exactly the apt failure is a failure, got %d: %+v", byClass[ClassFailure], ps)
+	}
+	if byClass[ClassAdvisory] != 4 {
+		t.Errorf("the four tool notices are advisories, got %d: %+v", byClass[ClassAdvisory], ps)
+	}
+
+	// failures sort ahead of advisories so triage reads top-down
+	if ps[0].Class != ClassFailure {
+		t.Errorf("failures must lead: %+v", ps)
+	}
+}
+
+// TestContinuationLinesFoldIntoTheirParent pins that a multi-line message is
+// ONE problem. All three shapes here are real, taken from live captures, and
+// each one was previously counted as several unrelated problems — which is
+// most of why a healthy host reported 34.
+//
+// Nothing is dropped: continuations are attached as detail, so the full text
+// is still there to read. The rules are deliberately shallow — an unfolded
+// line merely stands on its own, which is the old behaviour, so a miss costs
+// tidiness rather than information.
+func TestContinuationLinesFoldIntoTheirParent(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__pi.log",
+		"# fleet update — host=pi started=x\n"+
+			// (a) an unfinished sentence continues: "…To install them," -> "please run:" -> the command
+			"03:47:10 !! Updates are available for some Google Cloud CLI components.  To install them,\n"+
+			"03:47:10 !! please run:\n"+
+			"03:47:10 !!   $ gcloud components update\n"+
+			// (b) indentation AFTER the severity tag marks a continuation
+			"03:47:20 WARNING: Wayland needs the keyd GNOME extension:\n"+
+			"03:47:20 WARNING:   ln -s /usr/local/share/keyd/gnome-extension-45 \\\n"+
+			"03:47:20 WARNING:         ~/.local/share/gnome-shell/extensions/keyd\n"+
+			// (c) a repeated tool tag is one message
+			// goenv writes to stderr, as it does in a real capture
+			"03:47:30 !! goenv: WARNING: System 'go' found at /usr/bin/go\n"+
+			"03:47:30 !! goenv: Since your shims are at the end of PATH, system 'go' will be used\n"+
+			"03:47:30 !! goenv: To fix this, add the following to your ~/.goenvrc:\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+
+	c, _ := Read(filepath.Join(dir, "20260909T034714Z__pi.log"))
+	ps := c.Problems()
+
+	if len(ps) != 3 {
+		var got []string
+		for _, p := range ps {
+			got = append(got, p.Text)
+		}
+		t.Fatalf("three messages, want 3 problems, got %d:\n%s", len(ps), strings.Join(got, "\n"))
+	}
+
+	byText := map[string]Problem{}
+	for _, p := range ps {
+		byText[p.Text] = p
+	}
+	gcloud, ok := byText["Updates are available for some Google Cloud CLI components.  To install them,"]
+	if !ok || len(gcloud.Detail) != 2 {
+		t.Errorf("gcloud message must carry its 2 continuation lines: %+v", gcloud)
+	}
+	keyd, ok := byText["WARNING: Wayland needs the keyd GNOME extension:"]
+	if !ok || len(keyd.Detail) != 2 {
+		t.Errorf("keyd message must carry its 2 indented lines: %+v", keyd)
+	}
+	goenv, ok := byText["goenv: WARNING: System 'go' found at /usr/bin/go"]
+	if !ok || len(goenv.Detail) != 2 {
+		t.Errorf("goenv message must carry its 2 same-tag lines: %+v", goenv)
+	}
+}
+
+// TestSeverityTagIsNotATagForFolding guards the rule above: "WARNING:" is a
+// severity marker every unrelated failure shares, so folding on it would
+// swallow every warning into whichever one came first.
+func TestSeverityTagIsNotATagForFolding(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__pi.log",
+		"# fleet update — host=pi started=x\n"+
+			"03:47:10 WARNING: apt-get update failed; installs may be incomplete.\n"+
+			"03:47:11 WARNING: could not install these apt packages: git jq\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+
+	c, _ := Read(filepath.Join(dir, "20260909T034714Z__pi.log"))
+	if ps := c.Problems(); len(ps) != 2 {
+		t.Fatalf("two unrelated warnings are two problems, got %d: %+v", len(ps), ps)
+	}
+}
+
+// TestNearDuplicatesCollapseIntoOne pins the last of the three noise
+// sources. Nine ollama personas failed for ONE reason — a base model that
+// was never pulled — and listed as nine problems they crowded out
+// everything else on the host. They differ only by an identifier in the
+// middle, so they are one problem seen nine times.
+func TestNearDuplicatesCollapseIntoOne(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	b.WriteString("# fleet update — host=pi started=x\n")
+	for _, name := range []string{
+		"ai-ci-aiarch", "architecture-adversary", "architecture-em",
+		"architecture-principal", "architecture-secarch", "architecture-sysarch",
+	} {
+		b.WriteString("03:47:30 WARNING: ollama create teams-" + name +
+			" failed (base model 'qwen3.8:27b' likely not pulled) — Modelfile still written\n")
+	}
+	b.WriteString("# 2026-09-09T03:50:36Z finished\n")
+	write(t, dir, "20260909T034714Z__pi.log", b.String())
+
+	c, _ := Read(filepath.Join(dir, "20260909T034714Z__pi.log"))
+	ps := c.Problems()
+
+	if len(ps) != 1 {
+		t.Fatalf("six spellings of one failure are one problem, got %d: %+v", len(ps), ps)
+	}
+	if ps[0].Count != 6 {
+		t.Errorf("Count = %d, want 6", ps[0].Count)
+	}
+	if !strings.Contains(ps[0].Text, "ollama create teams-") ||
+		!strings.Contains(ps[0].Text, "likely not pulled") {
+		t.Errorf("the collapsed text must keep both the shared head and tail: %q", ps[0].Text)
+	}
+	if !strings.Contains(ps[0].Text, "…") {
+		t.Errorf("the varying middle must be elided, not invented: %q", ps[0].Text)
+	}
+}
+
+// TestDistinctFailuresAreNotMerged guards it. These two share a long tag and
+// both end in a period, but they are entirely different problems; merging
+// them would erase one. Collapsing must need a substantial shared HEAD and
+// TAIL, not merely a common prefix.
+func TestDistinctFailuresAreNotMerged(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__pi.log",
+		"# fleet update — host=pi started=x\n"+
+			"03:47:10 !! install_herdr: /home/u/.config/herdr/config.toml is hand-edited; leaving it alone.\n"+
+			"03:47:11 !! install_herdr: another herdr is earlier in PATH: /home/u/.local/bin/herdr; remove it.\n"+
+			"03:47:12 WARNING: apt-get update failed; installs may be incomplete.\n"+
+			"03:47:13 WARNING: could not install these apt packages: git jq\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+
+	c, _ := Read(filepath.Join(dir, "20260909T034714Z__pi.log"))
+	if ps := c.Problems(); len(ps) != 4 {
+		var got []string
+		for _, p := range ps {
+			got = append(got, p.Text)
+		}
+		t.Fatalf("four distinct problems must stay four, got %d:\n%s", len(ps), strings.Join(got, "\n"))
+	}
+}
+
+// TestFailureIsDecidedByContentNotStream pins that "WARNING: … failed" is a
+// failure wherever it was written. install.sh sends some of its own warnings
+// to stdout and others to stderr — on one host every install failure arrived
+// on stdout, on another every one arrived on stderr — so keying the class off
+// the stream classified a host's real failures as raw stderr and left the
+// failures group empty on exactly the hosts that had them.
+//
+// The stream still decides one thing: an unrecognised stderr line is
+// cause-level evidence (ClassStderr), because stderr is where subprocesses
+// report. It just cannot outrank an explicit WARNING:/ERROR: marker.
+func TestFailureIsDecidedByContentNotStream(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__pi.log",
+		"# fleet update — host=pi started=x\n"+
+			"03:47:10 WARNING: ollama create teams-x failed (base model not pulled)\n"+
+			"03:47:11 !! WARNING: cannot detect the focused window on this wayland session.\n"+
+			"03:47:12 !! sudo: a password is required\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+
+	c, _ := Read(filepath.Join(dir, "20260909T034714Z__pi.log"))
+	got := map[string]Class{}
+	for _, p := range c.Problems() {
+		got[p.Text] = p.Class
+	}
+
+	if cl := got["WARNING: ollama create teams-x failed (base model not pulled)"]; cl != ClassFailure {
+		t.Errorf("a stdout WARNING is a failure, got %v", cl)
+	}
+	if cl := got["WARNING: cannot detect the focused window on this wayland session."]; cl != ClassFailure {
+		t.Errorf("a stderr WARNING is ALSO a failure — the stream must not decide, got %v", cl)
+	}
+	if cl := got["sudo: a password is required"]; cl != ClassStderr {
+		t.Errorf("an unmarked stderr line stays cause-level evidence, got %v", cl)
+	}
+}
+
+// TestClassLabelsAgreeWithTheirCount keeps the headline from reading as a
+// template bug. "stderr" is invariant; the other two inflect.
+func TestClassLabelsAgreeWithTheirCount(t *testing.T) {
+	for _, tc := range []struct {
+		class Class
+		n     int
+		want  string
+	}{
+		{ClassFailure, 1, "1 failure"},
+		{ClassFailure, 3, "3 failures"},
+		{ClassAdvisory, 1, "1 advisory"},
+		{ClassAdvisory, 2, "2 advisories"},
+		{ClassStderr, 1, "1 stderr"},
+		{ClassStderr, 4, "4 stderr"},
+	} {
+		if got := tc.class.Label(tc.n); got != tc.want {
+			t.Errorf("Label(%d) = %q, want %q", tc.n, got, tc.want)
+		}
 	}
 }

--- a/sdk/fleet/internal/histindex/histindex_test.go
+++ b/sdk/fleet/internal/histindex/histindex_test.go
@@ -1,0 +1,192 @@
+package histindex
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func write(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestScanReadsHostAndTimeNewestFirst pins the listing order and the
+// filename decode. Captures are named <UTC>__<subject>.log by libs/log, so
+// the host and the run time are both recoverable without opening the file —
+// which is what makes listing a few hundred runs cheap.
+func TestScanReadsHostAndTimeNewestFirst(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260908T120000Z__alpha.log", "# h\n")
+	write(t, dir, "20260909T030000Z__beta.log", "# h\n")
+	write(t, dir, "20260907T010000Z__alpha.log", "# h\n")
+	write(t, dir, "notes.txt", "not a capture")
+
+	runs, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(runs) != 3 {
+		t.Fatalf("got %d runs, want 3 (notes.txt must be ignored): %+v", len(runs), runs)
+	}
+
+	want := []struct {
+		host string
+		at   time.Time
+	}{
+		{"beta", time.Date(2026, 9, 9, 3, 0, 0, 0, time.UTC)},
+		{"alpha", time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)},
+		{"alpha", time.Date(2026, 9, 7, 1, 0, 0, 0, time.UTC)},
+	}
+	for i, w := range want {
+		if runs[i].Host != w.host || !runs[i].At.Equal(w.at) {
+			t.Errorf("run %d = %s@%s, want %s@%s", i, runs[i].Host, runs[i].At, w.host, w.at)
+		}
+	}
+}
+
+// TestScanDecodesAHostContainingTheSeparator pins that the decode is
+// positional, not a split on "__". SafeName permits underscores, so a host
+// literally named "a__b" produces "<ts>__a__b.log"; splitting on the first
+// "__" would report the host as "a" and splitting on the last as "b".
+func TestScanDecodesAHostContainingTheSeparator(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260908T120000Z__a__b.log", "# h\n")
+
+	runs, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(runs) != 1 || runs[0].Host != "a__b" {
+		t.Fatalf("got %+v, want one run for host a__b", runs)
+	}
+}
+
+// TestScanIgnoresAnythingItCannotDecode pins that a stray file never becomes
+// a bogus row: a missing directory is an empty history, not an error, because
+// "no runs yet" is the normal state on a fresh machine.
+func TestScanIgnoresAnythingItCannotDecode(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "not-a-timestamp__alpha.log", "# h\n")
+	write(t, dir, "20260908T120000Z-no-separator.log", "# h\n")
+
+	runs, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("got %+v, want none", runs)
+	}
+
+	if runs, err := Scan(filepath.Join(dir, "does-not-exist")); err != nil || len(runs) != 0 {
+		t.Fatalf("a missing dir must be an empty history, got %v / %+v", err, runs)
+	}
+}
+
+// realCapture mirrors the shape libs/log + updexec actually write: a "# "
+// header, "HH:MM:SS text" body lines with stderr marked "!! ", and a
+// "# <iso> finished" footer.
+const realCapture = `# fleet update — host=pi plan=built-in default mode=fast-forward started=2026-09-08T20:47:14-07:00
+03:47:14 === step dotfiles.sync (sync) ===
+03:47:14 state=clean branch=main
+03:47:16 !! From github.com:sfc-gh-eraigosa/dotfiles
+03:47:16 !!  * branch            main       -> FETCH_HEAD
+03:47:16 Already up to date.
+03:47:20 !! fatal: could not read Username
+# 2026-09-09T03:50:36Z finished
+`
+
+// TestReadSplitsHeaderBodyAndFooter pins the decode of a capture's three
+// parts, and that the "!! " stderr mark is turned back into structure rather
+// than left in the text. The mark exists so a post-mortem can tell a warning
+// from progress; a reader that kept it as literal text would make every
+// stderr line sort and grep differently from its stdout neighbours.
+func TestReadSplitsHeaderBodyAndFooter(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__pi.log", realCapture)
+
+	c, err := Read(filepath.Join(dir, "20260909T034714Z__pi.log"))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if !strings.Contains(c.Header, "host=pi") {
+		t.Errorf("header = %q, want it to carry the run's metadata", c.Header)
+	}
+	if !strings.Contains(c.Footer, "finished") {
+		t.Errorf("footer = %q, want the finished marker", c.Footer)
+	}
+	if len(c.Lines) != 6 {
+		t.Fatalf("got %d body lines, want 6: %+v", len(c.Lines), c.Lines)
+	}
+
+	first := c.Lines[0]
+	if first.Time != "03:47:14" || first.Stderr || first.Text != "=== step dotfiles.sync (sync) ===" {
+		t.Errorf("line 0 = %+v, want the stdout step banner with its time split off", first)
+	}
+
+	fetch := c.Lines[2]
+	if !fetch.Stderr || fetch.Text != "From github.com:sfc-gh-eraigosa/dotfiles" {
+		t.Errorf("line 2 = %+v, want stderr with the !! mark removed", fetch)
+	}
+}
+
+// TestReadCountsOnlyNonBenignStderrAsAWarning pins that the count matches
+// what the TUI's error pane badges. Git writes its whole fetch progress to
+// stderr on a completely healthy run, so counting raw stderr lines would put
+// a warning badge on every successful update and make the signal worthless.
+// updexec.Benign is the SAME classifier the TUI uses — deliberately shared,
+// so the CLI and the dashboard can never disagree about what an error is.
+func TestReadCountsOnlyNonBenignStderrAsAWarning(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__pi.log", realCapture)
+
+	c, err := Read(filepath.Join(dir, "20260909T034714Z__pi.log"))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if got := c.Stderr(); len(got) != 3 {
+		t.Errorf("Stderr() returned %d lines, want all 3 marked ones", len(got))
+	}
+	if c.Warnings != 1 {
+		t.Errorf("Warnings = %d, want 1 — only the `fatal:` line is non-benign; "+
+			"git's two fetch-progress lines are routine", c.Warnings)
+	}
+}
+
+// TestSummarizeReportsFinishAndWarnings pins the two facts the listing shows
+// that a filename cannot supply. A capture with no "finished" footer is a run
+// that was killed or is still going — distinct from one that finished badly,
+// and the listing must not conflate them.
+func TestSummarizeReportsFinishAndWarnings(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__pi.log", realCapture)
+	cut := "# fleet update — host=nano started=x\n03:47:14 working\n"
+	write(t, dir, "20260909T034715Z__nano.log", cut)
+
+	runs, err := Scan(dir)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	got := map[string]Summary{}
+	for _, r := range runs {
+		s, err := Summarize(r)
+		if err != nil {
+			t.Fatalf("Summarize(%s): %v", r.Host, err)
+		}
+		got[r.Host] = s
+	}
+
+	if !got["pi"].Finished || got["pi"].Warnings != 1 {
+		t.Errorf("pi = %+v, want finished with 1 warning", got["pi"])
+	}
+	if got["nano"].Finished {
+		t.Errorf("nano = %+v, want NOT finished — it has no footer", got["nano"])
+	}
+}

--- a/sdk/fleet/internal/histindex/histindex_test.go
+++ b/sdk/fleet/internal/histindex/histindex_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
 )
 
 func write(t *testing.T, dir, name, body string) {
@@ -188,5 +190,218 @@ func TestSummarizeReportsFinishAndWarnings(t *testing.T) {
 	}
 	if got["nano"].Finished {
 		t.Errorf("nano = %+v, want NOT finished — it has no footer", got["nano"])
+	}
+}
+
+// problemCapture is the shape a real broken run has: install.sh's own
+// WARNING: diagnosis on STDOUT, the mechanical noise underneath it on
+// stderr, repeated many times, plus routine chatter that is neither.
+const problemCapture = `# fleet update — host=gig started=x
+03:47:15 === step dotfiles.install (run) ===
+03:47:16 !! From https://github.com/o/r
+03:47:16 !! Already on 'main'
+03:47:18 !! sudo: a password is required
+03:47:18 !! sudo: a password is required
+03:47:18 !! sudo: a password is required
+03:47:18 WARNING: apt-get update failed; installs may be incomplete.
+03:47:19 WARNING: could not install these apt packages: git gh jq
+03:47:20 Installing fnm...
+# 2026-09-09T03:50:36Z finished
+`
+
+// TestProblemsLeadWithTheAuthoredDiagnosis pins the ordering that makes this
+// useful. install.sh writes its OWN explanation of what broke to stdout
+// ("WARNING: could not install these apt packages: …"); the stderr underneath
+// is the mechanical cause, repeated once per failed call. A digest that
+// showed only stderr — which is what a stdout/stderr split gives you — would
+// print 37 copies of "sudo: a password is required" and never once mention
+// that 32 packages are missing. The authored line comes first because it is
+// the one a human can act on.
+func TestProblemsLeadWithTheAuthoredDiagnosis(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__gig.log", problemCapture)
+
+	c, err := Read(filepath.Join(dir, "20260909T034714Z__gig.log"))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	ps := c.Problems()
+
+	if len(ps) != 3 {
+		t.Fatalf("got %d problems, want 3 (2 diagnoses + 1 collapsed stderr): %+v", len(ps), ps)
+	}
+	if !strings.HasPrefix(ps[0].Text, "WARNING: apt-get update failed") {
+		t.Errorf("problem 0 = %q, want the first authored WARNING", ps[0].Text)
+	}
+	if !strings.Contains(ps[1].Text, "could not install these apt packages") {
+		t.Errorf("problem 1 = %q, want the second authored WARNING", ps[1].Text)
+	}
+	if !ps[0].Authored || ps[2].Authored {
+		t.Errorf("Authored must separate install.sh's diagnosis from raw stderr: %+v", ps)
+	}
+}
+
+// TestProblemsCollapseRepeats pins the collapsing. The same failure repeated
+// once per privileged call is ONE problem seen N times, not N problems; a
+// digest that listed each occurrence would bury the other findings exactly
+// the way the raw log does.
+func TestProblemsCollapseRepeats(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__gig.log", problemCapture)
+
+	c, _ := Read(filepath.Join(dir, "20260909T034714Z__gig.log"))
+	var sudo *Problem
+	for i := range c.Problems() {
+		if strings.Contains(c.Problems()[i].Text, "sudo") {
+			sudo = &c.Problems()[i]
+		}
+	}
+	if sudo == nil {
+		t.Fatal("the repeated sudo failure must be reported")
+	}
+	if sudo.Count != 3 {
+		t.Errorf("Count = %d, want 3 — the three occurrences collapse into one entry", sudo.Count)
+	}
+	if sudo.First != "03:47:18" {
+		t.Errorf("First = %q, want the earliest occurrence", sudo.First)
+	}
+}
+
+// TestProblemsExcludeRoutineChatter pins that benign stderr and ordinary
+// stdout never reach the digest. If a healthy run produced problems, the
+// digest would be as useless as the raw log.
+func TestProblemsExcludeRoutineChatter(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__gig.log", problemCapture)
+
+	c, _ := Read(filepath.Join(dir, "20260909T034714Z__gig.log"))
+	for _, p := range c.Problems() {
+		if strings.Contains(p.Text, "From https://") ||
+			strings.Contains(p.Text, "Already on") ||
+			strings.Contains(p.Text, "Installing fnm") {
+			t.Errorf("routine line reached the digest: %q", p.Text)
+		}
+	}
+}
+
+// TestCleanRunHasNoProblems pins the other end: the run that fixed the host
+// must digest to nothing at all.
+func TestCleanRunHasNoProblems(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__pi.log", realCapture)
+
+	c, _ := Read(filepath.Join(dir, "20260909T034714Z__pi.log"))
+	ps := c.Problems()
+	if len(ps) != 1 || !strings.Contains(ps[0].Text, "fatal: could not read Username") {
+		t.Fatalf("want only the genuine fatal line, got %+v", ps)
+	}
+}
+
+// TestUncapturedRunIsNotReportedAsProblemFree pins the distinction between
+// "nothing went wrong" and "I could not see what happened". An interactive
+// run's output never reaches the capture, so its digest is empty for the
+// same reason a perfect run's is — and calling that clean would present an
+// entirely unobserved host as verified, which is the exact failure mode
+// (a host reporting success it never earned) fleet exists to prevent.
+func TestUncapturedRunIsNotReportedAsProblemFree(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__gig.log",
+		"# fleet update — host=gig started=x\n"+
+			"04:32:23 === step dotfiles.install (run) ===\n"+
+			"04:32:23 "+updexec.InteractiveNote+"\n"+
+			"# 2026-09-09T04:34:20Z finished\n")
+
+	c, err := Read(filepath.Join(dir, "20260909T034714Z__gig.log"))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(c.Problems()) != 0 {
+		t.Fatalf("the note itself must not be a problem: %+v", c.Problems())
+	}
+	if c.Observed {
+		t.Error("a run whose output went to the terminal was NOT observed; " +
+			"an empty digest here means unseen, not clean")
+	}
+
+	clean, _ := Read(filepath.Join(dir, "20260909T034714Z__gig.log"))
+	_ = clean
+	dir2 := t.TempDir()
+	write(t, dir2, "20260909T034714Z__pi.log", realCapture)
+	c2, _ := Read(filepath.Join(dir2, "20260909T034714Z__pi.log"))
+	if !c2.Observed {
+		t.Error("a fully captured run IS observed")
+	}
+}
+
+// TestProblemsStripColourBeforeGrouping pins that escape sequences do not
+// reach the digest. install.sh colourises its own warnings, so the same
+// message wrapped in different escapes would group as two distinct problems
+// and would render as literal "[1;33m" noise in a summary whose entire job
+// is to be readable at a glance. --show still prints the file's own bytes;
+// the digest is a summary, and a summary normalises.
+func TestProblemsStripColourBeforeGrouping(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T034714Z__gig.log",
+		"# fleet update — host=gig started=x\n"+
+			"03:47:18 \x1b[1;33mWARNING: disk is nearly full\x1b[0m\n"+
+			"03:47:19 WARNING: disk is nearly full\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+
+	c, _ := Read(filepath.Join(dir, "20260909T034714Z__gig.log"))
+	ps := c.Problems()
+	if len(ps) != 1 {
+		t.Fatalf("the same message in two colourings is ONE problem, got %d: %+v", len(ps), ps)
+	}
+	if ps[0].Count != 2 {
+		t.Errorf("Count = %d, want 2", ps[0].Count)
+	}
+	if strings.Contains(ps[0].Text, "\x1b") {
+		t.Errorf("escape sequences must not reach the digest: %q", ps[0].Text)
+	}
+}
+
+// TestARunStepWithNoOutputIsUnobserved pins detection that works on
+// captures written BEFORE the interactive note existed — which is every
+// capture already on disk, and therefore every past run someone would use
+// this to investigate. A `run` step whose banner is followed by nothing at
+// all produced no output we can see: either it was interactive (ssh -t took
+// the terminal) or it was genuinely silent, and the capture cannot tell
+// which. Both mean "not observed", so the conservative reading is the
+// correct one — the failure direction is admitting we cannot vouch for a
+// run, never vouching for one we did not see.
+func TestARunStepWithNoOutputIsUnobserved(t *testing.T) {
+	dir := t.TempDir()
+	// exactly the shape of a real interactive capture: sync output, then an
+	// install banner with nothing after it.
+	write(t, dir, "20260909T043222Z__gig.log",
+		"# fleet update — host=gig started=x\n"+
+			"04:32:22 === step dotfiles.sync (sync) ===\n"+
+			"04:32:23 Already up to date.\n"+
+			"04:32:23 === step dotfiles.install (run) ===\n"+
+			"# 2026-09-09T04:34:20Z finished\n")
+
+	c, err := Read(filepath.Join(dir, "20260909T043222Z__gig.log"))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if c.Observed {
+		t.Error("a run step that produced no captured output means the run was not observed")
+	}
+}
+
+// TestARunStepWithOutputIsObserved guards the other direction: a step that
+// actually produced output must not be written off as unseen, or the flag
+// would fire on every healthy run and mean nothing.
+func TestARunStepWithOutputIsObserved(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "20260909T043222Z__gig.log",
+		"# fleet update — host=gig started=x\n"+
+			"04:32:23 === step dotfiles.install (run) ===\n"+
+			"04:32:24 Installing packages...\n"+
+			"# 2026-09-09T04:34:20Z finished\n")
+
+	c, _ := Read(filepath.Join(dir, "20260909T043222Z__gig.log"))
+	if !c.Observed {
+		t.Error("a run step with output WAS observed")
 	}
 }

--- a/sdk/fleet/internal/histindex/problems.go
+++ b/sdk/fleet/internal/histindex/problems.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
-	"github.com/charmbracelet/x/ansi"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
 )
 
@@ -213,7 +213,7 @@ func (c Capture) Problems() []Problem {
 		// sequence hid the "WARNING:" prefix from the matcher entirely —
 		// the coloured half of a message was not merely grouped separately,
 		// it was not recognised as a problem at all.
-		l.Text = strings.TrimRight(ansi.Strip(l.Text), " \t")
+		l.Text = clean(l.Text)
 		problem := (!l.Stderr && authoredProblem.MatchString(strings.TrimSpace(l.Text))) ||
 			(l.Stderr && !updexec.Benign(l.Text))
 		if !problem {
@@ -302,6 +302,12 @@ func collapseNearDuplicates(ps []Problem) []Problem {
 			out[i].prefix, out[i].suffix = pre, suf
 			out[i].Count += p.Count
 			out[i].Text = pre + "…" + suf
+			// The merged entry's OWN continuation lines come with it. The
+			// elided middle already costs the reader the identifier; also
+			// dropping the detail under it would delete text nothing else
+			// shows, in a view whose whole contract is that it classifies
+			// rather than hides.
+			out[i].Detail = append(out[i].Detail, p.Detail...)
 			if p.First < out[i].First {
 				out[i].First = p.First
 			}
@@ -320,11 +326,20 @@ func collapseNearDuplicates(ps []Problem) []Problem {
 	return res
 }
 
+// commonPrefix and commonSuffix compare BYTES but cut on RUNE boundaries.
+// Two different runes can share leading bytes ("…" is E2 80 A6 and "—" is
+// E2 80 94), so a byte-exact cut can land inside one and put half a rune
+// into the elided text — mojibake in the single line the digest exists to
+// make readable. Backing off to the nearest boundary costs at most a byte
+// or two of shared affix.
 func commonPrefix(a, b string) string {
 	n := min(len(a), len(b))
 	i := 0
 	for i < n && a[i] == b[i] {
 		i++
+	}
+	for i > 0 && i < len(a) && !utf8.RuneStart(a[i]) {
+		i--
 	}
 	return a[:i]
 }
@@ -334,6 +349,9 @@ func commonSuffix(a, b string) string {
 	i := 0
 	for i < n && a[len(a)-1-i] == b[len(b)-1-i] {
 		i++
+	}
+	for i > 0 && !utf8.RuneStart(a[len(a)-i]) {
+		i--
 	}
 	return a[len(a)-i:]
 }

--- a/sdk/fleet/internal/histindex/problems.go
+++ b/sdk/fleet/internal/histindex/problems.go
@@ -1,0 +1,102 @@
+package histindex
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
+)
+
+// authoredProblem matches a line the INSTALLER wrote about its own failure.
+// install.sh reports what actually broke this way — "WARNING: could not
+// install these apt packages: …" — and it writes it to STDOUT, because it is
+// a message to the operator rather than a subprocess's error channel.
+//
+// This is the whole reason a digest cannot be built on the stdout/stderr
+// split. On a host whose sudo was broken, stderr held 74 lines that were two
+// distinct messages repeated 37 times each; the five lines that explained
+// what the machine was now MISSING were all stdout. Filtering to stderr
+// showed the mechanism and hid the consequence.
+var authoredProblem = regexp.MustCompile(`^(WARNING|ERROR|FATAL|FAILED)\b`)
+
+// Problem is one distinct thing that went wrong, however many times it
+// happened.
+type Problem struct {
+	Text string
+	// Count is how many times this exact line appeared. A failure repeated
+	// once per privileged call is one problem seen N times, not N problems.
+	Count int
+	// First is the earliest occurrence's timestamp.
+	First string
+	// Authored distinguishes the installer's own explanation from the raw
+	// stderr underneath it. Authored lines are the ones a human can act on.
+	Authored bool
+}
+
+// Problems is the digest: every distinct problem in the capture, the
+// installer's own diagnosis first (in the order it was written), then
+// non-benign stderr with the loudest first.
+//
+// Ordering is the point. Raw order buries the authored explanation under
+// whatever repeated most; count order alone leads with the mechanism rather
+// than the consequence. Leading with what the installer SAID broke, then
+// showing what it saw, is the order someone debugging actually reads in.
+func (c Capture) Problems() []Problem {
+	type acc struct {
+		Problem
+		seq int
+	}
+	seen := map[string]*acc{}
+	var order int
+
+	add := func(l Line, authored bool) {
+		if a, ok := seen[l.Text]; ok {
+			a.Count++
+			return
+		}
+		order++
+		seen[l.Text] = &acc{
+			Problem: Problem{Text: l.Text, Count: 1, First: l.Time, Authored: authored},
+			seq:     order,
+		}
+	}
+
+	for _, l := range c.Lines {
+		// Colour is stripped BEFORE matching, not just before printing.
+		// install.sh colourises its own warnings, so a leading escape
+		// sequence hid the "WARNING:" prefix from the matcher entirely —
+		// the coloured half of a message was not merely grouped separately,
+		// it was not recognised as a problem at all.
+		l.Text = strings.TrimRight(ansi.Strip(l.Text), " \t")
+		switch {
+		case !l.Stderr && authoredProblem.MatchString(strings.TrimSpace(l.Text)):
+			add(l, true)
+		case l.Stderr && !updexec.Benign(l.Text):
+			add(l, false)
+		}
+	}
+
+	out := make([]Problem, 0, len(seen))
+	accs := make([]*acc, 0, len(seen))
+	for _, a := range seen {
+		accs = append(accs, a)
+	}
+	sort.Slice(accs, func(i, j int) bool {
+		if accs[i].Authored != accs[j].Authored {
+			return accs[i].Authored // authored diagnosis leads
+		}
+		if accs[i].Authored {
+			return accs[i].seq < accs[j].seq // in the order it was written
+		}
+		if accs[i].Count != accs[j].Count {
+			return accs[i].Count > accs[j].Count // then loudest stderr first
+		}
+		return accs[i].seq < accs[j].seq
+	})
+	for _, a := range accs {
+		out = append(out, a.Problem)
+	}
+	return out
+}

--- a/sdk/fleet/internal/histindex/problems.go
+++ b/sdk/fleet/internal/histindex/problems.go
@@ -1,6 +1,7 @@
 package histindex
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"strings"
@@ -21,6 +22,91 @@ import (
 // showed the mechanism and hid the consequence.
 var authoredProblem = regexp.MustCompile(`^(WARNING|ERROR|FATAL|FAILED)\b`)
 
+// Class sorts a problem by what it means, so triage can work down the list
+// instead of reading all of it. Nothing is ever hidden by class — a filter
+// that hides is a filter that can hide the one line that mattered.
+type Class int
+
+const (
+	// ClassFailure is the installer saying something it tried did not work.
+	// These are what an operator can act on, so they lead.
+	ClassFailure Class = iota
+	// ClassStderr is non-benign stderr: usually the mechanical cause under a
+	// failure ("sudo: a password is required"), occasionally the only
+	// evidence there is.
+	ClassStderr
+	// ClassAdvisory is a tool announcing news about ITSELF — an available
+	// upgrade, a config suggestion. Nothing failed. Grouping these with real
+	// failures is what made a healthy host report 34 problems.
+	ClassAdvisory
+)
+
+// Label names the class with its count, inflected. "stderr" is a stream
+// name, not a countable noun, so it never takes an s.
+func (c Class) Label(n int) string {
+	switch {
+	case c == ClassStderr:
+		return fmt.Sprintf("%d stderr", n)
+	case n == 1 && c == ClassFailure:
+		return "1 failure"
+	case n == 1:
+		return "1 advisory"
+	default:
+		return fmt.Sprintf("%d %s", n, c)
+	}
+}
+
+// String names the class for rendering and grouping.
+func (c Class) String() string {
+	switch c {
+	case ClassFailure:
+		return "failures"
+	case ClassStderr:
+		return "stderr"
+	default:
+		return "advisories"
+	}
+}
+
+// advisoryPatterns match tools reporting on themselves. Kept SHORT and
+// specific on purpose: an unrecognised line stays a failure, the same
+// conservative default updexec.Benign uses. A false advisory costs a
+// misplaced line in a list the operator can still see; a false failure costs
+// only a glance.
+var advisoryPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`^npm warn `),
+	regexp.MustCompile(`^\[notice\]`),
+	regexp.MustCompile(`^Updates are available for some .* components`),
+	regexp.MustCompile(`^WARNING: Running pip as the '?root'? user`),
+}
+
+// classify decides what a line means, from its CONTENT first.
+//
+// An explicit WARNING:/ERROR: marker makes it a failure wherever it was
+// written. install.sh sends some of its own warnings to stdout and others to
+// stderr — on one host every install failure arrived on stdout, on another
+// every one arrived on stderr — so letting the stream decide left the
+// failures group empty on exactly the hosts that had failures.
+//
+// The stream still decides the remainder: an unrecognised stderr line is
+// cause-level evidence, because stderr is where subprocesses report. It just
+// cannot outrank an explicit marker.
+func classify(text string, stderr bool) Class {
+	t := strings.TrimSpace(text)
+	for _, re := range advisoryPatterns {
+		if re.MatchString(t) {
+			return ClassAdvisory
+		}
+	}
+	if authoredProblem.MatchString(t) {
+		return ClassFailure
+	}
+	if stderr {
+		return ClassStderr
+	}
+	return ClassFailure
+}
+
 // Problem is one distinct thing that went wrong, however many times it
 // happened.
 type Problem struct {
@@ -30,9 +116,65 @@ type Problem struct {
 	Count int
 	// First is the earliest occurrence's timestamp.
 	First string
-	// Authored distinguishes the installer's own explanation from the raw
-	// stderr underneath it. Authored lines are the ones a human can act on.
-	Authored bool
+	// Class is what this line means — see Class.
+	Class Class
+	// Detail holds the continuation lines of a multi-line message. They are
+	// attached rather than dropped: the whole text stays readable, it just
+	// stops being counted as several unrelated problems.
+	Detail []string
+}
+
+// severityTag matches a leading severity marker. It is stripped before the
+// indentation test, so "WARNING:   ln -s …" is recognised as indented — but
+// it is deliberately NOT usable as a folding tag, since every unrelated
+// failure shares it and folding on it would swallow them all into the first.
+var severityTag = regexp.MustCompile(`^(WARNING|WARN|ERROR|FATAL|NOTICE|W|E):`)
+
+// toolTag matches a tool prefixing its own name to every line of one
+// message ("goenv: …", "npm warn allow-scripts …"). Two adjacent lines
+// sharing one belong to the same message.
+var toolTag = regexp.MustCompile(`^(npm warn [a-z-]+|[a-z][a-z0-9_.-]*:)`)
+
+// continues reports whether cur is a continuation of prev.
+//
+// Three signals, all drawn from real captures:
+//
+//   - prev ends mid-sentence (", " / ":" / "\") — gcloud's
+//     "…To install them," / "please run:" / "  $ gcloud components update".
+//   - cur is indented once its severity tag is removed — keyd's
+//     "WARNING:   ln -s …" under "WARNING: Wayland needs …".
+//   - both carry the same tool tag AND the same timestamp — goenv's
+//     "goenv: …" block, without merging a tool's separate remarks.
+//
+// A miss costs tidiness (the line stands alone, as before), never
+// information, so the rules stay shallow on purpose.
+func continues(prev, cur Line) bool {
+	if prev.Text == "" {
+		return false
+	}
+	p := strings.TrimRight(prev.Text, " ")
+	if strings.HasSuffix(p, ",") || strings.HasSuffix(p, ":") || strings.HasSuffix(p, "\\") {
+		return true
+	}
+	// TWO spaces, not one: "WARNING: text" always has one separating space,
+	// so a single-space test made every warning a continuation of the
+	// warning before it and collapsed the whole list into its first entry.
+	// Real continuations are visibly indented ("WARNING:   ln -s …").
+	if body := severityTag.ReplaceAllString(cur.Text, ""); body != cur.Text && strings.HasPrefix(body, "  ") {
+		return true
+	}
+	// Same tool tag AND the same timestamp. The tag alone is not enough:
+	// one tool emits many INDEPENDENT messages ("install_herdr: config is
+	// hand-edited" and "install_herdr: another herdr is earlier in PATH" are
+	// two different problems), and folding on the tag merged them. A
+	// multi-line message is written in one go, so sharing a second is the
+	// signal that separates a continuation from the tool's next remark.
+	pt := toolTag.FindString(strings.TrimSpace(prev.Text))
+	ct := toolTag.FindString(strings.TrimSpace(cur.Text))
+	if ct != "" && ct == pt && prev.Time == cur.Time && !severityTag.MatchString(ct) {
+		return true
+	}
+	return false
 }
 
 // Problems is the digest: every distinct problem in the capture, the
@@ -51,18 +193,20 @@ func (c Capture) Problems() []Problem {
 	seen := map[string]*acc{}
 	var order int
 
-	add := func(l Line, authored bool) {
+	add := func(l Line) {
 		if a, ok := seen[l.Text]; ok {
 			a.Count++
 			return
 		}
 		order++
 		seen[l.Text] = &acc{
-			Problem: Problem{Text: l.Text, Count: 1, First: l.Time, Authored: authored},
+			Problem: Problem{Text: l.Text, Count: 1, First: l.Time, Class: classify(l.Text, l.Stderr)},
 			seq:     order,
 		}
 	}
 
+	var last *acc
+	var lastLine Line
 	for _, l := range c.Lines {
 		// Colour is stripped BEFORE matching, not just before printing.
 		// install.sh colourises its own warnings, so a leading escape
@@ -70,12 +214,24 @@ func (c Capture) Problems() []Problem {
 		// the coloured half of a message was not merely grouped separately,
 		// it was not recognised as a problem at all.
 		l.Text = strings.TrimRight(ansi.Strip(l.Text), " \t")
-		switch {
-		case !l.Stderr && authoredProblem.MatchString(strings.TrimSpace(l.Text)):
-			add(l, true)
-		case l.Stderr && !updexec.Benign(l.Text):
-			add(l, false)
+		problem := (!l.Stderr && authoredProblem.MatchString(strings.TrimSpace(l.Text))) ||
+			(l.Stderr && !updexec.Benign(l.Text))
+		if !problem {
+			last, lastLine = nil, Line{}
+			continue
 		}
+		// A line already recorded as its own problem is a REPEAT, not a
+		// continuation — checked first because a repeated tagged line
+		// ("sudo: a password is required" three times) satisfies the
+		// same-tool-tag rule and would otherwise fold into itself and
+		// lose its count.
+		if _, dup := seen[l.Text]; !dup && last != nil && continues(lastLine, l) {
+			last.Detail = append(last.Detail, l.Text)
+			lastLine = l
+			continue
+		}
+		add(l)
+		last, lastLine = seen[l.Text], l
 	}
 
 	out := make([]Problem, 0, len(seen))
@@ -84,19 +240,100 @@ func (c Capture) Problems() []Problem {
 		accs = append(accs, a)
 	}
 	sort.Slice(accs, func(i, j int) bool {
-		if accs[i].Authored != accs[j].Authored {
-			return accs[i].Authored // authored diagnosis leads
+		if accs[i].Class != accs[j].Class {
+			return accs[i].Class < accs[j].Class // failures, stderr, advisories
 		}
-		if accs[i].Authored {
+		if accs[i].Class == ClassFailure {
 			return accs[i].seq < accs[j].seq // in the order it was written
 		}
 		if accs[i].Count != accs[j].Count {
-			return accs[i].Count > accs[j].Count // then loudest stderr first
+			return accs[i].Count > accs[j].Count // then loudest first
 		}
 		return accs[i].seq < accs[j].seq
 	})
 	for _, a := range accs {
 		out = append(out, a.Problem)
 	}
-	return out
+	return collapseNearDuplicates(out)
+}
+
+// minAffix is how much shared head AND tail two lines need before they are
+// treated as one failure with a varying middle. Twelve characters is enough
+// to require a real shared sentence: "WARNING: " alone is nine, so the two
+// unrelated apt warnings can never merge, and two remarks from one tool that
+// merely both end in a period share a one-character tail.
+const minAffix = 12
+
+// minAffixRatio additionally requires the shared parts to dominate the line.
+// Without it, two long messages that happen to share a boilerplate opening
+// and closing would collapse despite differing throughout the middle — where
+// the meaning is.
+const minAffixRatio = 0.5
+
+// collapseNearDuplicates merges problems that differ only by an identifier:
+// nine ollama personas that failed for one reason, five memory files skipped
+// for one reason. Listed separately they crowd out everything else on the
+// host; merged they are one line with a count.
+//
+// The varying middle is ELIDED with "…" rather than replaced by one of the
+// values — printing a single representative would state that a specific
+// persona failed when what is known is that nine did.
+func collapseNearDuplicates(ps []Problem) []Problem {
+	type cluster struct {
+		Problem
+		prefix, suffix string
+	}
+	var out []cluster
+
+	for _, p := range ps {
+		merged := false
+		for i := range out {
+			if out[i].Class != p.Class {
+				continue
+			}
+			pre := commonPrefix(out[i].prefix, p.Text)
+			suf := commonSuffix(out[i].suffix, p.Text)
+			shortest := min(len(out[i].prefix)+len(out[i].suffix), len(p.Text))
+			if len(pre) < minAffix || len(suf) < minAffix ||
+				len(pre)+len(suf) > len(p.Text) ||
+				float64(len(pre)+len(suf)) < minAffixRatio*float64(shortest) {
+				continue
+			}
+			out[i].prefix, out[i].suffix = pre, suf
+			out[i].Count += p.Count
+			out[i].Text = pre + "…" + suf
+			if p.First < out[i].First {
+				out[i].First = p.First
+			}
+			merged = true
+			break
+		}
+		if !merged {
+			out = append(out, cluster{Problem: p, prefix: p.Text, suffix: p.Text})
+		}
+	}
+
+	res := make([]Problem, 0, len(out))
+	for _, c := range out {
+		res = append(res, c.Problem)
+	}
+	return res
+}
+
+func commonPrefix(a, b string) string {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return a[:i]
+}
+
+func commonSuffix(a, b string) string {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[len(a)-1-i] == b[len(b)-1-i] {
+		i++
+	}
+	return a[len(a)-i:]
 }

--- a/sdk/fleet/internal/updexec/exec.go
+++ b/sdk/fleet/internal/updexec/exec.go
@@ -265,6 +265,24 @@ func (b Background) Interactive(ctx context.Context, host string, st updplan.Ste
 	return ErrNoTerminal
 }
 
+// batchLane is an OPTIONAL capability of a StepIO lane: it reports that a
+// step the PLAN marks interactive is nonetheless run in BATCH on this lane,
+// so its output does reach the capture after all.
+//
+// It exists because "interactive" is a property of the LANE, not of the plan
+// flag alone (see Background above). Without it, runWithRetry wrote
+// InteractiveNote into every TUI capture of the default plan's install.sh —
+// a step Background captures in full — and histindex then reported those
+// fully-observed runs as "not captured", which is exactly the inversion the
+// note was added to prevent.
+type batchLane interface {
+	runsAsBatch(kind updplan.Kind) bool
+}
+
+// runsAsBatch mirrors Interactive above: a run step is batched (and captured),
+// anything else needs a real terminal.
+func (Background) runsAsBatch(kind updplan.Kind) bool { return kind == updplan.KindRun }
+
 // teeable is an optional capability of a StepIO lane: one that can return a
 // copy of itself whose Batch/Interactive output ALSO reaches an extra
 // callback, without disturbing whatever Line callback it already had.
@@ -884,6 +902,25 @@ func (e Executor) runGhAuth(w LineWriter, host string, st updplan.Step) Result {
 		Attempts: res.Attempts + 1, MaxAttempts: res.MaxAttempts, Notes: notes}
 }
 
+// handsOverTerminal reports whether this step's output really is going
+// somewhere this process cannot see — the only condition under which a
+// capture should admit a gap.
+//
+// The plan's interactive flag alone is NOT that condition: Background runs an
+// interactive run step as Batch and tees every line into the capture, so
+// keying the note off the flag stamped "output went to the terminal" onto
+// captures that hold the whole run, and made histindex report them
+// unobserved.
+func (e Executor) handsOverTerminal(kind updplan.Kind, interactive bool) bool {
+	if !interactive {
+		return false
+	}
+	if b, ok := e.IO.(batchLane); ok && b.runsAsBatch(kind) {
+		return false
+	}
+	return true
+}
+
 // runWithRetry runs call under Executor's clock/sleep/rand, retrying per
 // retry when the failure class matches, up to a bounded number of
 // attempts, each under its own per-attempt deadline.
@@ -926,7 +963,7 @@ func (e Executor) runWithRetry(
 		}
 		header += " ==="
 		w.Line(header)
-		if interactive {
+		if e.handsOverTerminal(kind, interactive) {
 			// An interactive step hands the terminal to the remote command
 			// (ssh -t), so not one byte of its output passes through this
 			// process and none of it can reach the capture. Saying so is the

--- a/sdk/fleet/internal/updexec/exec.go
+++ b/sdk/fleet/internal/updexec/exec.go
@@ -278,6 +278,15 @@ type teeable interface {
 	withLines(out, err func(host, line string)) StepIO
 }
 
+// InteractiveNote is written into a capture in place of an interactive
+// step's output, which fleet never sees — see runWithRetry.
+//
+// EXPORTED because a reader has to be able to tell "this run had no
+// problems" from "this run's output went somewhere I cannot read". Reporting
+// the second as the first is how a host that was never actually observed
+// comes to look verified.
+const InteractiveNote = "(interactive step: output went to the terminal and is not captured here)"
+
 // StderrMark prefixes a stderr line in a host's captured log. Without it a
 // post-mortem of a headless run cannot tell a warning from progress — the
 // distinction exists on the wire now, and throwing it away at the capture is
@@ -917,6 +926,16 @@ func (e Executor) runWithRetry(
 		}
 		header += " ==="
 		w.Line(header)
+		if interactive {
+			// An interactive step hands the terminal to the remote command
+			// (ssh -t), so not one byte of its output passes through this
+			// process and none of it can reach the capture. Saying so is the
+			// difference between a log that is INCOMPLETE and one that looks
+			// like the step did nothing: a two-minute ./install.sh leaves the
+			// same empty banner as a no-op, and `fleet history` cannot tell
+			// the reader which it was unless the file admits the gap itself.
+			w.Line(InteractiveNote)
+		}
 
 		ctx := context.Background()
 		var cancel context.CancelFunc

--- a/sdk/fleet/internal/updexec/exec.go
+++ b/sdk/fleet/internal/updexec/exec.go
@@ -278,11 +278,17 @@ type teeable interface {
 	withLines(out, err func(host, line string)) StepIO
 }
 
-// stderrMark prefixes a stderr line in a host's captured log. Without it a
+// StderrMark prefixes a stderr line in a host's captured log. Without it a
 // post-mortem of a headless run cannot tell a warning from progress — the
 // distinction exists on the wire now, and throwing it away at the capture is
 // where it would be lost for good.
-const stderrMark = "!! "
+//
+// It is EXPORTED because the reader (internal/histindex, behind `fleet
+// history`) has to strip exactly what this writes. Two copies of "!! " in
+// two packages is a silent drift waiting to happen: change one and the
+// history view starts showing the mark as literal text while still calling
+// the line stdout.
+const StderrMark = "!! "
 
 // withLines returns a copy of c whose callbacks ALSO invoke out/err, after
 // whatever callbacks c already had.
@@ -416,7 +422,7 @@ func (e Executor) RunHost(host string, p updplan.Plan) HostReport {
 			// The prefix is applied unconditionally: RunHost has a value
 			// receiver, so its rewired e.IO never escapes this call and there
 			// is no path that tees twice.
-			func(_, line string) { w.Line(stderrMark + line) },
+			func(_, line string) { w.Line(StderrMark + line) },
 		)
 	}
 

--- a/sdk/fleet/internal/updexec/split_test.go
+++ b/sdk/fleet/internal/updexec/split_test.go
@@ -103,7 +103,7 @@ func TestCaptureMarksStderr(t *testing.T) {
 		if l == "installing" {
 			sawOut = true
 		}
-		if l == stderrMark+"WARNING: apt-get update failed" {
+		if l == StderrMark+"WARNING: apt-get update failed" {
 			sawErr = true
 		}
 	}
@@ -111,6 +111,6 @@ func TestCaptureMarksStderr(t *testing.T) {
 		t.Fatalf("stdout must reach the capture unprefixed: %q", captured)
 	}
 	if !sawErr {
-		t.Fatalf("stderr must reach the capture marked %q: %q", stderrMark, captured)
+		t.Fatalf("stderr must reach the capture marked %q: %q", StderrMark, captured)
 	}
 }

--- a/sdk/fleet/internal/updexec/split_test.go
+++ b/sdk/fleet/internal/updexec/split_test.go
@@ -143,3 +143,23 @@ func TestInteractiveStepSaysItsOutputWentToTheTerminal(t *testing.T) {
 		t.Fatalf("an interactive step must say its output was not captured, got:\n%q", captured)
 	}
 }
+
+// TestBackgroundLaneDoesNotClaimAnInteractiveGap is the guard on the note
+// above. "interactive" is a property of the LANE, not of the plan flag:
+// Background runs an `interactive: true` run step as Batch and tees every
+// line into the capture, so the note would be a lie there — and a costly
+// one, since histindex reads it (and the empty-step shape it describes) as
+// "this run was never observed" and refuses to call the host clean. Writing
+// it on the TUI's lane inverted the exact signal it was added to provide.
+func TestBackgroundLaneDoesNotClaimAnInteractiveGap(t *testing.T) {
+	var captured []string
+	f := runner.Fake{Out: map[string]string{"h": "state=clean branch=main"}}
+	ex := Executor{IO: Background{Console{R: f}}, Out: memOutput{&captured}}
+	ex.RunHost("h", updplan.Default())
+
+	for _, l := range captured {
+		if strings.Contains(l, "not captured") {
+			t.Fatalf("the background lane captures a run step in full; it must not claim a gap: %q\n%q", l, captured)
+		}
+	}
+}

--- a/sdk/fleet/internal/updexec/split_test.go
+++ b/sdk/fleet/internal/updexec/split_test.go
@@ -114,3 +114,32 @@ func TestCaptureMarksStderr(t *testing.T) {
 		t.Fatalf("stderr must reach the capture marked %q: %q", StderrMark, captured)
 	}
 }
+
+// TestInteractiveStepSaysItsOutputWentToTheTerminal pins that a capture is
+// HONEST about what it does not contain. An interactive step hands the
+// terminal to the remote command (ssh -t), so fleet never sees a byte of it:
+// the default plan's `./install.sh` can run for two minutes, do the entire
+// job, and leave the capture holding its step banner and nothing else.
+//
+// Read back by `fleet history` that is indistinguishable from an install
+// that produced no output at all — a real run against a host whose sudo was
+// broken looked identical to the successful re-run that fixed it. Naming the
+// gap costs one line and turns "apparently did nothing" into "went
+// somewhere else".
+func TestInteractiveStepSaysItsOutputWentToTheTerminal(t *testing.T) {
+	var captured []string
+	// A precheck the sync accepts, so the run reaches the interactive step.
+	f := runner.Fake{Out: map[string]string{"h": "state=clean branch=main"}}
+	ex := Executor{IO: Console{R: f}, Out: memOutput{&captured}}
+	ex.RunHost("h", updplan.Default())
+
+	var said bool
+	for _, l := range captured {
+		if strings.Contains(l, "interactive") && strings.Contains(l, "not captured") {
+			said = true
+		}
+	}
+	if !said {
+		t.Fatalf("an interactive step must say its output was not captured, got:\n%q", captured)
+	}
+}

--- a/sdk/fleet/internal/updexec/stderrnoise.go
+++ b/sdk/fleet/internal/updexec/stderrnoise.go
@@ -35,6 +35,12 @@ var benignPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^\* \[?new (branch|tag)\]?`),
 	regexp.MustCompile(`^\* branch\s+\S+\s+-> \S+$`),
 	regexp.MustCompile(`^[0-9a-f]{7,40}\.\.[0-9a-f]{7,40}\s+\S+\s+-> \S+$`),
+	// git checkout reports the branch you ended up on via stderr. Anchored
+	// at both ends and requiring the quoted branch to END the line: without
+	// that, "Already on 'main' but the working tree is dirty" would be
+	// swallowed along with the clean form. Before this, every host scored a
+	// warning on every run — a constant offset of 1 is the same as no signal.
+	regexp.MustCompile(`^(Already on|Switched to branch|Switched to a new branch) '[^']+'$`),
 	regexp.MustCompile(`^\[sudo\] password for `),
 }
 

--- a/sdk/fleet/internal/updexec/stderrnoise.go
+++ b/sdk/fleet/internal/updexec/stderrnoise.go
@@ -23,7 +23,12 @@ var benignPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^Pseudo-terminal will not be allocated`),
 	regexp.MustCompile(`^remote: (Enumerating|Counting|Compressing|Total|Finding|Resolving) `),
 	regexp.MustCompile(`^(Receiving|Resolving|Counting|Compressing|Unpacking|Enumerating) (objects|deltas):`),
-	regexp.MustCompile(`^From (https?://|git@|/)`),
+	// "From <remote>" and nothing else. Anchored at BOTH ends on purpose:
+	// the remote may be scp-style (github.com:owner/repo), a URL, or a local
+	// path, so enumerating spellings kept missing real ones — but requiring
+	// the line to be exactly the literal "From " plus one token keeps error
+	// text ("From X but then words", "remote: fatal: ...") out.
+	regexp.MustCompile(`^From \S+$`),
 	// NOTE: no leading-space patterns — Benign trims the line first, so
 	// `^ \* branch …` could never match, and every real `git fetch` would put
 	// a spurious ⚠ on the row.

--- a/sdk/fleet/internal/updexec/stderrnoise_test.go
+++ b/sdk/fleet/internal/updexec/stderrnoise_test.go
@@ -47,3 +47,41 @@ func TestBenignStderrTable(t *testing.T) {
 		}
 	}
 }
+
+// TestBenignAcceptsAnScpStyleFetchHeader pins a shape found in a REAL
+// capture, not in review: `git fetch` against an scp-style remote
+// (github.com:owner/repo — what an ssh clone actually has) prints
+// "From github.com:owner/repo" to stderr. The original pattern required
+// https://, git@ or a leading /, so it matched neither that nor anything
+// else this fleet produces — every healthy update scored a spurious ⚠, which
+// is precisely the "warning signal worth nothing" outcome the patterns exist
+// to prevent.
+func TestBenignAcceptsAnScpStyleFetchHeader(t *testing.T) {
+	for _, line := range []string{
+		"From github.com:sfc-gh-eraigosa/dotfiles",
+		"From git@github.com:sfc-gh-eraigosa/dotfiles",
+		"From https://github.com/sfc-gh-eraigosa/dotfiles",
+		"From /srv/mirrors/dotfiles.git",
+	} {
+		if !Benign(line) {
+			t.Errorf("Benign(%q) = false, want true — this is a routine fetch header", line)
+		}
+	}
+}
+
+// TestBenignStillRejectsAnErrorWearingTheSameShape guards the loosening
+// above. git reports failures through the same channels as progress, so a
+// pattern relaxed to accept "From <anything>" must not start accepting error
+// text that merely begins with a word and a colon.
+func TestBenignStillRejectsAnErrorWearingTheSameShape(t *testing.T) {
+	for _, line := range []string{
+		"remote: fatal: repository not found",
+		"From github.com:owner/repo but then extra words",
+		"fatal: could not read Username",
+		"error: failed to push some refs",
+	} {
+		if Benign(line) {
+			t.Errorf("Benign(%q) = true, want false — this is a real failure", line)
+		}
+	}
+}

--- a/sdk/fleet/internal/updexec/stderrnoise_test.go
+++ b/sdk/fleet/internal/updexec/stderrnoise_test.go
@@ -85,3 +85,35 @@ func TestBenignStillRejectsAnErrorWearingTheSameShape(t *testing.T) {
 		}
 	}
 }
+
+// TestBenignAcceptsGitCheckoutChatter pins the other line every healthy run
+// produces. `git checkout` reports which branch you ended up on via STDERR —
+// "Already on 'main'" when the sync was a no-op, "Switched to branch 'main'"
+// when it moved — so before this, every host scored exactly one warning on
+// every run no matter how clean it was. A constant offset of 1 is the same
+// as no signal: it is precisely what the benign list exists to remove.
+func TestBenignAcceptsGitCheckoutChatter(t *testing.T) {
+	for _, line := range []string{
+		"Already on 'main'",
+		"Switched to branch 'main'",
+		"Switched to a new branch 'feature/gff'",
+	} {
+		if !Benign(line) {
+			t.Errorf("Benign(%q) = false, want true — routine git checkout output", line)
+		}
+	}
+}
+
+// TestBenignStillRejectsCheckoutFailures guards the loosening above: the
+// quoted-branch shape must not swallow the errors git reports alongside it.
+func TestBenignStillRejectsCheckoutFailures(t *testing.T) {
+	for _, line := range []string{
+		"error: pathspec 'main' did not match any file(s) known to git",
+		"Already on 'main' but the working tree is dirty",
+		"fatal: invalid reference: main",
+	} {
+		if Benign(line) {
+			t.Errorf("Benign(%q) = true, want false", line)
+		}
+	}
+}

--- a/sdk/libs/AGENTS.md
+++ b/sdk/libs/AGENTS.md
@@ -50,6 +50,23 @@ logger that cannot open its file writes to `io.Discard`, and `NewCapture`
 returns a nil `*Capture` that is safe to call. A tool that dies because it
 could not log is strictly worse than one that runs unlogged.
 
+**A capture is written ONLY where its caller named.** `CaptureOptions.Dir` is
+required: an empty `Dir` means *no capture*, never a fallback to
+`<state>/<tool>/logs`. The fallback existed and was actively harmful — it made
+every zero-value construction (which is what tests and not-yet-configured
+callers produce) write into the developer's own home. `go test ./...` was
+depositing files in `~/.local/state/fleet/logs` on every run; 351 of the 384
+files found there were named after test fixtures (`h`, `host-a`, `alpha`).
+There is deliberately no `Tool` field on `CaptureOptions` to resolve a
+directory *from*, so the mistake is unrepresentable rather than merely
+avoided. Pinned by `TestEmptyDirMeansNoCapture`.
+
+**Retention is per subject, and the caller sets it.** `Keep` (default 200) is
+how many captures survive for *that* subject; `Prune` runs inside `NewCapture`
+and never touches another subject's files, so a rarely-updated host cannot
+have its history evicted by a busy one. fleet sets 50. Pinned by
+`TestPruneKeepsNewestPerSubject`.
+
 **Environment**, per tool: `$FLEET_LOG_FILE`, `$FLEET_LOG_LEVEL`
 (hyphens become underscores: `tmux-mgr` → `$TMUX_MGR_LOG_FILE`).
 

--- a/sdk/libs/log/capture.go
+++ b/sdk/libs/log/capture.go
@@ -26,10 +26,10 @@ type Capture struct {
 
 // CaptureOptions configures a capture file.
 type CaptureOptions struct {
-	// Tool names the component; with Dir empty it selects
-	// <state>/<tool>/logs. Required unless Dir is set.
-	Tool string
-	// Dir overrides the directory entirely.
+	// Dir is the directory the capture file is written to. Required: an
+	// empty Dir means no capture at all. The caller resolves it (fleet uses
+	// StateDir("fleet")+"/logs"), so a capture is never written to a
+	// location the caller did not name.
 	Dir string
 	// Subject is what this run is about — a hostname, a target, a job id. It
 	// becomes part of the filename, sanitized.
@@ -50,12 +50,13 @@ func NewCapture(opts CaptureOptions) *Capture {
 	if now == nil {
 		now = time.Now
 	}
+	// An empty Dir disables the capture. It deliberately does NOT fall back
+	// to <state>/<tool>/logs: that fallback made every zero-value
+	// construction — which is what tests and not-yet-configured callers
+	// produce — write into the developer's own home. Losing a capture costs
+	// nothing (a nil *Capture is a safe no-op); writing one somewhere the
+	// caller never named costs a polluted state directory nobody audits.
 	dir := opts.Dir
-	if dir == "" {
-		if s := StateDir(opts.Tool); s != "" {
-			dir = filepath.Join(s, "logs")
-		}
-	}
 	if dir == "" {
 		return nil
 	}

--- a/sdk/libs/log/capture_test.go
+++ b/sdk/libs/log/capture_test.go
@@ -187,3 +187,28 @@ func TestWriterSplitsIntoTimestampedLines(t *testing.T) {
 		t.Fatalf("expected two timestamped lines:\n%s", b)
 	}
 }
+
+// TestEmptyDirMeansNoCapture pins that an unset Dir disables the capture
+// rather than falling back to the real state directory. A zero-value
+// capture construction is what every test and every not-yet-configured
+// caller produces; resolving that to <state>/<tool>/logs meant a test run
+// silently wrote files into the developer's own home — which is how
+// ~/.local/state/fleet/logs accumulated 351 files named after test
+// fixtures. Writing to a nil *Capture is already a no-op, so "no directory"
+// can safely mean "no capture", matching the rule fleet's answers store
+// follows for its own path.
+func TestEmptyDirMeansNoCapture(t *testing.T) {
+	// A real HOME/XDG_STATE_HOME is in scope: if the fallback is still
+	// there, this is exactly where the stray file would land.
+	home := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", home)
+
+	c := NewCapture(CaptureOptions{Subject: "h", Now: fixedClock()})
+	if c != nil {
+		t.Fatalf("expected no capture when Dir is empty, got one at %q", c.Path())
+	}
+
+	if entries, err := os.ReadDir(filepath.Join(home, "fleet", "logs")); err == nil && len(entries) > 0 {
+		t.Fatalf("an empty Dir wrote %d file(s) into the state dir: %v", len(entries), entries)
+	}
+}


### PR DESCRIPTION
## What

Five commits, each standing on its own.

**1. `fix(fleet,libs)` — captures are written only where the caller named them**

`libs/log`'s `NewCapture` fell back to `<state>/<tool>/logs` when `Dir` was empty, so every zero-value construction — what tests and not-yet-configured callers produce — wrote into the developer's own home. A plain `go test ./...` deposited three files per run; **351 of the 384 files** in the real log directory were named after test fixtures rather than hosts. An empty `Dir` now means *no capture*, and `CaptureOptions.Tool` is removed so the fallback cannot be reintroduced to justify the field. `runUpdateWith` takes the capture as a parameter instead of resolving it internally — it already injected its writer and its runner, and the capture was the one dependency touching `$HOME` that wasn't under test control. Retention drops from the shared default of 200 per host to 50.

**2. `feat(fleet)` — `fleet history`**

Captures had been written for a while but nothing could read one back. New pure `internal/histindex` (`Scan` / `Read` / `Summarize`) plus:

```
fleet history [host] [--show] [--run N] [--errors] [--grep RE] [--limit N] [--json]
```

`RESULT` says `finished` / `unfinished`, never `ok` / `failed` — a capture records output, not an exit code.

**3. `feat(fleet)` — `--problems`, a digest**

`--errors` filters to stderr, and on a real broken host that proved the wrong axis. `install.sh` writes its own account of what failed to **stdout** (`WARNING: could not install these apt packages: …`); stderr carries the mechanical cause beneath it. On a host whose sudo could not prompt, stderr held 79 lines that were two messages repeated 37× each, while the five lines naming what the machine was now *missing* were all stdout. That run digests **79 → 11**, led by the five that matter.

**4. `feat(fleet)` — classify problems instead of counting every line**

The digest still reported every matching line separately, so a healthy host showed 34 "problems". Nothing is hidden to fix that — a filter that hides can hide the one line that mattered. Instead: a class label, and three structural reductions.

```console
$ fleet history pi-01 --problems
pi-01  2026-09-08 13:47  4 failures · 2 stderr · 2 advisories
  failures
    WARNING: cannot detect the focused window on this wayland session.
    WARNING: Wayland needs the keyd GNOME extension:
        WARNING:   ln -s /usr/local/share/keyd/gnome-extension-45 \
    WARNING: REFUSING to install the keyd config: without per-app overrides,
        WARNING: Cmd+C in a terminal would send SIGINT instead of copying.
    9× WARNING: ollama create teams-… failed (base model not pulled)
  stderr
    5× WARN: skipping '….md' — a host-local memory of the same name exists
  advisories
    Updates are available for some Google Cloud CLI components.  To install them,
        please run:
```

**34 entries → 8, with every original line still present** as detail under its parent.


**5. `fix(fleet)` — the capture gap is a property of the LANE, not the plan flag**

Four defects found by code review, two of them inversions of signals commits 3–4 added.

- **The interactive note was keyed off the plan flag.** `Background` — the TUI lane — deliberately runs an `interactive: true` *run* step as `Batch` and tees every line into the capture; only a `gh-auth` login truly needs a terminal. The shipped default plan marks `./install.sh` interactive, so **every dashboard-driven update** stamped "output went to the terminal and is not captured here" onto a file holding the complete run, and `histindex` read that as never-observed and refused to call the host clean — the exact inversion the note exists to prevent. The condition is now asked of the lane via an optional `batchLane` capability, mirroring `teeable`.
- **The two views disagreed on colourised lines.** `Read`'s WARN count passed `Benign` the raw line while `Problems()` stripped colour first, so a line could be `⚠1` in the listing and absent from the digest — against this PR's own claim that they "can never disagree". Both now strip through one `clean` helper; `Lines` keeps the host's original bytes, so `--show` is unchanged.
- **`collapseNearDuplicates` dropped merged entries' `Detail`**, deleting continuation text from every view, in a digest whose contract is that it classifies rather than hides.
- **`commonPrefix`/`commonSuffix` cut on bytes.** `…` is `E2 80 A6` and `—` is `E2 80 94`, so lines differing at such a rune shared a partial prefix and the elided text emitted half a rune — mojibake in the one line the digest exists to make readable. Both now back off to a rune boundary.

Each fix has a test watched failing against the pre-fix code, plus a re-verification that reverting the lane fix makes `TestBackgroundLaneDoesNotClaimAnInteractiveGap` fail with the note landing immediately before the captured output.

## Why

Continuations attach to their parent (an unfinished sentence, a line indented two spaces past its severity tag, or the same tool tag at the same timestamp). Near-duplicates differing only by an identifier collapse to one entry with a count and an **elided** middle — printing one persona's name would claim a specific persona failed when what is known is that nine did. Advisories (`npm warn`, `[notice]`, gcloud's component notice, pip's root-user warning) are labelled and sorted last, never suppressed.

**Class comes from content, not the stream.** `install.sh` sends some of its own warnings to stdout and others to stderr — on one host every install failure arrived on stdout, on another every one arrived on stderr — so keying off the stream left the `failures` group empty on exactly the hosts that had failures.

## Impact

- **An empty digest reads `clean` only when the run was observed.** An interactive step hands the terminal to the remote command, so `install.sh`'s output never reaches the capture and the run digests to nothing for the same reason a perfect one does. Those report `not captured (interactive run)` instead — a host nobody saw must never look verified. Detection is **structural** (a `run` banner followed by no output), so it works on captures written before this PR — exactly the past runs this tool gets opened to investigate.
- Interactive steps now write a note saying their output went elsewhere, so a two-minute install no longer leaves a file reading as though the step did nothing.
- **Three `Benign`/classifier fixes, all found by using real captures as fixtures rather than invented ones.** `^From (https?://|git@|/)` never matched an scp-style remote — the spelling an ssh clone actually has — so every healthy fetch scored a spurious ⚠. `git checkout` reports its branch on stderr (`Already on 'main'`), adding a warning to every host on every run; a constant offset of one is the same as no signal. And colour was stripped only before printing, so a leading escape sequence hid the `WARNING:` prefix from the matcher entirely — those lines were not detected at all.
- `updexec.StderrMark` and `InteractiveNote` are exported: the reader must strip exactly what the writer wrote.
- Behaviour change in shared `libs/log`. `NewCapture` has exactly one caller in the SDK (fleet); `gsl`, `tmux-mgr` and `wlink` use the logger only. All five consumers build and pass.

## Testing

TDD throughout — every test watched failing first, including one that passed against the pre-fix code and was rewritten once that showed it was pinning the wrong mechanism.

- Full suite green; `go vet` and `gofmt` clean.
- Coverage: `cmd` 67.3 → **68.5%**, `internal/histindex` **92.2%**, `updexec` **92.9%**, `libs/log` **92.3%** (floors 60 / 80).
- A full `go test ./...` now writes **zero** files to the real state directory, down from three per run.
- Exercised against a live fleet's real captures throughout — which is how both `Benign` gaps, the colour bug, the `clean`-vs-unobserved bug, and two folding traps surfaced. The folding traps are pinned: the tool-tag rule needs a matching timestamp (or a tool's independent remarks merge), and the indentation rule needs two spaces (`WARNING: text` always has one, and a single-space test folded the whole list into its first entry).

## Not in this PR

- The `--tui` viewer — deferred; the CLI verb is canonical and a viewer would read through the same `histindex`.
- Capturing interactive runs for real needs a pty proxy. This PR only makes the gap **visible**.
- The advisory list is short and specific by design, so some third-party chatter still classifies as a failure. That is the conservative direction — an unrecognised line stays a failure — and the list can grow as real captures suggest entries.
- No `docs/mbo` objective was opened for this work, so it is not in the objective tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014C8SFEQ9ukCThDPc9MH1FZ
