### PR TITLE
fleet-history-tui: tui-history

### DIFF
--- a/sdk/fleet/AGENTS.md
+++ b/sdk/fleet/AGENTS.md
@@ -28,6 +28,7 @@ facts. `opt/scripts/system/install-stamp.sh` now records the second one; this to
 | `fleet wake [host...]` | rouse hosts asleep at layer 2: ladder `retry → local-prime → peer-relay`, printed rung by rung; `--json`; exits non-zero if any target stayed down |
 | `fleet history [host]` | list the captures past updates left behind (newest first: when · host · finished/unfinished · ⚠N · size); naming a host narrows to it. `--show` prints a run (`--run N`, 1 = newest), `--errors` keeps only stderr, `--grep RE` filters lines, `--limit N`, `--json` |
 | `fleet history --problems` | the digest: what actually went wrong, deduped — the installer's own `WARNING:`/`ERROR:` lines first, then non-benign stderr with repeats collapsed (`37× sudo: a password is required`). With no host it reports the NEWEST run of every host, so one command answers "what is broken across the fleet" |
+| `fleet tui` → `H` | history INSIDE the dashboard: the run list for the selection (or cursor host), `enter` opens a run into the log/stderr panes, `esc` unwinds one level. Same motions, same pane toggles, same `/` search |
 
 ## Layout
 
@@ -47,6 +48,7 @@ facts. `opt/scripts/system/install-stamp.sh` now records the second one; this to
 | `internal/lanscan` | sweep a subnet for a listening port (injected dialer — no nmap, no socket in tests) |
 | `internal/keys` | authorized_keys diff (reports removals, never applies them) |
 | `internal/histindex` | read past captures (pure but for the file open): `Scan` decodes `<UTC>__<host>.log` positionally, `Read` splits header/body/footer and decodes the `!! ` mark, `Summarize` adds finished + warning count |
+| `cmd/tui_history.go` | the dashboard's history view: `historyRuns` (scoped loader), the load/open Cmds and msgs, the run-keyed cursor, and `logEntries` -- the single accessor that swaps the panes between the live stream and a stored capture |
 | `internal/reach` | the wake ladder: rung order, peer ranking, provenance (pure; every impure edge injected via `Deps`) |
 | `cmd/answers_store.go` | the non-secret prompt preferences on disk (`0600`); the on-disk type has no credential field |
 | `internal/runner` | the **only** seam that touches a remote host (`Exec` real, `Fake` for tests); `RunStreamCtx` is the deadline-aware path |
@@ -474,6 +476,37 @@ I/O are all injected), so the decision surface is unit-tested without opening a 
   `TestProblemsLeadWithTheAuthoredDiagnosis`, `TestProblemsCollapseRepeats`,
   `TestProblemsStripColourBeforeGrouping`,
   `TestColouredBenignStderrIsNotCountedAsAWarning`.
+- **History in the TUI is VIEW state, never a `tuiMode`.** Modes exist to reroute
+  keystrokes -- a key typed in search is text, not a motion -- and history reroutes
+  nothing: every motion, both pane toggles and `/` keep their meaning. Only what the panes
+  READ changes, from the live stream to a stored capture. The branch lives in two motion
+  primitives (`move`/`moveTo`), in `listLen`, and in ONE source accessor (`logEntries`), so
+  a second copy of the normal-mode routing table never has to exist to drift out of sync.
+  Scope is snapshotted from `updateTargets()` at press time -- the same selection-or-cursor
+  rule the update and wake keys use -- so moving the run cursor cannot silently change
+  which runs the list covers. Pinned by `TestHistoryKeyScopeFollowsTheSelection`,
+  `TestHistoryMotionUsesTheSameKeysAsTheHostList`,
+  `TestHistoryMotionLeavesTheHostCursorAlone`, `TestEscUnwindsOneLevelAtATime`.
+- **Reading the past never costs the present.** The log pane is shared with a running
+  update, so opening a capture leaves `m.logs` completely alone: the engine keeps appending
+  the whole time a run is on screen, and closing it shows the live stream again with
+  nothing missing. `tailFor` deliberately does NOT follow the switch -- a host row's FAIL
+  text is about the run that failed, not about whatever the operator is reading. Pinned by
+  `TestOpeningARunNeverLosesLiveStreamLines`.
+- **An opened capture must drive the pane's EMPTINESS check too, not just its contents.**
+  `errCount` is maintained incrementally as live lines arrive and is therefore zero for a
+  capture read from disk, so the stderr pane rendered "stderr: none captured" directly
+  underneath the captured stderr line it was showing. `errTotal()` reads whichever source
+  is active; the counter still serves the live path, where it exists to keep height queries
+  off a 2000-entry filtered rebuild. **Found by the demo frames, not by a unit test** --
+  every unit assertion about the opened capture passed while the pane on screen said the
+  opposite, which is the case for rendering real frames and looking at them. Pinned by
+  `TestOpenedRunFillsTheStderrPane`.
+- **The new panel gets its own size sweep.** The existing 1219-size sweep renders the HOST
+  list and says nothing about the run list, and bubbletea drops lines from the TOP of an
+  over-tall frame -- one row of overflow walks the banner off the screen. Both history
+  states are swept, including the empty-history prose, which wraps and is the likelier to
+  grow. Pinned by `TestHistoryFrameNeverExceedsTheTerminal`.
 - **The digest CLASSIFIES; it never hides.** Every line still appears — advisories are
   labelled and sorted last, not suppressed, because a filter that hides is a filter that can
   hide the one line that mattered. Three reductions, all structural rather than selective:

--- a/sdk/fleet/AGENTS.md
+++ b/sdk/fleet/AGENTS.md
@@ -487,6 +487,41 @@ I/O are all injected), so the decision surface is unit-tested without opening a 
   which runs the list covers. Pinned by `TestHistoryKeyScopeFollowsTheSelection`,
   `TestHistoryMotionUsesTheSameKeysAsTheHostList`,
   `TestHistoryMotionLeavesTheHostCursorAlone`, `TestEscUnwindsOneLevelAtATime`.
+- **`m.logDir` must be WIRED, and the whole feature is silent when it is not.** It was
+  declared and read twice but never assigned outside tests: `H` scanned `""` and always
+  rendered "no captured runs", and the same empty string reached `beginStream`, where
+  `libs/log`'s "an empty `Dir` means no capture" rule meant the dashboard's own updates
+  wrote NOTHING. Both paths looked correct in tests, which inject a temp dir directly into
+  `historyRuns`. `wireTUIPaths` now attaches `ansPath` and `logDir` together, in one place,
+  so the next path cannot be half-wired. Pinned by `TestTUIWiresTheCaptureDirectory`.
+- **The run list has its OWN scroll offset (`histTop`).** `m.vp` belongs to the host list
+  and `clampViewport` recomputes it from the host cursor, so slicing runs by it rendered a
+  framed header with nothing under it whenever the host cursor sat deeper than the run
+  count — and pinned the run cursor off-screen with no way to reach it. Pinned by
+  `TestHistoryViewportFollowsTheRunCursor`.
+- **Both exits from an open run go through `closeHistoryRun`.** `histRunOpen()` keys off
+  `histPath` alone, so `H` toggling off while a run was open brought the dashboard back
+  with the stored capture still filling the panes over a live update. It also restores the
+  follow state the panes had before the open — a capture is read from its start, and
+  returning to a still-growing buffer frozen at line 1 is not a state anyone asked for.
+  Pinned by `TestHTogglingOffClosesTheOpenedRun`, `TestClosingARunRestoresLiveFollowing`.
+- **A stored line keeps the time it was WRITTEN.** Stamping every line with the model's
+  construction time made a three-minute run read as one instant repeated, in the column
+  that exists to show how long a step took. Pinned by
+  `TestCaptureLinesKeepTheirRecordedTime`.
+- **Everything that classifies a captured line strips colour first.** The `!` gutter passed
+  `Benign` the raw text while `histindex.Read` strips, so a colourised benign git line
+  counted 0 in the run list and raised a warning gutter once opened. Pinned by
+  `TestWarnGutterAgreesWithTheRunListColumn`.
+- **A history load is answered only for the scope that asked.** Two `H` presses with
+  different scopes race; without a scope tag the slower answer overwrote the newer list,
+  leaving `histScope` describing one set of hosts while the rows showed another — which
+  also flips the HOST-column decision and lets `enter` open a run outside the shown scope.
+  Pinned by `TestStaleHistoryLoadIsDropped`.
+- **Every pane read follows the active source — body AND chrome.** `errTotal` and
+  `warnTotals` join `logEntries`/`errEntries`: a title summing `m.warns` (live-only) over a
+  stored capture is the same lie as a body showing the wrong lines. Pinned by
+  `TestOpenedRunFillsTheStderrPane`, `TestStderrTitleFollowsTheOpenedCapture`.
 - **Reading the past never costs the present.** The log pane is shared with a running
   update, so opening a capture leaves `m.logs` completely alone: the engine keeps appending
   the whole time a run is on screen, and closing it shows the live stream again with

--- a/sdk/fleet/README.md
+++ b/sdk/fleet/README.md
@@ -749,6 +749,42 @@ That run's raw log is 79 stderr lines, 74 of which are those two messages.
 - **Retention is 50 runs per host**, pruned as each new capture opens. A host
   updated once a month never has its history evicted by one updated hourly.
 
+### History inside the dashboard — `H`
+
+`fleet history` reads captures from the shell. `H` does it from the dashboard,
+where you are already standing when you wonder what happened last time.
+
+```
+H        open the past runs of the SELECTION (or the cursor host, like u and w)
+j k gg G move the run cursor          /  search        h l e  toggle the panes
+enter    open the run under the cursor into the log and stderr panes
+esc      close the run, then leave history
+```
+
+```console
+╭──────────────────────────────────────────────────────────────────────────╮
+│     WHEN             HOST             RESULT     WARN   SIZE             │
+│ >   2026-09-08 13:47 host-nano        finished   -      343B             │
+│     2026-09-08 13:30 host-pi          finished   !1     244B             │
+│     2026-09-07 03:15 host-nano        finished   -      207B             │
+╰──────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────────────────────╮
+│ logs   scrolled 1/2   tab: focus  l: hide                                │
+│  12:00:00 host-pi       │ === step dotfiles.sync (sync) ===              │
+│ !12:00:00 host-pi       │ fatal: could not read Username for 'https://…' │
+╰──────────────────────────────────────────────────────────────────────────╯
+```
+
+- **It is the same panes, reading a different source.** History is a view of
+  the model, not a separate screen, so every motion, both pane toggles and `/`
+  keep working and there are no new bindings to learn beyond `H` and `enter`.
+- **Reading the past never costs you the present.** An update still running
+  keeps streaming into the log buffer the whole time a capture is on screen;
+  closing the run shows it again with nothing missing.
+- **`RESULT` says `finished` / `unfinished`, never `ok` / `failed`** — the same
+  honesty the CLI listing keeps, for the same reason: a capture records
+  output, not an exit code.
+
 ### `fleet version`
 
 ```sh

--- a/sdk/fleet/README.md
+++ b/sdk/fleet/README.md
@@ -770,8 +770,8 @@ esc      close the run, then leave history
 ╰──────────────────────────────────────────────────────────────────────────╯
 ╭──────────────────────────────────────────────────────────────────────────╮
 │ logs   scrolled 1/2   tab: focus  l: hide                                │
-│  12:00:00 host-pi       │ === step dotfiles.sync (sync) ===              │
-│ !12:00:00 host-pi       │ fatal: could not read Username for 'https://…' │
+│  03:30:00 host-pi       │ === step dotfiles.sync (sync) ===              │
+│ !03:30:02 host-pi       │ fatal: could not read Username for 'https://…' │
 ╰──────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/sdk/fleet/cmd/tui.go
+++ b/sdk/fleet/cmd/tui.go
@@ -93,8 +93,7 @@ var tuiCmd = &cobra.Command{
 		m.setLocal(detectLocal())
 		// Persistence is wired HERE, not in newTUIModel, so the model stays a
 		// pure value and tests never touch a real config directory.
-		m.ansPath = answersPath()
-		m.ans = loadAnswers(m.ansPath)
+		wireTUIPaths(&m)
 		// Re-passed to the interactive handoff's self-exec (`fleet update
 		// <alias> --file <tuiFile> ...`) so a routed host resolves the SAME
 		// plan the TUI itself loaded, not gff's own (possibly different)

--- a/sdk/fleet/cmd/tui_demo_test.go
+++ b/sdk/fleet/cmd/tui_demo_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/histindex"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updplan"
 )
 
@@ -198,6 +200,34 @@ func TestDemoFrames(t *testing.T) {
 			m.setLocal(localHost{Name: "some-laptop"})
 			return m
 		}},
+		{"18. HISTORY — H lists the selection's past runs", "WHEN", func() tuiModel {
+			m := settled()
+			m.vp = viewport{height: 26, width: 100}
+			m.histOn = true
+			m.histScope = []string{"host-nano", "host-pi"}
+			m.histRuns = demoRuns(t)
+			m.histCursor = m.histRuns[0].Path
+			return m
+		}},
+		{"19. HISTORY — enter opens a past run into the log and stderr panes", "could not read Username", func() tuiModel {
+			m := settled()
+			m.vp = viewport{height: 30, width: 100}
+			m.histOn, m.errOpen = true, true
+			m.histScope = []string{"host-nano", "host-pi"}
+			m.histRuns = demoRuns(t)
+			// The FAILED run, chosen by host rather than index: the list is
+			// newest-first, so an index would silently point elsewhere the
+			// moment a fixture is added.
+			var failed histindex.Summary
+			for _, r := range m.histRuns {
+				if r.Host == "host-pi" {
+					failed = r
+				}
+			}
+			m.histCursor = failed.Path
+			x, _ := m.Update(openHistoryRun(failed)().(historyOpenedMsg))
+			return x.(tuiModel)
+		}},
 	}
 
 	for _, f := range frames {
@@ -243,4 +273,41 @@ func build2Empty() tuiModel {
 func mustSend(m tuiModel, keys ...string) tuiModel {
 	m, _ = send(m, keys...)
 	return m
+}
+
+// demoRuns writes a small, realistic set of captures and reads them back
+// through the real loader, so the history frames render from the same code
+// path an operator drives rather than from hand-built structs.
+func demoRuns(t *testing.T) []histindex.Summary {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(stamp, host, body string) {
+		if err := os.WriteFile(filepath.Join(dir, stamp+"__"+host+".log"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("20260908T204714Z", "host-nano",
+		"# fleet update — host=host-nano plan=built-in default mode=fast-forward started=2026-09-08T20:47:14Z\n"+
+			"03:47:14 === step dotfiles.sync (sync) ===\n"+
+			"03:47:16 !! From github.com:owner/dotfiles\n"+
+			"03:47:16 Already up to date.\n"+
+			"03:47:17 === step dotfiles.install (run) ===\n"+
+			"03:47:20 Installing 28 core packages via apt...\n"+
+			"# 2026-09-08T20:50:36Z finished\n")
+	write("20260908T203000Z", "host-pi",
+		"# fleet update — host=host-pi plan=built-in default mode=fast-forward started=2026-09-08T20:30:00Z\n"+
+			"03:30:00 === step dotfiles.sync (sync) ===\n"+
+			"03:30:02 !! fatal: could not read Username for 'https://github.com'\n"+
+			"# 2026-09-08T20:30:03Z finished\n")
+	write("20260907T101500Z", "host-nano",
+		"# fleet update — host=host-nano plan=built-in default mode=fast-forward started=2026-09-07T10:15:00Z\n"+
+			"03:15:00 === step dotfiles.sync (sync) ===\n"+
+			"03:15:01 Already up to date.\n"+
+			"# 2026-09-07T10:15:04Z finished\n")
+
+	runs, err := historyRuns(dir, []string{"host-nano", "host-pi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runs
 }

--- a/sdk/fleet/cmd/tui_demo_test.go
+++ b/sdk/fleet/cmd/tui_demo_test.go
@@ -224,9 +224,7 @@ func TestDemoFrames(t *testing.T) {
 					failed = r
 				}
 			}
-			m.histCursor = failed.Path
-			x, _ := m.Update(openHistoryRun(failed)().(historyOpenedMsg))
-			return x.(tuiModel)
+			return openVia(t, m, failed)
 		}},
 	}
 

--- a/sdk/fleet/cmd/tui_history.go
+++ b/sdk/fleet/cmd/tui_history.go
@@ -49,8 +49,8 @@ func historyRuns(dir string, hosts []string) ([]histindex.Summary, error) {
 		s, err := histindex.Summarize(r)
 		if err != nil {
 			// One unreadable capture must not cost the whole list: the row
-			// still names the run, it just carries no summary.
-			s = histindex.Summary{Run: r}
+			// still names the run, and says its summary is unknown.
+			s = histindex.Summary{Run: r, Unreadable: true}
 		}
 		out = append(out, s)
 	}
@@ -125,28 +125,43 @@ func (m *tuiModel) histMoveTo(i int) {
 	if i > len(m.histRuns)-1 {
 		i = len(m.histRuns) - 1
 	}
+	// Start from the window the operator is LOOKING at, which may already
+	// differ from histTop if the pane changed height since the last motion.
+	m.histTop = m.histWindowTop(m.histIndexOf(m.histCursor))
 	m.histCursor = m.histRuns[i].Path
-	m.clampHistViewport(i)
+	m.histTop = m.histWindowTop(i)
 }
 
-// clampHistViewport keeps the run cursor on screen. The run list has its own
-// offset because m.vp belongs to the HOST list and clampViewport recomputes
-// it from the host cursor — slicing the runs by it rendered a header with
-// nothing under it, and pinned the cursor off-screen with no way to reach it.
-func (m *tuiModel) clampHistViewport(i int) {
+// histWindowTop is the first run row to draw: histTop, pulled just far enough
+// to keep row i on screen at the pane's CURRENT height. The run list has its
+// own offset because m.vp belongs to the HOST list and clampViewport
+// recomputes it from the host cursor — slicing the runs by it rendered a
+// header with nothing under it.
+//
+// It is computed rather than only stored because the height changes under
+// the list without any motion: opening a run starts the log pane and
+// squeezes the list, and a stored offset then left the cursor off-screen.
+func (m tuiModel) histWindowTop(i int) int {
 	h := m.visibleRows()
 	if h < 1 {
 		h = 1
 	}
-	if i < m.histTop {
-		m.histTop = i
+	top := m.histTop
+	if i >= 0 {
+		if i < top {
+			top = i
+		}
+		if i >= top+h {
+			top = i - h + 1
+		}
 	}
-	if i >= m.histTop+h {
-		m.histTop = i - h + 1
+	if top > len(m.histRuns)-1 {
+		top = len(m.histRuns) - 1
 	}
-	if m.histTop < 0 {
-		m.histTop = 0
+	if top < 0 {
+		top = 0
 	}
+	return top
 }
 
 // historyOpenedMsg carries one capture's parsed contents back into Update.
@@ -228,16 +243,21 @@ func captureEntries(host string, c histindex.Capture, day time.Time) []logEntry 
 //
 // A line with no parsable stamp keeps the run's own time rather than being
 // dropped or zeroed — output written before the first stamp is still output.
+//
+// libs/log writes the stamp in UTC, so it is rebuilt in UTC and only then
+// moved to local time — the zone the run list's WHEN column and the live
+// lines use, so an opened run reads on the same clock as its row.
 func stampOf(day time.Time, clock string) time.Time {
 	if clock == "" {
-		return day
+		return day.In(time.Local)
 	}
 	t, err := time.Parse("15:04:05", clock)
 	if err != nil {
-		return day
+		return day.In(time.Local)
 	}
-	return time.Date(day.Year(), day.Month(), day.Day(),
-		t.Hour(), t.Minute(), t.Second(), 0, day.Location())
+	d := day.UTC()
+	return time.Date(d.Year(), d.Month(), d.Day(),
+		t.Hour(), t.Minute(), t.Second(), 0, time.UTC).In(time.Local)
 }
 
 // wireTUIPaths attaches the on-disk locations the model needs. It exists as
@@ -259,7 +279,15 @@ func wireTUIPaths(m *tuiModel) {
 // follow state the operator had before the capture was opened. Both exits
 // from an open run (esc, and toggling H off) go through it, so neither can
 // leave the panes showing a stored capture over a running update.
+//
+// With no run open there is nothing to restore: the follow state is saved
+// only when a run opens, so restoring it here handed back a stale or zero
+// value and a round trip through the run list stopped the live panes.
 func (m *tuiModel) closeHistoryRun() {
+	m.histPending = ""
+	if !m.histRunOpen() {
+		return
+	}
 	m.histPath, m.histLines, m.histErrCount = "", nil, 0
 	m.logFollow, m.errFollow = m.liveFollow, m.liveErrFollow
 	m.logTop, m.errTop = 0, 0

--- a/sdk/fleet/cmd/tui_history.go
+++ b/sdk/fleet/cmd/tui_history.go
@@ -69,3 +69,37 @@ func loadHistory(dir string, hosts []string) tea.Cmd {
 		return historyLoadedMsg{runs: runs, err: err}
 	}
 }
+
+// listLen is how many rows the ACTIVE list has — host rows normally, runs in
+// history. Motion keys compute their targets from it, which is what lets
+// j/k/gg/G/ctrl+d serve both lists without a second key table.
+func (m tuiModel) listLen() int {
+	if m.histOn {
+		return len(m.histRuns)
+	}
+	return len(m.rows)
+}
+
+// histIndexOf locates a run by PATH, the run list's stable key.
+func (m tuiModel) histIndexOf(path string) int {
+	for i, r := range m.histRuns {
+		if r.Path == path {
+			return i
+		}
+	}
+	return -1
+}
+
+// histMoveTo clamps like moveTo: motion may not run off either end.
+func (m *tuiModel) histMoveTo(i int) {
+	if len(m.histRuns) == 0 {
+		return
+	}
+	if i < 0 {
+		i = 0
+	}
+	if i > len(m.histRuns)-1 {
+		i = len(m.histRuns) - 1
+	}
+	m.histCursor = m.histRuns[i].Path
+}

--- a/sdk/fleet/cmd/tui_history.go
+++ b/sdk/fleet/cmd/tui_history.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/histindex"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/updexec"
 )
 
 // historyRuns loads the captured runs for hosts from dir, newest first, with
@@ -102,4 +105,68 @@ func (m *tuiModel) histMoveTo(i int) {
 		i = len(m.histRuns) - 1
 	}
 	m.histCursor = m.histRuns[i].Path
+}
+
+// historyOpenedMsg carries one capture's parsed contents back into Update.
+type historyOpenedMsg struct {
+	path string
+	// host travels with the message rather than being re-derived from the
+	// filename: the run list already knows it, and decoding it twice is a
+	// second place for the name to come out different.
+	host string
+	cap  histindex.Capture
+	err  error
+}
+
+// openHistoryRun reads and parses one capture inside a Cmd. Reading a file is
+// I/O, and I/O never happens in Update.
+func openHistoryRun(r histindex.Summary) tea.Cmd {
+	return func() tea.Msg {
+		c, err := histindex.Read(r.Path)
+		return historyOpenedMsg{path: r.Path, host: r.Host, cap: c, err: err}
+	}
+}
+
+// histAt returns the run under the run cursor.
+func (m tuiModel) histAt() (histindex.Summary, bool) {
+	i := m.histIndexOf(m.histCursor)
+	if i < 0 {
+		return histindex.Summary{}, false
+	}
+	return m.histRuns[i], true
+}
+
+// histRunOpen reports whether a capture is on screen rather than the list.
+// It is the second level of history, and esc unwinds it before leaving.
+func (m tuiModel) histRunOpen() bool { return m.histPath != "" }
+
+// logEntries is the ACTIVE source for the stream panes: the opened capture
+// when a run is on screen, the live buffer otherwise.
+//
+// The live buffer is never touched by history. An update still running keeps
+// appending to m.logs the whole time a capture is being read, and closing the
+// run shows it again with nothing missing — the pane is shared, so viewing
+// the past must not cost the operator the present.
+func (m tuiModel) logEntries() []logEntry {
+	if m.histRunOpen() {
+		return m.histLines
+	}
+	return m.logs
+}
+
+// captureEntries converts a parsed capture into the same logEntry the stream
+// panes already render, so the panes need no notion of where their lines came
+// from and the two sources cannot drift into two renderers.
+func captureEntries(host string, c histindex.Capture, now time.Time) []logEntry {
+	out := make([]logEntry, 0, len(c.Lines))
+	for _, l := range c.Lines {
+		out = append(out, logEntry{
+			alias:  host,
+			line:   l.Text,
+			at:     now,
+			stderr: l.Stderr,
+			warn:   l.Stderr && !updexec.Benign(l.Text),
+		})
+	}
+	return out
 }

--- a/sdk/fleet/cmd/tui_history.go
+++ b/sdk/fleet/cmd/tui_history.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/histindex"
@@ -58,7 +60,26 @@ func historyRuns(dir string, hosts []string) ([]histindex.Summary, error) {
 // historyLoadedMsg carries the scan result back into Update.
 type historyLoadedMsg struct {
 	runs []histindex.Summary
-	err  error
+	// scope identifies WHICH request this answers. Two H presses with
+	// different scopes can be in flight at once, and without this the slower
+	// one overwrites the newer list — leaving histScope describing one set of
+	// hosts while the rows show another, which also flips the HOST-column
+	// decision and lets enter open a run outside the displayed scope.
+	scope []string
+	err   error
+}
+
+// sameScope reports whether two scope snapshots are the same request.
+func sameScope(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // loadHistory reads the run list from inside a Cmd. Scanning a directory and
@@ -69,7 +90,7 @@ type historyLoadedMsg struct {
 func loadHistory(dir string, hosts []string) tea.Cmd {
 	return func() tea.Msg {
 		runs, err := historyRuns(dir, hosts)
-		return historyLoadedMsg{runs: runs, err: err}
+		return historyLoadedMsg{runs: runs, scope: hosts, err: err}
 	}
 }
 
@@ -105,6 +126,27 @@ func (m *tuiModel) histMoveTo(i int) {
 		i = len(m.histRuns) - 1
 	}
 	m.histCursor = m.histRuns[i].Path
+	m.clampHistViewport(i)
+}
+
+// clampHistViewport keeps the run cursor on screen. The run list has its own
+// offset because m.vp belongs to the HOST list and clampViewport recomputes
+// it from the host cursor — slicing the runs by it rendered a header with
+// nothing under it, and pinned the cursor off-screen with no way to reach it.
+func (m *tuiModel) clampHistViewport(i int) {
+	h := m.visibleRows()
+	if h < 1 {
+		h = 1
+	}
+	if i < m.histTop {
+		m.histTop = i
+	}
+	if i >= m.histTop+h {
+		m.histTop = i - h + 1
+	}
+	if m.histTop < 0 {
+		m.histTop = 0
+	}
 }
 
 // historyOpenedMsg carries one capture's parsed contents back into Update.
@@ -114,8 +156,11 @@ type historyOpenedMsg struct {
 	// filename: the run list already knows it, and decoding it twice is a
 	// second place for the name to come out different.
 	host string
-	cap  histindex.Capture
-	err  error
+	// day is the run's date, so a captured line can be stamped with the time
+	// it was actually written rather than with the moment the TUI started.
+	day time.Time
+	cap histindex.Capture
+	err error
 }
 
 // openHistoryRun reads and parses one capture inside a Cmd. Reading a file is
@@ -123,7 +168,7 @@ type historyOpenedMsg struct {
 func openHistoryRun(r histindex.Summary) tea.Cmd {
 	return func() tea.Msg {
 		c, err := histindex.Read(r.Path)
-		return historyOpenedMsg{path: r.Path, host: r.Host, cap: c, err: err}
+		return historyOpenedMsg{path: r.Path, host: r.Host, day: r.At, cap: c, err: err}
 	}
 }
 
@@ -157,16 +202,65 @@ func (m tuiModel) logEntries() []logEntry {
 // captureEntries converts a parsed capture into the same logEntry the stream
 // panes already render, so the panes need no notion of where their lines came
 // from and the two sources cannot drift into two renderers.
-func captureEntries(host string, c histindex.Capture, now time.Time) []logEntry {
+func captureEntries(host string, c histindex.Capture, day time.Time) []logEntry {
 	out := make([]logEntry, 0, len(c.Lines))
 	for _, l := range c.Lines {
 		out = append(out, logEntry{
 			alias:  host,
 			line:   l.Text,
-			at:     now,
+			at:     stampOf(day, l.Time),
 			stderr: l.Stderr,
-			warn:   l.Stderr && !updexec.Benign(l.Text),
+			// Colour is stripped BEFORE classifying, exactly as
+			// histindex.Read does for the WARN column. Passing the raw line
+			// made a colourised benign git line count as 0 in the run list
+			// and yet raise the `!` gutter once the run was opened — the two
+			// views disagreeing about the same line.
+			warn: l.Stderr && !updexec.Benign(ansi.Strip(l.Text)),
 		})
 	}
 	return out
+}
+
+// stampOf rebuilds a captured line's wall-clock time from the run's date and
+// the line's "HH:MM:SS" prefix. The panes render this column to show how long
+// a step took; stamping every line with the model's construction time made a
+// three-minute run read as a single instant repeated.
+//
+// A line with no parsable stamp keeps the run's own time rather than being
+// dropped or zeroed — output written before the first stamp is still output.
+func stampOf(day time.Time, clock string) time.Time {
+	if clock == "" {
+		return day
+	}
+	t, err := time.Parse("15:04:05", clock)
+	if err != nil {
+		return day
+	}
+	return time.Date(day.Year(), day.Month(), day.Day(),
+		t.Hour(), t.Minute(), t.Second(), 0, day.Location())
+}
+
+// wireTUIPaths attaches the on-disk locations the model needs. It exists as
+// one function because logDir was declared, read in two places, and never
+// assigned: H scanned "" and always rendered "no captured runs", and the same
+// empty string reached beginStream, where libs/log's "an empty Dir means no
+// capture" rule meant the dashboard's own updates wrote NOTHING. Both paths
+// looked fine in tests, which inject a temp directory directly.
+//
+// Wiring stays HERE rather than in newTUIModel so the model remains a pure
+// value and tests never touch a real config or state directory.
+func wireTUIPaths(m *tuiModel) {
+	m.ansPath = answersPath()
+	m.ans = loadAnswers(m.ansPath)
+	m.logDir = fleetLogDir()
+}
+
+// closeHistoryRun returns the stream panes to the live buffer, restoring the
+// follow state the operator had before the capture was opened. Both exits
+// from an open run (esc, and toggling H off) go through it, so neither can
+// leave the panes showing a stored capture over a running update.
+func (m *tuiModel) closeHistoryRun() {
+	m.histPath, m.histLines, m.histErrCount = "", nil, 0
+	m.logFollow, m.errFollow = m.liveFollow, m.liveErrFollow
+	m.logTop, m.errTop = 0, 0
 }

--- a/sdk/fleet/cmd/tui_history.go
+++ b/sdk/fleet/cmd/tui_history.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/histindex"
+)
+
+// historyRuns loads the captured runs for hosts from dir, newest first, with
+// each run's summary already read.
+//
+// Scope follows the SELECTION, exactly as `u` and `w` do through
+// updateTargets(): an operator who selected three hosts means those three,
+// and one who selected none means the host under the cursor. An empty list
+// means the whole fleet — the fresh-session case, where there is nothing to
+// scope by yet.
+//
+// It returns Summary rather than Run because the list has to be triageable
+// without opening anything: whether the run finished and how many warnings
+// it carries are the two facts a filename cannot supply, and both need the
+// file read. Retention caps captures at 50 per host, so the read cost is
+// bounded by the scope the operator chose.
+//
+// A missing directory is an EMPTY history, never an error — the dashboard on
+// a machine that has never run an update must open history to a sentence
+// rather than a failure, the same rule fleet applies to a missing
+// ~/.ssh/config.
+func historyRuns(dir string, hosts []string) ([]histindex.Summary, error) {
+	runs, err := histindex.Scan(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	want := make(map[string]bool, len(hosts))
+	for _, h := range hosts {
+		want[h] = true
+	}
+
+	out := make([]histindex.Summary, 0, len(runs))
+	for _, r := range runs {
+		if len(want) > 0 && !want[r.Host] {
+			continue
+		}
+		s, err := histindex.Summarize(r)
+		if err != nil {
+			// One unreadable capture must not cost the whole list: the row
+			// still names the run, it just carries no summary.
+			s = histindex.Summary{Run: r}
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// historyLoadedMsg carries the scan result back into Update.
+type historyLoadedMsg struct {
+	runs []histindex.Summary
+	err  error
+}
+
+// loadHistory reads the run list from inside a Cmd. Scanning a directory and
+// summarising up to fifty captures per host is I/O, and I/O never happens in
+// Update: a model built without a log dir (tests, the demo) would otherwise
+// touch the filesystem on a keystroke, and a slow or unreadable mount would
+// stall the whole UI rather than one message.
+func loadHistory(dir string, hosts []string) tea.Cmd {
+	return func() tea.Msg {
+		runs, err := historyRuns(dir, hosts)
+		return historyLoadedMsg{runs: runs, err: err}
+	}
+}

--- a/sdk/fleet/cmd/tui_history_test.go
+++ b/sdk/fleet/cmd/tui_history_test.go
@@ -361,3 +361,137 @@ func TestHistoryFrameNeverExceedsTheTerminal(t *testing.T) {
 		}
 	}
 }
+
+// TestEnterOpensTheRunIntoThePanes pins the drill-down: enter on a run fills
+// the log pane with that capture and the stderr pane with its error
+// projection, read through histindex so the TUI and `fleet history` can never
+// disagree about what a capture contains.
+func TestEnterOpensTheRunIntoThePanes(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha",
+		"# fleet update — host=alpha started=x\n"+
+			"03:47:14 === step dotfiles.sync (sync) ===\n"+
+			"03:47:16 !! fatal: could not read Username\n"+
+			"03:47:17 Already up to date.\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+	runs, err := historyRuns(dir, []string{"alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m, _ := send(testModel("alpha"), "H")
+	mm, _ := m.Update(historyLoadedMsg{runs: runs})
+	m2 := mm.(tuiModel)
+
+	_, cmd := send(m2, "enter")
+	if cmd == nil {
+		t.Fatal("enter must return a Cmd — reading a capture is I/O and never happens in Update")
+	}
+	msg := cmd()
+	opened, ok := msg.(historyOpenedMsg)
+	if !ok {
+		t.Fatalf("want historyOpenedMsg, got %T", msg)
+	}
+
+	m3m, _ := m2.Update(opened)
+	m3 := m3m.(tuiModel)
+
+	if !m3.histRunOpen() {
+		t.Fatal("the run must be open after enter")
+	}
+	body := m3.logEntries()
+	if len(body) != 3 {
+		t.Fatalf("want the capture's 3 body lines, got %d: %+v", len(body), body)
+	}
+	var sawErr bool
+	for _, e := range m3.errEntries() {
+		if strings.Contains(e.line, "could not read Username") {
+			sawErr = true
+		}
+	}
+	if !sawErr {
+		t.Error("the stderr pane must show the capture's stderr projection")
+	}
+}
+
+// TestEscUnwindsOneLevelAtATime pins the back-out: run -> list -> dashboard,
+// and only THEN esc's existing meaning of clearing selection and search. An
+// esc that dropped straight out of history would lose the operator's place
+// in a list they may have scrolled a long way down.
+func TestEscUnwindsOneLevelAtATime(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	m, _ := send(testModel("alpha", "beta"), "space", "H")
+	mm, _ := m.Update(historyLoadedMsg{runs: runs})
+	m2 := mm.(tuiModel)
+	_, cmd := send(m2, "enter")
+	om, _ := m2.Update(cmd().(historyOpenedMsg))
+	open := om.(tuiModel)
+
+	if !open.histRunOpen() {
+		t.Fatal("precondition: a run is open")
+	}
+	back1, _ := send(open, "esc")
+	if back1.histRunOpen() {
+		t.Error("the first esc must close the run, not leave history")
+	}
+	if !back1.histOn {
+		t.Error("the first esc must stay in history")
+	}
+	if len(back1.selected) == 0 {
+		t.Error("the first esc must not clear the selection — it was unwinding history")
+	}
+
+	back2, _ := send(back1, "esc")
+	if back2.histOn {
+		t.Error("the second esc must leave history")
+	}
+	if len(back2.selected) == 0 {
+		t.Error("the second esc leaves history; it must not also clear the selection")
+	}
+
+	back3, _ := send(back2, "esc")
+	if len(back3.selected) != 0 {
+		t.Error("once out of history, esc resumes its normal meaning and clears the selection")
+	}
+}
+
+// TestOpeningARunNeverLosesLiveStreamLines pins the interaction the design
+// flagged as the real risk: the log pane is shared with a running update.
+// Viewing history must not discard lines the engine is still producing, so
+// they keep buffering into m.logs and are shown again on the way out.
+func TestOpeningARunNeverLosesLiveStreamLines(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	m := testModel("alpha")
+	m.appendLog("alpha", "live line before history")
+
+	m2, _ := send(m, "H")
+	lm, _ := m2.Update(historyLoadedMsg{runs: runs})
+	m3 := lm.(tuiModel)
+	_, cmd := send(m3, "enter")
+	om, _ := m3.Update(cmd().(historyOpenedMsg))
+	open := om.(tuiModel)
+
+	// a line arrives from the still-running update while history is on screen
+	open.appendLog("alpha", "live line during history")
+
+	for _, e := range open.logEntries() {
+		if strings.Contains(e.line, "live line") {
+			t.Fatalf("the live stream must not leak into the opened capture: %q", e.line)
+		}
+	}
+
+	back, _ := send(open, "esc", "esc")
+	var got []string
+	for _, e := range back.logEntries() {
+		got = append(got, e.line)
+	}
+	if len(got) != 2 {
+		t.Fatalf("both live lines must survive the round trip, got %v", got)
+	}
+}

--- a/sdk/fleet/cmd/tui_history_test.go
+++ b/sdk/fleet/cmd/tui_history_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var errTestScan = errors.New("scan boom")
+
+func histCapture(t *testing.T, dir, stamp, host, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, stamp+"__"+host+".log"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const histRun = `# fleet update — host=x started=y
+03:47:14 === step dotfiles.sync (sync) ===
+03:47:16 Already up to date.
+# 2026-09-09T03:50:36Z finished
+`
+
+// TestHistoryRunsScopeToTheGivenHosts pins that history follows the SELECTION,
+// the same rule `u` and `w` already use via updateTargets(): an operator who
+// has selected three hosts means those three, and one who has selected none
+// means the host under the cursor. Loading the whole fleet regardless would
+// discard the scoping the operator just did by hand.
+func TestHistoryRunsScopeToTheGivenHosts(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+	histCapture(t, dir, "20260909T040000Z", "beta", histRun)
+	histCapture(t, dir, "20260909T050000Z", "gamma", histRun)
+
+	runs, err := historyRuns(dir, []string{"alpha", "gamma"})
+	if err != nil {
+		t.Fatalf("historyRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("got %d runs, want alpha+gamma only: %+v", len(runs), runs)
+	}
+	// newest first, so gamma (05:00) leads alpha (03:00)
+	if runs[0].Host != "gamma" || runs[1].Host != "alpha" {
+		t.Errorf("want gamma then alpha (newest first), got %s then %s", runs[0].Host, runs[1].Host)
+	}
+}
+
+// TestHistoryRunsWithNoHostsIsTheWholeFleet pins the wider scope: an empty
+// host list means "everything", which is what an empty selection with no
+// cursor (an empty fleet, or a search that matched nothing) should show
+// rather than an error.
+func TestHistoryRunsWithNoHostsIsTheWholeFleet(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+	histCapture(t, dir, "20260909T040000Z", "beta", histRun)
+
+	runs, err := historyRuns(dir, nil)
+	if err != nil {
+		t.Fatalf("historyRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("got %d runs, want both: %+v", len(runs), runs)
+	}
+}
+
+// TestHistoryRunsCarriesTheSummary pins that the list has what it needs to be
+// triaged without opening anything: whether the run finished, and its warning
+// count. Those require the file to be read, which is why the list holds
+// Summary rather than the filename-only Run.
+func TestHistoryRunsCarriesTheSummary(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+
+	runs, err := historyRuns(dir, []string{"alpha"})
+	if err != nil {
+		t.Fatalf("historyRuns: %v", err)
+	}
+	if !runs[0].Finished {
+		t.Errorf("a capture with a footer is finished: %+v", runs[0])
+	}
+	if runs[0].Path == "" || !strings.HasSuffix(runs[0].Path, "__alpha.log") {
+		t.Errorf("the run must carry its path so it can be opened: %+v", runs[0])
+	}
+}
+
+// TestHistoryRunsWithNoLogDirIsEmptyNotAnError pins the fresh-machine case:
+// a dashboard on a host that has never run an update opens history to an
+// empty list and a sentence, never a failure — the same rule fleet applies
+// to a missing ~/.ssh/config.
+func TestHistoryRunsWithNoLogDirIsEmptyNotAnError(t *testing.T) {
+	runs, err := historyRuns(filepath.Join(t.TempDir(), "nope"), []string{"alpha"})
+	if err != nil {
+		t.Fatalf("a missing log dir must not be an error: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("want no runs, got %+v", runs)
+	}
+}
+
+// TestHistoryKeyScopeFollowsTheSelection pins that H obeys the same rule as
+// `u` and `w`: the selection if there is one, otherwise the cursor host. An
+// operator who has just selected three hosts and presses H means those
+// three; widening to the whole fleet would silently discard the scoping they
+// did by hand.
+func TestHistoryKeyScopeFollowsTheSelection(t *testing.T) {
+	m := testModel("alpha", "beta", "gamma")
+
+	// no selection: the cursor host alone
+	m2, cmd := send(m, "H")
+	if !m2.histOn {
+		t.Fatal("H must enter history")
+	}
+	if cmd == nil {
+		t.Error("H must return a Cmd to load the runs — I/O never happens in Update")
+	}
+	if len(m2.histScope) != 1 || m2.histScope[0] != m.cursor {
+		t.Errorf("scope = %v, want the cursor host %q", m2.histScope, m.cursor)
+	}
+
+	// with a selection: exactly the selected hosts
+	m3, _ := send(m, "space", "j", "space")
+	sel := m3.updateTargets()
+	m4, _ := send(m3, "H")
+	if len(m4.histScope) != len(sel) {
+		t.Errorf("scope = %v, want the selection %v", m4.histScope, sel)
+	}
+}
+
+// TestHistoryKeyTogglesBackToTheDashboard pins that H is a toggle and that
+// leaving restores the dashboard exactly — history is VIEW state, so the
+// host cursor it was scoped from must survive the round trip untouched.
+func TestHistoryKeyTogglesBackToTheDashboard(t *testing.T) {
+	m := testModel("alpha", "beta", "gamma")
+	before := m.cursor
+
+	m2, _ := send(m, "H")
+	if !m2.histOn {
+		t.Fatal("H must enter history")
+	}
+	m3, _ := send(m2, "H")
+	if m3.histOn {
+		t.Error("a second H must return to the dashboard")
+	}
+	if m3.cursor != before {
+		t.Errorf("host cursor = %q, want it preserved as %q across the round trip", m3.cursor, before)
+	}
+}
+
+// TestHistoryLoadedCursorsTheNewestRun pins where the cursor lands. The run
+// list is newest-first, and "what happened last" is the question someone
+// opening history is nearly always asking.
+func TestHistoryLoadedCursorsTheNewestRun(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+	histCapture(t, dir, "20260909T050000Z", "alpha", histRun)
+
+	runs, err := historyRuns(dir, []string{"alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m, _ := send(testModel("alpha"), "H")
+	mm, _ := m.Update(historyLoadedMsg{runs: runs})
+	m2 := mm.(tuiModel)
+
+	if len(m2.histRuns) != 2 {
+		t.Fatalf("want both runs loaded, got %d", len(m2.histRuns))
+	}
+	if m2.histCursor != runs[0].Path {
+		t.Errorf("cursor = %q, want the newest run %q", m2.histCursor, runs[0].Path)
+	}
+}
+
+// TestHistoryLoadFailureIsSaidNotSwallowed pins that a scan error reaches the
+// operator. An empty list that silently means "I could not read the
+// directory" is the same class of lie as calling an unobserved run clean.
+func TestHistoryLoadFailureIsSaidNotSwallowed(t *testing.T) {
+	m, _ := send(testModel("alpha"), "H")
+	mm, _ := m.Update(historyLoadedMsg{err: errTestScan})
+	m2 := mm.(tuiModel)
+
+	if m2.status == "" || !strings.Contains(m2.status, "history") {
+		t.Errorf("a failed history load must be reported in the status line, got %q", m2.status)
+	}
+}

--- a/sdk/fleet/cmd/tui_history_test.go
+++ b/sdk/fleet/cmd/tui_history_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -183,5 +184,77 @@ func TestHistoryLoadFailureIsSaidNotSwallowed(t *testing.T) {
 
 	if m2.status == "" || !strings.Contains(m2.status, "history") {
 		t.Errorf("a failed history load must be reported in the status line, got %q", m2.status)
+	}
+}
+
+// histModelWith returns a model already in history with runs loaded, so the
+// motion tests exercise the real key path rather than poking state.
+func histModelWith(t *testing.T, n int) tuiModel {
+	t.Helper()
+	dir := t.TempDir()
+	for i := 0; i < n; i++ {
+		histCapture(t, dir, fmt.Sprintf("2026090%dT030000Z", i+1), "alpha", histRun)
+	}
+	runs, err := historyRuns(dir, []string{"alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, _ := send(testModel("alpha"), "H")
+	mm, _ := m.Update(historyLoadedMsg{runs: runs})
+	return mm.(tuiModel)
+}
+
+// TestHistoryMotionUsesTheSameKeysAsTheHostList pins the payoff of history
+// being view state rather than a mode: j/k/G/gg and the half-page motions
+// move the RUN cursor with no new bindings and no duplicated routing. If
+// this needed its own key table, history should have been a mode.
+func TestHistoryMotionUsesTheSameKeysAsTheHostList(t *testing.T) {
+	m := histModelWith(t, 4)
+	first := m.histCursor
+
+	m2, _ := send(m, "j")
+	if m2.histCursor == first {
+		t.Error("j must move the run cursor")
+	}
+	m3, _ := send(m2, "k")
+	if m3.histCursor != first {
+		t.Errorf("k must move back to %q, got %q", first, m3.histCursor)
+	}
+
+	m4, _ := send(m, "G")
+	if m4.histCursor != m.histRuns[len(m.histRuns)-1].Path {
+		t.Error("G must jump to the oldest run")
+	}
+	m5, _ := send(m4, "g", "g")
+	if m5.histCursor != first {
+		t.Error("gg must jump back to the newest run")
+	}
+}
+
+// TestHistoryMotionLeavesTheHostCursorAlone pins the separation: the two
+// cursors are independent, so leaving history puts the operator back exactly
+// where they were in the host list.
+func TestHistoryMotionLeavesTheHostCursorAlone(t *testing.T) {
+	m := histModelWith(t, 3)
+	host := m.cursor
+
+	m2, _ := send(m, "j", "j", "G")
+	if m2.cursor != host {
+		t.Errorf("host cursor moved to %q while navigating history; want %q", m2.cursor, host)
+	}
+}
+
+// TestHistoryMotionClampsAtBothEnds pins that motion cannot run off the list
+// — the same clamping moveTo already gives the host list.
+func TestHistoryMotionClampsAtBothEnds(t *testing.T) {
+	m := histModelWith(t, 3)
+
+	m2, _ := send(m, "k", "k", "k", "k")
+	if m2.histCursor != m.histRuns[0].Path {
+		t.Error("k past the top must clamp to the newest run")
+	}
+	m3, _ := send(m, "j", "j", "j", "j", "j")
+	if m3.histCursor != m.histRuns[len(m.histRuns)-1].Path {
+		t.Error("j past the bottom must clamp to the oldest run")
 	}
 }

--- a/sdk/fleet/cmd/tui_history_test.go
+++ b/sdk/fleet/cmd/tui_history_test.go
@@ -7,9 +7,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/histindex"
 )
 
 var errTestScan = errors.New("scan boom")
@@ -383,7 +387,7 @@ func TestEnterOpensTheRunIntoThePanes(t *testing.T) {
 	mm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
 	m2 := mm.(tuiModel)
 
-	_, cmd := send(m2, "enter")
+	m2, cmd := send(m2, "enter")
 	if cmd == nil {
 		t.Fatal("enter must return a Cmd — reading a capture is I/O and never happens in Update")
 	}
@@ -426,7 +430,7 @@ func TestEscUnwindsOneLevelAtATime(t *testing.T) {
 	m, _ := send(testModel("alpha", "beta"), "space", "H")
 	mm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
 	m2 := mm.(tuiModel)
-	_, cmd := send(m2, "enter")
+	m2, cmd := send(m2, "enter")
 	om, _ := m2.Update(cmd().(historyOpenedMsg))
 	open := om.(tuiModel)
 
@@ -473,7 +477,7 @@ func TestOpeningARunNeverLosesLiveStreamLines(t *testing.T) {
 	m2, _ := send(m, "H")
 	lm, _ := m2.Update(historyLoadedMsg{runs: runs, scope: m2.histScope})
 	m3 := lm.(tuiModel)
-	_, cmd := send(m3, "enter")
+	m3, cmd := send(m3, "enter")
 	om, _ := m3.Update(cmd().(historyOpenedMsg))
 	open := om.(tuiModel)
 
@@ -517,8 +521,7 @@ func TestOpenedRunFillsTheStderrPane(t *testing.T) {
 	m2.errOpen = true
 	m2.vp.width, m2.vp.height = 100, 30
 
-	om, _ := m2.Update(openHistoryRun(runs[0])().(historyOpenedMsg))
-	open := om.(tuiModel)
+	open := openVia(t, m2, runs[0])
 
 	if !open.errActive() {
 		t.Error("a capture carrying stderr must make the error pane active")
@@ -597,8 +600,7 @@ func TestHTogglingOffClosesTheOpenedRun(t *testing.T) {
 	m, _ := send(testModel("alpha"), "H")
 	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
 	m2 := lm.(tuiModel)
-	om, _ := m2.Update(openHistoryRun(runs[0])().(historyOpenedMsg))
-	open := om.(tuiModel)
+	open := openVia(t, m2, runs[0])
 	open.appendLog("alpha", "a live line")
 
 	off, _ := send(open, "H")
@@ -628,8 +630,7 @@ func TestCaptureLinesKeepTheirRecordedTime(t *testing.T) {
 
 	m, _ := send(testModel("alpha"), "H")
 	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
-	om, _ := lm.(tuiModel).Update(openHistoryRun(runs[0])().(historyOpenedMsg))
-	open := om.(tuiModel)
+	open := openVia(t, lm.(tuiModel), runs[0])
 
 	got := open.logEntries()
 	if len(got) != 2 {
@@ -638,8 +639,10 @@ func TestCaptureLinesKeepTheirRecordedTime(t *testing.T) {
 	if a, b := got[0].at.Format("15:04:05"), got[1].at.Format("15:04:05"); a == b {
 		t.Errorf("both lines stamped %s — the recorded times were discarded", a)
 	}
-	if got[0].at.Format("15:04:05") != "03:47:14" {
-		t.Errorf("first line stamped %s, want its recorded 03:47:14", got[0].at.Format("15:04:05"))
+	// The file records UTC; the pane shows it in local time.
+	want := time.Date(2026, 9, 9, 3, 47, 14, 0, time.UTC).In(time.Local).Format("15:04:05")
+	if got[0].at.Format("15:04:05") != want {
+		t.Errorf("first line stamped %s, want its recorded 03:47:14Z (%s local)", got[0].at.Format("15:04:05"), want)
 	}
 }
 
@@ -660,8 +663,7 @@ func TestCapitalJScrollsAnOpenedCapture(t *testing.T) {
 
 	m, _ := send(testModel("alpha"), "H")
 	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
-	om, _ := lm.(tuiModel).Update(openHistoryRun(runs[0])().(historyOpenedMsg))
-	open := om.(tuiModel)
+	open := openVia(t, lm.(tuiModel), runs[0])
 	open.logOpen = true
 	open.vp.width, open.vp.height = 100, 30
 
@@ -686,8 +688,7 @@ func TestClosingARunRestoresLiveFollowing(t *testing.T) {
 	if !m2.logFollow {
 		t.Skip("live following is off by default in this model; nothing to restore")
 	}
-	om, _ := m2.Update(openHistoryRun(runs[0])().(historyOpenedMsg))
-	open := om.(tuiModel)
+	open := openVia(t, m2, runs[0])
 	if open.logFollow {
 		t.Fatal("precondition: opening a capture stops following")
 	}
@@ -718,8 +719,7 @@ func TestStderrTitleFollowsTheOpenedCapture(t *testing.T) {
 
 	m2, _ := send(m, "H")
 	lm, _ := m2.Update(historyLoadedMsg{runs: runs, scope: m2.histScope})
-	om, _ := lm.(tuiModel).Update(openHistoryRun(runs[0])().(historyOpenedMsg))
-	open := om.(tuiModel)
+	open := openVia(t, lm.(tuiModel), runs[0])
 
 	title := stripANSI(open.errViewN(6))
 	if strings.Contains(title, "2 warning") {
@@ -744,8 +744,7 @@ func TestWarnGutterAgreesWithTheRunListColumn(t *testing.T) {
 
 	m, _ := send(testModel("alpha"), "H")
 	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
-	om, _ := lm.(tuiModel).Update(openHistoryRun(runs[0])().(historyOpenedMsg))
-	open := om.(tuiModel)
+	open := openVia(t, lm.(tuiModel), runs[0])
 
 	for _, e := range open.logEntries() {
 		if e.warn {
@@ -780,5 +779,274 @@ func TestStaleHistoryLoadIsDropped(t *testing.T) {
 		if r.Host == "alpha" {
 			t.Fatalf("a stale scan for a discarded scope overwrote the current list: %+v", after.histRuns)
 		}
+	}
+}
+
+// --- fixes for the second PR #320 review ----------------------------------
+
+// openVia opens r the way the operator does — cursor on it, enter, and the
+// read's answer — so the pending-open check is exercised, never bypassed.
+func openVia(t *testing.T, m tuiModel, r histindex.Summary) tuiModel {
+	t.Helper()
+	m.histCursor = r.Path
+	m, cmd := send(m, "enter")
+	if cmd == nil {
+		t.Fatal("precondition: enter must issue the open")
+	}
+	om, _ := m.Update(cmd())
+	return om.(tuiModel)
+}
+
+// histOpen drives H → load → enter → open through the real Update path and
+// returns the model with the run on screen.
+func histOpen(t *testing.T, m tuiModel, runs []histindex.Summary) tuiModel {
+	t.Helper()
+	in, _ := send(m, "H")
+	lm, _ := in.Update(historyLoadedMsg{runs: runs, scope: in.histScope})
+	listed := lm.(tuiModel)
+	listed, cmd := send(listed, "enter")
+	if cmd == nil {
+		t.Fatal("precondition: enter must issue the open")
+	}
+	om, _ := listed.Update(cmd().(historyOpenedMsg))
+	return om.(tuiModel)
+}
+
+// TestLeavingHistoryWithoutOpeningKeepsTheLivePanes pins that a round trip
+// through the run list costs the live panes nothing. closeHistoryRun ran on
+// every exit and restored follow state that is only SAVED when a run opens —
+// so H,H (or H,esc) during a streaming update restored the zero value, and
+// both panes stopped following and jumped to line 1.
+func TestLeavingHistoryWithoutOpeningKeepsTheLivePanes(t *testing.T) {
+	for _, exit := range []string{"H", "esc"} {
+		m := testModel("alpha")
+		m.appendLog("alpha", "live")
+
+		in, _ := send(m, "H")
+		lm, _ := in.Update(historyLoadedMsg{runs: nil, scope: in.histScope})
+		out, _ := send(lm.(tuiModel), exit)
+		if !out.logFollow || !out.errFollow {
+			t.Errorf("H then %s: live panes stopped following (log=%v err=%v)",
+				exit, out.logFollow, out.errFollow)
+		}
+
+		// and a scrolled live pane keeps its place
+		s := testModel("alpha")
+		s.logFollow, s.logTop = false, 7
+		s.errFollow, s.errTop = false, 3
+		in2, _ := send(s, "H")
+		out2, _ := send(in2, exit)
+		if out2.logFollow || out2.logTop != 7 || out2.errFollow || out2.errTop != 3 {
+			t.Errorf("H then %s: a scrolled live pane lost its place (log=%v/%d err=%v/%d)",
+				exit, out2.logFollow, out2.logTop, out2.errFollow, out2.errTop)
+		}
+	}
+}
+
+// TestLiveEvictionLeavesAnOpenedCaptureWhereItIs pins that a busy update
+// cannot scroll a capture the operator is reading. The eviction shift in
+// appendLogLine corrects offsets into m.logs — but while a run is open,
+// logTop/errTop index the CAPTURE, so every evicted live line walked the
+// reader's view up by one.
+func TestLiveEvictionLeavesAnOpenedCaptureWhereItIs(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	b.WriteString("# fleet update — host=alpha started=x\n")
+	for i := 0; i < 100; i++ {
+		fmt.Fprintf(&b, "03:47:%02d line %d\n", i%60, i)
+		fmt.Fprintf(&b, "03:47:%02d !! warning %d\n", i%60, i)
+	}
+	b.WriteString("# 2026-09-09T03:50:36Z finished\n")
+	histCapture(t, dir, "20260909T030000Z", "alpha", b.String())
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	open := histOpen(t, testModel("alpha"), runs)
+	open.logTop, open.errTop = 50, 20
+
+	for i := 0; i < logCap+30; i++ {
+		open.appendLogLine("alpha", fmt.Sprintf("live %d", i), i%2 == 0)
+	}
+	if open.logTop != 50 || open.errTop != 20 {
+		t.Errorf("live eviction scrolled the opened capture: logTop=%d errTop=%d, want 50/20",
+			open.logTop, open.errTop)
+	}
+}
+
+// TestALateOpenAfterLeavingHistoryIsDropped pins that the async read cannot
+// resurrect a run the operator already walked away from. With enter then a
+// quick esc or H, the message landed after history was off and put the
+// stored capture back into the dashboard's panes — the exact state the H-off
+// fix exists to prevent.
+func TestALateOpenAfterLeavingHistoryIsDropped(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	for _, exit := range []string{"H", "esc"} {
+		m := testModel("alpha")
+		m.appendLog("alpha", "live")
+		in, _ := send(m, "H")
+		lm, _ := in.Update(historyLoadedMsg{runs: runs, scope: in.histScope})
+		listed := lm.(tuiModel)
+		listed, cmd := send(listed, "enter")
+		gone, _ := send(listed, exit)
+
+		late, _ := gone.Update(cmd().(historyOpenedMsg))
+		got := late.(tuiModel)
+		if got.histRunOpen() {
+			t.Errorf("enter then %s: the late open put a capture on the dashboard", exit)
+		}
+		if !got.logFollow {
+			t.Errorf("enter then %s: the late open stopped the live pane following", exit)
+		}
+	}
+}
+
+// TestDoubleEnterStillRestoresLiveFollowing pins the other race: two enters
+// before the read lands give two messages, and the second saved the ALREADY
+// cleared follow state as the "live" one — so closing the run froze the live
+// pane at line 1.
+func TestDoubleEnterStillRestoresLiveFollowing(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	in, _ := send(testModel("alpha"), "H")
+	lm, _ := in.Update(historyLoadedMsg{runs: runs, scope: in.histScope})
+	listed := lm.(tuiModel)
+	listed, cmd1 := send(listed, "enter")
+	listed, cmd2 := send(listed, "enter")
+
+	var mm tea.Model = listed
+	for _, c := range []tea.Cmd{cmd1, cmd2} {
+		if c != nil {
+			mm, _ = mm.Update(c())
+		}
+	}
+	open := mm.(tuiModel)
+	if !open.histRunOpen() {
+		t.Fatal("precondition: the run is open")
+	}
+	back, _ := send(open, "esc")
+	if !back.logFollow {
+		t.Error("closing the run after a double enter must resume following the live stream")
+	}
+}
+
+// TestSearchInHistoryLandsOnAMatchingRun pins that / n N search the list on
+// screen. jumpMatch matched HOST rows and handed the host index to moveTo,
+// which in history moves the RUN cursor — so /gam landed on whichever run
+// happened to share gamma's host-row position.
+func TestSearchInHistoryLandsOnAMatchingRun(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T060000Z", "alpha", histRun)
+	histCapture(t, dir, "20260909T050000Z", "beta", histRun)
+	histCapture(t, dir, "20260909T040000Z", "alpha", histRun)
+	histCapture(t, dir, "20260909T030000Z", "beta", histRun)
+	histCapture(t, dir, "20260909T010000Z", "gamma", histRun)
+
+	m, _ := send(testModel("alpha", "beta", "gamma"), "a", "H")
+	runs, _ := historyRuns(dir, m.histScope)
+	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
+	listed := lm.(tuiModel)
+
+	found, _ := send(listed, "/", "g", "a", "m", "enter")
+	r, ok := found.histAt()
+	if !ok || r.Host != "gamma" {
+		t.Errorf("/gam in history must land on gamma's run, got %+v", r)
+	}
+	again, _ := send(found, "n")
+	if r2, _ := again.histAt(); r2.Host != "gamma" {
+		t.Errorf("n must stay on the only gamma run, got %+v", r2)
+	}
+	if again.cursor != listed.cursor {
+		t.Errorf("searching the run list moved the host cursor from %q to %q", listed.cursor, again.cursor)
+	}
+}
+
+// TestOpeningARunKeepsItsRowOnScreen pins that the run cursor survives the
+// list getting SHORTER. histTop was only adjusted by motion keys, and opening
+// a run starts the log pane, which squeezes the list — so with the cursor on
+// the last of nine runs the list showed runs 1-4 and no cursor at all.
+func TestOpeningARunKeepsItsRowOnScreen(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 9; i++ {
+		histCapture(t, dir, fmt.Sprintf("2026090%dT030000Z", i+1), "alpha", histRun)
+	}
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	m := testModel("alpha")
+	m.logOpen = true
+	m.vp.width, m.vp.height = 100, 30
+	in, _ := send(m, "H")
+	lm, _ := in.Update(historyLoadedMsg{runs: runs, scope: in.histScope})
+	listed, _ := send(lm.(tuiModel), "G")
+	listed, cmd := send(listed, "enter")
+	om, _ := listed.Update(cmd().(historyOpenedMsg))
+	open := om.(tuiModel)
+
+	if open.visibleRows() >= len(runs) {
+		t.Fatalf("precondition: the open run must squeeze the list below %d rows, got %d",
+			len(runs), open.visibleRows())
+	}
+	if !strings.Contains(stripANSI(open.histPanel()), ">") {
+		t.Errorf("the opened run's row scrolled out of the list:\n%s", stripANSI(open.histPanel()))
+	}
+	// and moving afterwards does not jump the window
+	up, _ := send(open, "k")
+	if !strings.Contains(stripANSI(up.histPanel()), ">") {
+		t.Errorf("k after opening lost the cursor:\n%s", stripANSI(up.histPanel()))
+	}
+}
+
+// TestCaptureStampsRenderInLocalTime pins that an opened run speaks the same
+// clock as everything around it. libs/log writes line stamps in UTC; the run
+// list's WHEN column and live lines are local, so in PDT a run listed at
+// 20:00 opened with lines stamped 03:47.
+func TestCaptureStampsRenderInLocalTime(t *testing.T) {
+	saved := time.Local
+	time.Local = time.FixedZone("PDT", -7*3600)
+	t.Cleanup(func() { time.Local = saved })
+
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha",
+		"# fleet update — host=alpha started=x\n"+
+			"03:47:14 first\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+	runs, _ := historyRuns(dir, []string{"alpha"})
+	open := histOpen(t, testModel("alpha"), runs)
+
+	if got := open.logEntries()[0].at.Format("15:04:05"); got != "20:47:14" {
+		t.Errorf("line stamped %s, want 20:47:14 (03:47:14Z in PDT)", got)
+	}
+}
+
+// TestUnreadableCaptureIsNotCalledUnfinished pins the "never invent a fact"
+// rule for a row whose file could not be read. It got a zero summary and
+// rendered as "unfinished -" — a result and a warning count the file never
+// supported.
+func TestUnreadableCaptureIsNotCalledUnfinished(t *testing.T) {
+	dir := t.TempDir()
+	// a dangling symlink: listed by Scan, unreadable by Read, even as root
+	if err := os.Symlink(filepath.Join(dir, "gone"),
+		filepath.Join(dir, "20260909T030000Z__alpha.log")); err != nil {
+		t.Fatal(err)
+	}
+	runs, err := historyRuns(dir, []string{"alpha"})
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("precondition: one unreadable run listed, got %v %+v", err, runs)
+	}
+
+	m, _ := send(testModel("alpha"), "H")
+	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
+	listed := lm.(tuiModel)
+	listed.vp.width, listed.vp.height = 120, 40
+
+	out := stripANSI(listed.histPanel())
+	if strings.Contains(out, "unfinished") {
+		t.Errorf("an unreadable capture must not claim the run was unfinished:\n%s", out)
+	}
+	if !strings.Contains(out, "unreadable") {
+		t.Errorf("an unreadable capture must say so:\n%s", out)
 	}
 }

--- a/sdk/fleet/cmd/tui_history_test.go
+++ b/sdk/fleet/cmd/tui_history_test.go
@@ -166,7 +166,7 @@ func TestHistoryLoadedCursorsTheNewestRun(t *testing.T) {
 	}
 
 	m, _ := send(testModel("alpha"), "H")
-	mm, _ := m.Update(historyLoadedMsg{runs: runs})
+	mm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
 	m2 := mm.(tuiModel)
 
 	if len(m2.histRuns) != 2 {
@@ -182,7 +182,7 @@ func TestHistoryLoadedCursorsTheNewestRun(t *testing.T) {
 // directory" is the same class of lie as calling an unobserved run clean.
 func TestHistoryLoadFailureIsSaidNotSwallowed(t *testing.T) {
 	m, _ := send(testModel("alpha"), "H")
-	mm, _ := m.Update(historyLoadedMsg{err: errTestScan})
+	mm, _ := m.Update(historyLoadedMsg{err: errTestScan, scope: m.histScope})
 	m2 := mm.(tuiModel)
 
 	if m2.status == "" || !strings.Contains(m2.status, "history") {
@@ -203,7 +203,7 @@ func histModelWith(t *testing.T, n int) tuiModel {
 		t.Fatal(err)
 	}
 	m, _ := send(testModel("alpha"), "H")
-	mm, _ := m.Update(historyLoadedMsg{runs: runs})
+	mm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
 	return mm.(tuiModel)
 }
 
@@ -313,7 +313,7 @@ func TestHistoryPanelMarksTheCursor(t *testing.T) {
 // bare frame that reads as a broken pane.
 func TestHistoryPanelSaysWhenThereIsNothing(t *testing.T) {
 	m, _ := send(testModel("alpha"), "H")
-	mm, _ := m.Update(historyLoadedMsg{runs: nil})
+	mm, _ := m.Update(historyLoadedMsg{runs: nil, scope: m.histScope})
 	m2 := mm.(tuiModel)
 	m2.vp.width, m2.vp.height = 120, 40
 
@@ -341,7 +341,7 @@ func TestHistoryFrameNeverExceedsTheTerminal(t *testing.T) {
 	full := histModelWith(t, 12)
 
 	empty, _ := send(testModel("alpha"), "H")
-	em, _ := empty.Update(historyLoadedMsg{runs: nil})
+	em, _ := empty.Update(historyLoadedMsg{runs: nil, scope: empty.histScope})
 	emptyM := em.(tuiModel)
 
 	for _, m := range []tuiModel{full, emptyM} {
@@ -380,7 +380,7 @@ func TestEnterOpensTheRunIntoThePanes(t *testing.T) {
 	}
 
 	m, _ := send(testModel("alpha"), "H")
-	mm, _ := m.Update(historyLoadedMsg{runs: runs})
+	mm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
 	m2 := mm.(tuiModel)
 
 	_, cmd := send(m2, "enter")
@@ -424,7 +424,7 @@ func TestEscUnwindsOneLevelAtATime(t *testing.T) {
 	runs, _ := historyRuns(dir, []string{"alpha"})
 
 	m, _ := send(testModel("alpha", "beta"), "space", "H")
-	mm, _ := m.Update(historyLoadedMsg{runs: runs})
+	mm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
 	m2 := mm.(tuiModel)
 	_, cmd := send(m2, "enter")
 	om, _ := m2.Update(cmd().(historyOpenedMsg))
@@ -471,7 +471,7 @@ func TestOpeningARunNeverLosesLiveStreamLines(t *testing.T) {
 	m.appendLog("alpha", "live line before history")
 
 	m2, _ := send(m, "H")
-	lm, _ := m2.Update(historyLoadedMsg{runs: runs})
+	lm, _ := m2.Update(historyLoadedMsg{runs: runs, scope: m2.histScope})
 	m3 := lm.(tuiModel)
 	_, cmd := send(m3, "enter")
 	om, _ := m3.Update(cmd().(historyOpenedMsg))
@@ -512,7 +512,7 @@ func TestOpenedRunFillsTheStderrPane(t *testing.T) {
 	runs, _ := historyRuns(dir, []string{"alpha"})
 
 	m, _ := send(testModel("alpha"), "H")
-	lm, _ := m.Update(historyLoadedMsg{runs: runs})
+	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
 	m2 := lm.(tuiModel)
 	m2.errOpen = true
 	m2.vp.width, m2.vp.height = 100, 30
@@ -529,5 +529,256 @@ func TestOpenedRunFillsTheStderrPane(t *testing.T) {
 	}
 	if !strings.Contains(stripANSI(out), "could not read Username") {
 		t.Errorf("the capture's stderr line must appear in the pane:\n%s", out)
+	}
+}
+
+// --- fixes for the PR #320 review -----------------------------------------
+
+// TestTUIWiresTheCaptureDirectory pins the bug that made the whole feature a
+// no-op in the shipped binary: m.logDir was declared and read in two places
+// but NEVER assigned outside tests, so H scanned "" and always rendered "no
+// captured runs". Worse, the same empty dir reaches beginStream, so with
+// libs/log's "empty Dir means no capture" rule the dashboard's own updates
+// were writing NO captures at all — a regression the CLI tests could not see
+// because they inject a temp dir straight into historyRuns.
+func TestTUIWiresTheCaptureDirectory(t *testing.T) {
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+
+	m := testModel("alpha")
+	wireTUIPaths(&m)
+
+	if m.logDir == "" {
+		t.Fatal("logDir must be wired, or H scans nothing and TUI updates capture nothing")
+	}
+	if !strings.HasPrefix(m.logDir, state) {
+		t.Errorf("logDir = %q, want it under the state dir %q", m.logDir, state)
+	}
+	if m.ansPath == "" {
+		t.Error("wiring must still attach the answers path")
+	}
+}
+
+// TestHistoryViewportFollowsTheRunCursor pins that the run list scrolls by its
+// OWN offset. It was sliced by m.vp.top, which clampViewport recomputes from
+// the HOST cursor: with the cursor deep in a long host list and a host with
+// few captures, top exceeded the run count and the panel rendered a header
+// with nothing under it.
+func TestHistoryViewportFollowsTheRunCursor(t *testing.T) {
+	m := histModelWith(t, 3)
+	m.vp.width, m.vp.height = 100, 30
+	m.vp.top = 24 // as if the host cursor were row 24 of a long fleet
+
+	out := stripANSI(m.histPanel())
+	if !strings.Contains(out, "finished") {
+		t.Fatalf("the run list must render regardless of the host viewport:\n%s", out)
+	}
+
+	// and the cursor must stay reachable when scrolling down a long list
+	long := histModelWith(t, 40)
+	long.vp.width, long.vp.height = 100, 20
+	for i := 0; i < 30; i++ {
+		long, _ = send(long, "j")
+	}
+	if !strings.Contains(stripANSI(long.histPanel()), ">") {
+		t.Error("the run cursor must remain visible when it moves past the pane height")
+	}
+}
+
+// TestHTogglingOffClosesTheOpenedRun pins that H off is as complete as esc.
+// Toggling off cleared histOn but not histPath, and histRunOpen() keys off
+// histPath alone — so the dashboard came back with the stored capture still
+// filling the log and stderr panes while a live update streamed unseen.
+func TestHTogglingOffClosesTheOpenedRun(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	m, _ := send(testModel("alpha"), "H")
+	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
+	m2 := lm.(tuiModel)
+	om, _ := m2.Update(openHistoryRun(runs[0])().(historyOpenedMsg))
+	open := om.(tuiModel)
+	open.appendLog("alpha", "a live line")
+
+	off, _ := send(open, "H")
+	if off.histRunOpen() {
+		t.Error("toggling history off must close the opened run")
+	}
+	if len(off.logEntries()) != 1 || !strings.Contains(off.logEntries()[0].line, "a live line") {
+		t.Errorf("the panes must return to the live buffer, got %+v", off.logEntries())
+	}
+	if off.errTotal() != 0 {
+		t.Errorf("errTotal must return to the live count, got %d", off.errTotal())
+	}
+}
+
+// TestCaptureLinesKeepTheirRecordedTime pins that a stored line renders the
+// time it was WRITTEN. Every line was stamped m.now (model construction), so
+// a run captured over three minutes displayed as one instant repeated — and
+// the stamp column exists precisely to show how long a step took.
+func TestCaptureLinesKeepTheirRecordedTime(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha",
+		"# fleet update — host=alpha started=x\n"+
+			"03:47:14 first\n"+
+			"03:50:21 later\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	m, _ := send(testModel("alpha"), "H")
+	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
+	om, _ := lm.(tuiModel).Update(openHistoryRun(runs[0])().(historyOpenedMsg))
+	open := om.(tuiModel)
+
+	got := open.logEntries()
+	if len(got) != 2 {
+		t.Fatalf("want 2 lines, got %d", len(got))
+	}
+	if a, b := got[0].at.Format("15:04:05"), got[1].at.Format("15:04:05"); a == b {
+		t.Errorf("both lines stamped %s — the recorded times were discarded", a)
+	}
+	if got[0].at.Format("15:04:05") != "03:47:14" {
+		t.Errorf("first line stamped %s, want its recorded 03:47:14", got[0].at.Format("15:04:05"))
+	}
+}
+
+// TestCapitalJScrollsAnOpenedCapture pins the one J/K call site that was not
+// converted to logEntries(). With no update running the live buffer is empty,
+// so the clamp pinned logTop to 0 and J would not scroll a 300-line capture —
+// while tab-focusing the pane and pressing j worked, making it look arbitrary.
+func TestCapitalJScrollsAnOpenedCapture(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	b.WriteString("# fleet update — host=alpha started=x\n")
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&b, "03:47:%02d line %d\n", i%60, i)
+	}
+	b.WriteString("# 2026-09-09T03:50:36Z finished\n")
+	histCapture(t, dir, "20260909T030000Z", "alpha", b.String())
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	m, _ := send(testModel("alpha"), "H")
+	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
+	om, _ := lm.(tuiModel).Update(openHistoryRun(runs[0])().(historyOpenedMsg))
+	open := om.(tuiModel)
+	open.logOpen = true
+	open.vp.width, open.vp.height = 100, 30
+
+	scrolled, _ := send(open, "J")
+	if scrolled.logTop == 0 {
+		t.Error("J must scroll an opened capture even when the live buffer is empty")
+	}
+}
+
+// TestClosingARunRestoresLiveFollowing pins that leaving history hands the
+// live pane back in a usable state. Opening a capture turns following OFF (a
+// stored run is read from its start); esc restored neither, so the operator
+// returned to a still-growing buffer frozen at line 1.
+func TestClosingARunRestoresLiveFollowing(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	m, _ := send(testModel("alpha"), "H")
+	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
+	m2 := lm.(tuiModel)
+	if !m2.logFollow {
+		t.Skip("live following is off by default in this model; nothing to restore")
+	}
+	om, _ := m2.Update(openHistoryRun(runs[0])().(historyOpenedMsg))
+	open := om.(tuiModel)
+	if open.logFollow {
+		t.Fatal("precondition: opening a capture stops following")
+	}
+
+	back, _ := send(open, "esc")
+	if !back.logFollow || back.logTop != 0 {
+		t.Errorf("closing a run must resume following the live stream (follow=%v top=%d)",
+			back.logFollow, back.logTop)
+	}
+}
+
+// TestStderrTitleFollowsTheOpenedCapture pins the same class of mismatch this
+// branch already fixed once for errCount: the pane BODY followed the capture
+// while its TITLE still summed m.warns, a map only live lines ever write. An
+// older clean capture displayed under a header counting a different run's
+// warnings.
+func TestStderrTitleFollowsTheOpenedCapture(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun) // clean: no stderr
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	m := testModel("alpha")
+	m.errOpen = true
+	m.vp.width, m.vp.height = 100, 30
+	// a live run that produced warnings
+	m.appendLogLine("alpha", "WARNING: apt-get update failed", true)
+	m.appendLogLine("alpha", "WARNING: grouped install failed", true)
+
+	m2, _ := send(m, "H")
+	lm, _ := m2.Update(historyLoadedMsg{runs: runs, scope: m2.histScope})
+	om, _ := lm.(tuiModel).Update(openHistoryRun(runs[0])().(historyOpenedMsg))
+	open := om.(tuiModel)
+
+	title := stripANSI(open.errViewN(6))
+	if strings.Contains(title, "2 warning") {
+		t.Errorf("the stderr title reports the LIVE run's warnings over a stored capture:\n%s", title)
+	}
+}
+
+// TestWarnGutterAgreesWithTheRunListColumn pins that the `!` gutter and the
+// list's WARN column classify identically. captureEntries passed Benign the
+// RAW line while histindex.Read strips colour first, so a colourised benign
+// git line counted as 0 in the list and was flagged as a warning once opened.
+func TestWarnGutterAgreesWithTheRunListColumn(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha",
+		"# fleet update — host=alpha started=x\n"+
+			"03:47:16 !! \x1b[1;33mAlready on 'main'\x1b[0m\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+	runs, _ := historyRuns(dir, []string{"alpha"})
+	if runs[0].Warnings != 0 {
+		t.Fatalf("precondition: the colourised git line is benign, got %d", runs[0].Warnings)
+	}
+
+	m, _ := send(testModel("alpha"), "H")
+	lm, _ := m.Update(historyLoadedMsg{runs: runs, scope: m.histScope})
+	om, _ := lm.(tuiModel).Update(openHistoryRun(runs[0])().(historyOpenedMsg))
+	open := om.(tuiModel)
+
+	for _, e := range open.logEntries() {
+		if e.warn {
+			t.Errorf("line flagged as a warning though the list counted none: %q", e.line)
+		}
+	}
+}
+
+// TestStaleHistoryLoadIsDropped pins that a slow scan cannot overwrite a newer
+// one. Two H presses with different scopes race; if the first finishes second
+// the list would show scope A's runs while histScope says B — which also flips
+// the HOST-column decision and lets enter open a run outside the shown scope.
+func TestStaleHistoryLoadIsDropped(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha", histRun)
+	histCapture(t, dir, "20260909T040000Z", "beta", histRun)
+	aRuns, _ := historyRuns(dir, []string{"alpha"})
+	bRuns, _ := historyRuns(dir, []string{"beta"})
+
+	m, _ := send(testModel("alpha", "beta"), "H") // scope: alpha (cursor)
+	m2, _ := send(m, "H")                         // leave
+	m3, _ := send(m2, "j", "H")                   // scope: beta
+	scope := m3.histScope
+
+	// beta's result lands first, then alpha's stale one arrives
+	lm, _ := m3.Update(historyLoadedMsg{runs: bRuns, scope: scope})
+	cur := lm.(tuiModel)
+	sm, _ := cur.Update(historyLoadedMsg{runs: aRuns, scope: []string{"alpha"}})
+	after := sm.(tuiModel)
+
+	for _, r := range after.histRuns {
+		if r.Host == "alpha" {
+			t.Fatalf("a stale scan for a discarded scope overwrote the current list: %+v", after.histRuns)
+		}
 	}
 }

--- a/sdk/fleet/cmd/tui_history_test.go
+++ b/sdk/fleet/cmd/tui_history_test.go
@@ -495,3 +495,39 @@ func TestOpeningARunNeverLosesLiveStreamLines(t *testing.T) {
 		t.Fatalf("both live lines must survive the round trip, got %v", got)
 	}
 }
+
+// TestOpenedRunFillsTheStderrPane pins a bug the demo frames caught that the
+// unit tests missed: errEntries() correctly returned the capture's stderr,
+// but the pane's EMPTINESS check reads errCount — a counter maintained
+// incrementally as live lines arrive, and therefore zero for a capture that
+// was read from disk. The pane rendered "stderr: none captured" directly
+// underneath the very line it should have been showing.
+func TestOpenedRunFillsTheStderrPane(t *testing.T) {
+	dir := t.TempDir()
+	histCapture(t, dir, "20260909T030000Z", "alpha",
+		"# fleet update — host=alpha started=x\n"+
+			"03:47:14 === step dotfiles.sync (sync) ===\n"+
+			"03:47:16 !! fatal: could not read Username\n"+
+			"# 2026-09-09T03:50:36Z finished\n")
+	runs, _ := historyRuns(dir, []string{"alpha"})
+
+	m, _ := send(testModel("alpha"), "H")
+	lm, _ := m.Update(historyLoadedMsg{runs: runs})
+	m2 := lm.(tuiModel)
+	m2.errOpen = true
+	m2.vp.width, m2.vp.height = 100, 30
+
+	om, _ := m2.Update(openHistoryRun(runs[0])().(historyOpenedMsg))
+	open := om.(tuiModel)
+
+	if !open.errActive() {
+		t.Error("a capture carrying stderr must make the error pane active")
+	}
+	out := open.View()
+	if strings.Contains(out, "none captured") {
+		t.Errorf("the stderr pane claims nothing was captured while showing a captured run:\n%s", out)
+	}
+	if !strings.Contains(stripANSI(out), "could not read Username") {
+		t.Errorf("the capture's stderr line must appear in the pane:\n%s", out)
+	}
+}

--- a/sdk/fleet/cmd/tui_history_test.go
+++ b/sdk/fleet/cmd/tui_history_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 var errTestScan = errors.New("scan boom")
@@ -256,5 +259,105 @@ func TestHistoryMotionClampsAtBothEnds(t *testing.T) {
 	m3, _ := send(m, "j", "j", "j", "j", "j")
 	if m3.histCursor != m.histRuns[len(m.histRuns)-1].Path {
 		t.Error("j past the bottom must clamp to the oldest run")
+	}
+}
+
+// TestHistoryPanelListsTheRuns pins what the run list shows: enough to triage
+// without opening anything — when it ran, whether it finished, and its
+// warning count — which is why the list holds Summary rather than Run.
+func TestHistoryPanelListsTheRuns(t *testing.T) {
+	m := histModelWith(t, 3)
+	m.vp.width, m.vp.height = 120, 40
+
+	out := m.histPanel()
+	for _, want := range []string{"WHEN", "RESULT", "WARN"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("run list must carry a %q column:\n%s", want, out)
+		}
+	}
+	if strings.Count(out, "finished") < 3 {
+		t.Errorf("all three runs must be listed:\n%s", out)
+	}
+}
+
+// TestHistoryPanelShowsHostOnlyWhenScopeIsWider pins that the HOST column
+// earns its width. Scoped to one host every row would repeat the same name,
+// spending cells the run list needs and telling the operator nothing they
+// did not just choose.
+func TestHistoryPanelShowsHostOnlyWhenScopeIsWider(t *testing.T) {
+	one := histModelWith(t, 2)
+	one.vp.width, one.vp.height = 120, 40
+	if strings.Contains(one.histPanel(), "HOST") {
+		t.Errorf("a single-host scope must not spend a HOST column:\n%s", one.histPanel())
+	}
+
+	two := one
+	two.histScope = []string{"alpha", "beta"}
+	if !strings.Contains(two.histPanel(), "HOST") {
+		t.Errorf("a multi-host scope must name the host per row:\n%s", two.histPanel())
+	}
+}
+
+// TestHistoryPanelMarksTheCursor pins that the run under the cursor is
+// visibly the one enter would open.
+func TestHistoryPanelMarksTheCursor(t *testing.T) {
+	m := histModelWith(t, 3)
+	m.vp.width, m.vp.height = 120, 40
+	if !strings.Contains(m.histPanel(), ">") {
+		t.Errorf("the cursor row must be marked:\n%s", m.histPanel())
+	}
+}
+
+// TestHistoryPanelSaysWhenThereIsNothing pins the empty case: a host that has
+// never been updated gets a sentence naming why the list is empty, never a
+// bare frame that reads as a broken pane.
+func TestHistoryPanelSaysWhenThereIsNothing(t *testing.T) {
+	m, _ := send(testModel("alpha"), "H")
+	mm, _ := m.Update(historyLoadedMsg{runs: nil})
+	m2 := mm.(tuiModel)
+	m2.vp.width, m2.vp.height = 120, 40
+
+	out := m2.histPanel()
+	if !strings.Contains(strings.ToLower(out), "no ") {
+		t.Errorf("an empty history must explain itself:\n%s", out)
+	}
+}
+
+// TestHistoryFrameNeverExceedsTheTerminal pins the height invariant for the
+// NEW panel. The existing 1219-size sweep renders the host list, so it says
+// nothing about this one — and bubbletea's renderer drops lines from the TOP
+// of an over-tall frame, so a single row of overflow silently walks the
+// banner off the screen. Both history states are swept: the run list, and the
+// empty-history prose, which WRAPS and is therefore the more likely to grow.
+//
+// ANSI256 is set deliberately: init() pins termenv.Ascii, under which every
+// style is a no-op and a frame carries no escape bytes at all — measuring a
+// layout under it proves nothing.
+func TestHistoryFrameNeverExceedsTheTerminal(t *testing.T) {
+	saved := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	t.Cleanup(func() { lipgloss.SetColorProfile(saved) })
+
+	full := histModelWith(t, 12)
+
+	empty, _ := send(testModel("alpha"), "H")
+	em, _ := empty.Update(historyLoadedMsg{runs: nil})
+	emptyM := em.(tuiModel)
+
+	for _, m := range []tuiModel{full, emptyM} {
+		for _, h := range []int{6, 8, 10, 14, 20, 30, 50} {
+			for _, w := range []int{40, 60, 80, 120, 200} {
+				for _, logOpen := range []bool{false, true} {
+					mm := m
+					mm.vp.height, mm.vp.width = h, w
+					mm.logOpen = logOpen
+					got := strings.Count(mm.View(), "\n") + 1
+					if got > h {
+						t.Fatalf("frame is %d lines in a %dx%d terminal (logOpen=%v); "+
+							"bubbletea drops from the TOP, so this eats the banner", got, w, h, logOpen)
+					}
+				}
+			}
+		}
 	}
 }

--- a/sdk/fleet/cmd/tui_keys.go
+++ b/sdk/fleet/cmd/tui_keys.go
@@ -334,10 +334,15 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// selection on the way would discard the scoping that chose these
 		// runs in the first place.
 		if m.histRunOpen() {
-			m.histPath, m.histLines = "", nil
+			m.closeHistoryRun()
 			return m, nil
 		}
 		if m.histOn {
+			// Toggling off must be as complete as esc: histRunOpen() keys off
+			// histPath alone, so leaving it set brought the dashboard back
+			// with the stored capture still filling the panes while a live
+			// update streamed into a buffer nobody could see.
+			m.closeHistoryRun()
 			m.histOn = false
 			return m, nil
 		}
@@ -383,7 +388,7 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Scrolling stops the tail from yanking the view away mid-read.
 		if m.logOpen {
 			m.logFollow = false
-			m.logTop = minInt(m.logTop+1, maxInt(0, len(m.logs)-1))
+			m.logTop = minInt(m.logTop+1, maxInt(0, len(m.logEntries())-1))
 		}
 	case "K":
 		if m.logOpen {
@@ -414,6 +419,11 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// history is a different VIEW of the same model, not a different
 		// place in it.
 		if m.histOn {
+			// Toggling off must be as complete as esc: histRunOpen() keys off
+			// histPath alone, so leaving it set brought the dashboard back
+			// with the stored capture still filling the panes while a live
+			// update streamed into a buffer nobody could see.
+			m.closeHistoryRun()
 			m.histOn = false
 			return m, nil
 		}

--- a/sdk/fleet/cmd/tui_keys.go
+++ b/sdk/fleet/cmd/tui_keys.go
@@ -352,8 +352,9 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		// Only meaningful on the run list: enter opens the run under the
 		// cursor into the stream panes.
-		if m.histOn && !m.histRunOpen() {
+		if m.histOn && !m.histRunOpen() && m.histPending == "" {
 			if r, ok := m.histAt(); ok {
+				m.histPending = r.Path
 				return m, openHistoryRun(r)
 			}
 		}

--- a/sdk/fleet/cmd/tui_keys.go
+++ b/sdk/fleet/cmd/tui_keys.go
@@ -39,7 +39,8 @@ var keyHelp = []struct {
 	{"◉", "a", "select all (respects an active search)", false},
 	{"📖", "J / K", "scroll the log pane (G re-follows the tail)", false},
 	{"◍", "v", "visual range select", false},
-	{"⎋", "esc", "clear search / selection", false},
+	{"\u23ce", "enter", "(history) open the run under the cursor", false},
+	{"⎋", "esc", "(history) close the run, then leave history \u00b7 else clear search / selection", false},
 	{"⏰", "w", "wake selection (or cursor host)", false},
 	{"📥", "p", "pull ssh config FROM cursor host", false},
 	{"📤", "P", "push ssh config TO cursor host", false},
@@ -327,9 +328,30 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.vAnchor = &c
 		}
 	case "esc":
+		// History unwinds ONE level at a time, before esc resumes its normal
+		// meaning. Dropping straight out would lose the operator's place in a
+		// run list they may have scrolled a long way down, and clearing the
+		// selection on the way would discard the scoping that chose these
+		// runs in the first place.
+		if m.histRunOpen() {
+			m.histPath, m.histLines = "", nil
+			return m, nil
+		}
+		if m.histOn {
+			m.histOn = false
+			return m, nil
+		}
 		m.vAnchor = nil
 		m.selected = map[string]bool{}
 		m.search = searchState{}
+	case "enter":
+		// Only meaningful on the run list: enter opens the run under the
+		// cursor into the stream panes.
+		if m.histOn && !m.histRunOpen() {
+			if r, ok := m.histAt(); ok {
+				return m, openHistoryRun(r)
+			}
+		}
 	case "u":
 		// The form is asked once per session, not once per wave: retyping a
 		// credential for every wave is what made a fleet-wide update apply

--- a/sdk/fleet/cmd/tui_keys.go
+++ b/sdk/fleet/cmd/tui_keys.go
@@ -28,6 +28,7 @@ var keyHelp = []struct {
 	{"🗂️", "h", "show / hide the host list", true},
 	{"⚠️", "e", "show / hide the stderr pane · (confirm) edit the remembered answers", true},
 	{"🖥️", "s", "ssh to cursor host", true},
+	{"\U0001f5c3\ufe0f", "H", "history: past runs for the selection (or cursor host)", true},
 	{"🔄", "r", "refresh", true},
 	{"🚪", "q", "quit", true},
 	{"⬍", "j / k / ↓ / ↑", "move cursor", false},
@@ -384,6 +385,22 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if t := m.updateTargets(); len(t) > 0 {
 			return m, m.startWake(t)
 		}
+	case "H":
+		// History is a toggle, and leaving restores the dashboard untouched:
+		// the alias cursor and the selection are never disturbed, because
+		// history is a different VIEW of the same model, not a different
+		// place in it.
+		if m.histOn {
+			m.histOn = false
+			return m, nil
+		}
+		m.histOn = true
+		// Snapshot the scope now, by the same selection-or-cursor rule the
+		// update and wake keys use. Re-reading it later would let moving the
+		// cursor inside the run list silently change which runs it lists.
+		m.histScope = m.updateTargets()
+		m.histRuns, m.histCursor = nil, ""
+		return m, loadHistory(m.logDir, m.histScope)
 	case "s":
 		// An ssh visit while the engine owns the host would race its update.
 		if m.cursor != "" && !m.inFlight(m.cursor) {

--- a/sdk/fleet/cmd/tui_keys.go
+++ b/sdk/fleet/cmd/tui_keys.go
@@ -287,7 +287,8 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "g":
 		pendingG = true
 	case "G":
-		m.moveTo(len(m.rows) - 1)
+		// listLen, not len(m.rows): in history G means the OLDEST run.
+		m.moveTo(m.listLen() - 1)
 	case "j", "down":
 		m.move(1)
 	case "k", "up":

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -328,6 +328,14 @@ func (m *tuiModel) clampViewport() {
 func (m tuiModel) visibleRows() int { return m.listHeight() }
 
 func (m *tuiModel) moveTo(i int) {
+	// History is a different VIEW of the same model, so the motion keys move
+	// whichever list is on screen. Branching here rather than in the keymap
+	// is what keeps j/k/gg/G/ctrl+d/ctrl+f working in both without a second
+	// routing table to drift out of sync.
+	if m.histOn {
+		m.histMoveTo(i)
+		return
+	}
 	if len(m.rows) == 0 {
 		return
 	}
@@ -342,6 +350,14 @@ func (m *tuiModel) moveTo(i int) {
 }
 
 func (m *tuiModel) move(d int) {
+	if m.histOn {
+		i := m.histIndexOf(m.histCursor)
+		if i < 0 {
+			i = 0
+		}
+		m.histMoveTo(i + d)
+		return
+	}
 	i := m.indexOf(m.cursor)
 	if i < 0 {
 		i = 0

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/drift"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/histindex"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/reach"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/runner"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/sshconf"
@@ -162,6 +163,26 @@ type tuiModel struct {
 	// hermeticity bug and a rude thing to do to someone's home directory.
 	// Empty (the test default) disables persistence entirely.
 	ansPath string
+
+	// ---- history -----------------------------------------------------------
+	// History is VIEW state, deliberately NOT a tuiMode. Modes exist to
+	// reroute keystrokes (a key typed in search is text, not a motion);
+	// history reroutes nothing -- every motion, the pane toggles and the
+	// search key mean exactly what they always did. Only what the panes READ
+	// changes, from a live stream to a stored capture. Making it a mode would
+	// have forced a second copy of the whole normal-mode routing table.
+	histOn bool
+	// histScope is the hosts the run list covers, snapshotted from
+	// updateTargets() when H was pressed -- the same selection-or-cursor rule
+	// the update and wake keys use. Snapshotted rather than re-read so that
+	// moving the cursor inside the run list cannot silently change which runs
+	// it lists.
+	histScope []string
+	histRuns  []histindex.Summary
+	// histCursor is keyed by the run's PATH for the same reason m.cursor is
+	// keyed by alias rather than an index: the list is re-sorted and
+	// re-loaded, and an index would point at a different row afterwards.
+	histCursor string
 
 	hosts map[string]sshconf.Host
 	// local is who THIS machine is, and localAlias is the fleet row that IS
@@ -1154,6 +1175,23 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.streams[msg.alias] = msg.st
 		return m, tea.Batch(readLine(msg.alias, msg.st), awaitDone(msg.alias, msg.st))
 
+	case historyLoadedMsg:
+		if msg.err != nil {
+			// A failed scan is SAID. An empty list that silently meant "I
+			// could not read the directory" is the same class of lie as
+			// calling an unobserved run clean.
+			m.status = fmt.Sprintf("history: %v", msg.err)
+			m.histOn = false
+			return m, nil
+		}
+		m.histRuns = msg.runs
+		m.histCursor = ""
+		if len(msg.runs) > 0 {
+			// Newest first: "what happened last" is the question someone
+			// opening history is nearly always asking.
+			m.histCursor = msg.runs[0].Path
+		}
+		return m, nil
 	case logLineMsg:
 		m.appendLogLine(msg.alias, msg.line, msg.stderr)
 		// Re-issue the reader: one Cmd per line is what turns the channel into

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -193,6 +193,15 @@ type tuiModel struct {
 	// histErrCount mirrors errCount for the opened capture: counted once at
 	// open, so the pane's height queries stay off a per-keystroke rebuild.
 	histErrCount int
+	// histTop is the run list's own scroll offset. m.vp is the HOST list's and
+	// clampViewport recomputes it from the host cursor, so slicing the runs by
+	// it rendered a header with nothing under it whenever the host cursor sat
+	// deeper than the run count.
+	histTop int
+	// liveFollow / liveErrFollow remember whether the stream panes were
+	// following before a capture was opened, so closing it restores them.
+	liveFollow    bool
+	liveErrFollow bool
 
 	hosts map[string]sshconf.Host
 	// local is who THIS machine is, and localAlias is the fleet row that IS
@@ -867,8 +876,27 @@ func (m tuiModel) errEntries() []logEntry {
 	return out
 }
 
-// warnTotals is the status bar's summary: lines, and how many hosts wrote them.
+// warnTotals is the status bar's summary: lines, and how many hosts wrote
+// them. Over an OPENED capture it reports that capture's own figures: m.warns
+// is written only by appendLogLine, so the live run's totals would otherwise
+// be printed as the header of a stored run's stderr — the same body/heading
+// mismatch errTotal already had to fix.
 func (m tuiModel) warnTotals() (lines, hosts int) {
+	if m.histRunOpen() {
+		seen := map[string]bool{}
+		for _, e := range m.histLines {
+			if e.warn {
+				lines++
+				seen[e.alias] = true
+			}
+		}
+		return lines, len(seen)
+	}
+	return m.liveWarnTotals()
+}
+
+// liveWarnTotals is the streaming path's summary.
+func (m tuiModel) liveWarnTotals() (lines, hosts int) {
 	for _, n := range m.warns {
 		if n > 0 {
 			lines += n
@@ -1227,15 +1255,22 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.histPath = msg.path
-		m.histLines = captureEntries(msg.host, msg.cap, m.now)
+		m.histLines = captureEntries(msg.host, msg.cap, msg.day)
 		m.histErrCount = len(msg.cap.Stderr())
 		// A freshly opened capture reads from its start, not its tail: unlike a
 		// live stream there is no "newest" to follow, and the beginning is where
-		// the run explains itself.
+		// the run explains itself. The live pane's own follow state is
+		// remembered so closing the run hands it back as it was, rather than
+		// frozen at line 1 of a buffer that is still growing.
+		m.liveFollow, m.liveErrFollow = m.logFollow, m.errFollow
 		m.logFollow, m.logTop = false, 0
 		m.errFollow, m.errTop = false, 0
 		return m, nil
 	case historyLoadedMsg:
+		// Drop an answer to a request the operator has already moved on from.
+		if !sameScope(msg.scope, m.histScope) {
+			return m, nil
+		}
 		if msg.err != nil {
 			// A failed scan is SAID. An empty list that silently meant "I
 			// could not read the directory" is the same class of lie as
@@ -1246,6 +1281,9 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.histRuns = msg.runs
 		m.histCursor = ""
+		// The run list has its OWN offset; the host viewport is meaningless
+		// here and clampViewport recomputes it from the host cursor.
+		m.histTop = 0
 		if len(msg.runs) > 0 {
 			// Newest first: "what happened last" is the question someone
 			// opening history is nearly always asking.

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -183,6 +183,13 @@ type tuiModel struct {
 	// keyed by alias rather than an index: the list is re-sorted and
 	// re-loaded, and an index would point at a different row afterwards.
 	histCursor string
+	// histPath is the capture currently OPEN (empty = the list level), and
+	// histLines is its parsed body rendered as stream entries. The live buffer
+	// in m.logs is deliberately left alone while this is set: an update that is
+	// still running keeps appending to it, so closing the run shows the present
+	// again with nothing lost.
+	histPath  string
+	histLines []logEntry
 
 	hosts map[string]sshconf.Host
 	// local is who THIS machine is, and localAlias is the fleet row that IS
@@ -842,10 +849,14 @@ func (m *tuiModel) appendLogLine(alias, line string, isErr bool) {
 	}
 }
 
-// errEntries is the error pane's projection: the stderr subset, in order.
+// errEntries is the error pane's projection: the stderr subset, in order, of
+// whichever source is on screen — the opened capture in history, the live
+// buffer otherwise. tailFor deliberately does NOT follow: a host row's FAIL
+// text is about the run that just failed, not about a capture the operator
+// happens to be reading.
 func (m tuiModel) errEntries() []logEntry {
 	out := make([]logEntry, 0, m.errCount)
-	for _, e := range m.logs {
+	for _, e := range m.logEntries() {
 		if e.stderr {
 			out = append(out, e)
 		}
@@ -887,7 +898,7 @@ func (m tuiModel) tailFor(alias string, n int) string {
 // costs the host list its rows once output exists: the pane is ON by default
 // so it is discoverable, but an empty box must not shrink the fleet view to a
 // fifth to display nothing.
-func (m tuiModel) logActive() bool { return m.logOpen && len(m.logs) > 0 }
+func (m tuiModel) logActive() bool { return m.logOpen && len(m.logEntries()) > 0 }
 
 // errActive is its stderr twin. It reads the COUNTER, not the projection —
 // this is consulted from every height query.
@@ -1068,7 +1079,7 @@ func (m *tuiModel) focusedStream() (streamNav, bool) {
 	switch {
 	case m.logFocused():
 		return streamNav{
-			entries: m.logs, follow: &m.logFollow, top: &m.logTop,
+			entries: m.logEntries(), follow: &m.logFollow, top: &m.logTop,
 			search: &m.logSearch, height: m.logHeight(), label: "log",
 		}, true
 	case m.errFocused():
@@ -1096,7 +1107,7 @@ func streamMatches(nav streamNav) []int {
 
 // logMatches are the log buffer's indexes matching its own pattern.
 func (m tuiModel) logMatches() []int {
-	return streamMatches(streamNav{entries: m.logs, search: &m.logSearch})
+	return streamMatches(streamNav{entries: m.logEntries(), search: &m.logSearch})
 }
 
 // streamJump moves the pane to the next/previous match, wrapping. It stops
@@ -1191,6 +1202,19 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.streams[msg.alias] = msg.st
 		return m, tea.Batch(readLine(msg.alias, msg.st), awaitDone(msg.alias, msg.st))
 
+	case historyOpenedMsg:
+		if msg.err != nil {
+			m.status = fmt.Sprintf("history: %v", msg.err)
+			return m, nil
+		}
+		m.histPath = msg.path
+		m.histLines = captureEntries(msg.host, msg.cap, m.now)
+		// A freshly opened capture reads from its start, not its tail: unlike a
+		// live stream there is no "newest" to follow, and the beginning is where
+		// the run explains itself.
+		m.logFollow, m.logTop = false, 0
+		m.errFollow, m.errTop = false, 0
+		return m, nil
 	case historyLoadedMsg:
 		if msg.err != nil {
 			// A failed scan is SAID. An empty list that silently meant "I

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -190,6 +190,9 @@ type tuiModel struct {
 	// again with nothing lost.
 	histPath  string
 	histLines []logEntry
+	// histErrCount mirrors errCount for the opened capture: counted once at
+	// open, so the pane's height queries stay off a per-keystroke rebuild.
+	histErrCount int
 
 	hosts map[string]sshconf.Host
 	// local is who THIS machine is, and localAlias is the fleet row that IS
@@ -902,7 +905,23 @@ func (m tuiModel) logActive() bool { return m.logOpen && len(m.logEntries()) > 0
 
 // errActive is its stderr twin. It reads the COUNTER, not the projection —
 // this is consulted from every height query.
-func (m tuiModel) errActive() bool { return m.errOpen && m.errCount > 0 }
+func (m tuiModel) errActive() bool { return m.errOpen && m.errTotal() > 0 }
+
+// errTotal is how many stderr lines the ACTIVE source has. errCount is
+// maintained incrementally as live lines arrive and is therefore zero for a
+// capture read from disk — reading it directly made the pane render
+// "stderr: none captured" directly underneath the captured stderr line it
+// was supposed to be showing. Found by the demo frames, not by a unit test.
+//
+// The counter still serves the live path, where it exists to keep every
+// height query off a 2000-entry filtered rebuild; the opened capture is
+// counted once, when it is opened.
+func (m tuiModel) errTotal() int {
+	if m.histRunOpen() {
+		return m.histErrCount
+	}
+	return m.errCount
+}
 
 // pane names the three stacked panels the operator composes.
 type pane int
@@ -1209,6 +1228,7 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.histPath = msg.path
 		m.histLines = captureEntries(msg.host, msg.cap, m.now)
+		m.histErrCount = len(msg.cap.Stderr())
 		// A freshly opened capture reads from its start, not its tail: unlike a
 		// live stream there is no "newest" to follow, and the beginning is where
 		// the run explains itself.

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -190,6 +190,13 @@ type tuiModel struct {
 	// again with nothing lost.
 	histPath  string
 	histLines []logEntry
+	// histPending is the run enter asked to open and whose read has not landed
+	// yet. The read is async, so its answer is accepted only while this still
+	// names it: leaving history clears it, and enter is ignored while it is
+	// set. Without that a late answer put a capture back on the dashboard, or
+	// a second enter's answer saved the already cleared follow state as the
+	// live one.
+	histPending string
 	// histErrCount mirrors errCount for the opened capture: counted once at
 	// open, so the pane's height queries stay off a per-keystroke rebuild.
 	histErrCount int
@@ -447,8 +454,19 @@ func (m tuiModel) matches(r Row) bool {
 	return m.search.re != nil && m.search.re.MatchString(m.rowText(r))
 }
 
+// matchIndexes indexes the ACTIVE list, because moveTo does: in history the
+// positions are run rows, and matching host rows there handed a host's
+// position to the run cursor.
 func (m tuiModel) matchIndexes() []int {
 	var out []int
+	if m.histOn {
+		for i, r := range m.histRuns {
+			if m.search.re != nil && m.search.re.MatchString(histRowText(r)) {
+				out = append(out, i)
+			}
+		}
+		return out
+	}
 	for i, r := range m.rows {
 		if m.matches(r) {
 			out = append(out, i)
@@ -465,6 +483,9 @@ func (m *tuiModel) jumpMatch(d int) {
 		return
 	}
 	cur := m.indexOf(m.cursor)
+	if m.histOn {
+		cur = m.histIndexOf(m.histCursor)
+	}
 	if d > 0 {
 		for _, i := range idx {
 			if i > cur {
@@ -848,6 +869,12 @@ func (m *tuiModel) appendLogLine(alias, line string, isErr bool) {
 			}
 		}
 		m.logs = m.logs[drop:]
+		// While a run is open the offsets index the CAPTURE, and the live
+		// buffer's own offsets are reset when the run closes — so a busy
+		// update must not scroll the stored run the operator is reading.
+		if m.histRunOpen() {
+			return
+		}
 		if m.logTop >= drop {
 			m.logTop -= drop
 		} else {
@@ -1250,6 +1277,11 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(readLine(msg.alias, msg.st), awaitDone(msg.alias, msg.st))
 
 	case historyOpenedMsg:
+		// Drop an answer the operator has already walked away from.
+		if !m.histOn || msg.path != m.histPending {
+			return m, nil
+		}
+		m.histPending = ""
 		if msg.err != nil {
 			m.status = fmt.Sprintf("history: %v", msg.err)
 			return m, nil

--- a/sdk/fleet/cmd/tui_view.go
+++ b/sdk/fleet/cmd/tui_view.go
@@ -172,7 +172,13 @@ func (m tuiModel) View() string {
 
 	body := head
 	if m.hostOpen {
-		body += m.listPanel() + "\n"
+		// The same pane, a different list. History is a view of the model,
+		// so `h` still hides it and the stream panes below are untouched.
+		if m.histOn {
+			body += m.histPanel() + "\n"
+		} else {
+			body += m.listPanel() + "\n"
+		}
 	}
 	tail := "\n" + m.statusView()
 
@@ -274,6 +280,87 @@ func (m tuiModel) listPanel() string {
 		list.WriteString(trunc(m.rowView(i), m.panelInner()) + "\n")
 	}
 	return m.renderPanel(th.panel, strings.TrimRight(list.String(), "\n"))
+}
+
+// histPanel renders the run list in place of the host table. It is the same
+// panel, drawn from a different list — history is a view of the model, not a
+// separate screen — so it inherits renderPanel's width clamping and the
+// frame-fitting in View() without restating either.
+//
+// The columns are what makes a run triageable WITHOUT opening it: when it
+// ran, whether it reached its footer, and how many non-benign warnings it
+// carries. That is why the list holds histindex.Summary rather than the
+// filename-only Run.
+func (m tuiModel) histPanel() string {
+	if len(m.histRuns) == 0 {
+		// An empty frame reads as a broken pane. Say why it is empty: on a
+		// machine that has never updated anything this is the normal state,
+		// not a failure.
+		return m.wrapPanel(th.panel, th.dim.Render(
+			"no captured runs for this selection — a `fleet update` writes one per host per run"))
+	}
+
+	// The HOST column earns its width only when the scope spans more than one
+	// host; scoped to one, every row would repeat the name the operator just
+	// chose and spend cells the rest of the row needs.
+	multi := len(m.histScope) > 1
+
+	var list strings.Builder
+	head := fmt.Sprintf("%-16s %-10s %-6s %s", "WHEN", "RESULT", "WARN", "SIZE")
+	if multi {
+		head = fmt.Sprintf("%-16s %-16s %-10s %-6s %s", "WHEN", "HOST", "RESULT", "WARN", "SIZE")
+	}
+	list.WriteString(strings.Repeat(" ", rowMarkPrefix) + th.header.Render(head) + "\n")
+
+	h := m.visibleRows()
+	end := m.vp.top + h
+	if end > len(m.histRuns) {
+		end = len(m.histRuns)
+	}
+	for i := m.vp.top; i < end; i++ {
+		list.WriteString(trunc(m.histRowView(i), m.panelInner()) + "\n")
+	}
+	return m.renderPanel(th.panel, strings.TrimRight(list.String(), "\n"))
+}
+
+// histRowView renders one run. RESULT says finished / unfinished and never
+// ok / failed: a capture records OUTPUT, not an exit code, and a column
+// claiming success on that evidence would be inventing a fact.
+func (m tuiModel) histRowView(i int) string {
+	r := m.histRuns[i]
+
+	cur := "    "
+	if r.Path == m.histCursor {
+		cur = th.cursor.Render(">   ")
+	}
+
+	result := "finished"
+	if !r.Finished {
+		result = "unfinished"
+	}
+	warn := "-"
+	if r.Warnings > 0 {
+		warn = fmt.Sprintf("!%d", r.Warnings)
+	}
+	when := r.At.In(time.Local).Format("2006-01-02 15:04")
+
+	if len(m.histScope) > 1 {
+		return cur + fmt.Sprintf("%-16s %-16s %-10s %-6s %s",
+			when, r.Host, result, warn, histSize(r.Size))
+	}
+	return cur + fmt.Sprintf("%-16s %-10s %-6s %s", when, result, warn, histSize(r.Size))
+}
+
+// histSize renders a byte count compactly.
+func histSize(n int64) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1fM", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1fK", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
 }
 
 // logView is the framed streaming pane. It sits BELOW the host list rather

--- a/sdk/fleet/cmd/tui_view.go
+++ b/sdk/fleet/cmd/tui_view.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/drift"
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/fleet/internal/histindex"
 )
 
 const spinnerInterval = 120 * time.Millisecond
@@ -313,10 +314,7 @@ func (m tuiModel) histPanel() string {
 	list.WriteString(strings.Repeat(" ", rowMarkPrefix) + th.header.Render(head) + "\n")
 
 	h := m.visibleRows()
-	top := m.histTop
-	if top > maxInt(0, len(m.histRuns)-1) {
-		top = maxInt(0, len(m.histRuns)-1)
-	}
+	top := m.histWindowTop(m.histIndexOf(m.histCursor))
 	end := top + h
 	if end > len(m.histRuns) {
 		end = len(m.histRuns)
@@ -338,21 +336,43 @@ func (m tuiModel) histRowView(i int) string {
 		cur = th.cursor.Render(">   ")
 	}
 
-	result := "finished"
-	if !r.Finished {
-		result = "unfinished"
-	}
-	warn := "-"
-	if r.Warnings > 0 {
-		warn = fmt.Sprintf("!%d", r.Warnings)
-	}
-	when := r.At.In(time.Local).Format("2006-01-02 15:04")
-
+	when, result, warn := histCells(r)
 	if len(m.histScope) > 1 {
 		return cur + fmt.Sprintf("%-16s %-16s %-10s %-6s %s",
 			when, r.Host, result, warn, histSize(r.Size))
 	}
 	return cur + fmt.Sprintf("%-16s %-10s %-6s %s", when, result, warn, histSize(r.Size))
+}
+
+// histCells is a run's WHEN, RESULT and WARN text — shared by the row and by
+// search, so `/unfinished` matches exactly what the operator reads.
+//
+// An unreadable capture says so in both columns. Its summary is empty, and
+// rendering that as "unfinished -" claimed a result and a warning count the
+// file never supplied.
+func histCells(r histindex.Summary) (when, result, warn string) {
+	when = r.At.In(time.Local).Format("2006-01-02 15:04")
+	switch {
+	case r.Unreadable:
+		return when, "unreadable", "?"
+	case r.Finished:
+		result = "finished"
+	default:
+		result = "unfinished"
+	}
+	warn = "-"
+	if r.Warnings > 0 {
+		warn = fmt.Sprintf("!%d", r.Warnings)
+	}
+	return when, result, warn
+}
+
+// histRowText is what a search pattern matches in the run list: the row's
+// cells, with the host always included so `/gamma` finds a host's runs even
+// when a single-host scope hides the HOST column.
+func histRowText(r histindex.Summary) string {
+	when, result, warn := histCells(r)
+	return strings.Join([]string{when, r.Host, result, warn}, " ")
 }
 
 // histSize renders a byte count compactly.

--- a/sdk/fleet/cmd/tui_view.go
+++ b/sdk/fleet/cmd/tui_view.go
@@ -432,7 +432,7 @@ func (m tuiModel) logViewN(h int) string {
 	}
 	mode := "following"
 	if !m.logFollow {
-		mode = fmt.Sprintf("scrolled %d/%d", m.logTop+1, len(m.logs))
+		mode = fmt.Sprintf("scrolled %d/%d", m.logTop+1, len(m.logEntries()))
 	}
 	keys := "tab: focus  l: hide"
 	if m.logFocused() {
@@ -453,8 +453,9 @@ func (m tuiModel) logViewN(h int) string {
 	}
 
 	start := m.logStart(h)
-	for i := start; i < len(m.logs) && i < start+h; i++ {
-		e := m.logs[i]
+	entries := m.logEntries()
+	for i := start; i < len(entries) && i < start+h; i++ {
+		e := entries[i]
 		// hh:mm:ss first, then the host, then the line. Short on purpose: the
 		// date is the session's, and seconds are what matter when reading how
 		// long a step took.
@@ -576,13 +577,13 @@ func streamStart(follow bool, top, n, h int) int {
 
 func (m tuiModel) logStart(h int) int {
 	if m.logFollow {
-		if s := len(m.logs) - h; s > 0 {
+		if s := len(m.logEntries()) - h; s > 0 {
 			return s
 		}
 		return 0
 	}
-	if m.logTop > len(m.logs)-1 {
-		return maxInt(0, len(m.logs)-1)
+	if m.logTop > len(m.logEntries())-1 {
+		return maxInt(0, len(m.logEntries())-1)
 	}
 	return m.logTop
 }

--- a/sdk/fleet/cmd/tui_view.go
+++ b/sdk/fleet/cmd/tui_view.go
@@ -313,11 +313,15 @@ func (m tuiModel) histPanel() string {
 	list.WriteString(strings.Repeat(" ", rowMarkPrefix) + th.header.Render(head) + "\n")
 
 	h := m.visibleRows()
-	end := m.vp.top + h
+	top := m.histTop
+	if top > maxInt(0, len(m.histRuns)-1) {
+		top = maxInt(0, len(m.histRuns)-1)
+	}
+	end := top + h
 	if end > len(m.histRuns) {
 		end = len(m.histRuns)
 	}
-	for i := m.vp.top; i < end; i++ {
+	for i := top; i < end; i++ {
 		list.WriteString(trunc(m.histRowView(i), m.panelInner()) + "\n")
 	}
 	return m.renderPanel(th.panel, strings.TrimRight(list.String(), "\n"))

--- a/sdk/fleet/internal/histindex/capture.go
+++ b/sdk/fleet/internal/histindex/capture.go
@@ -150,6 +150,10 @@ type Summary struct {
 	Warnings int
 	Finished bool
 	Lines    int
+	// Unreadable marks a row kept for a run whose file could not be read, so
+	// Warnings, Finished and Lines are unknown rather than zero. Summarize
+	// never sets it; a caller that keeps such a row does.
+	Unreadable bool `json:",omitempty"`
 }
 
 // Summarize reads one run's file for its result. Finished is whether the

--- a/sdk/fleet/pkg/provider/provider.go
+++ b/sdk/fleet/pkg/provider/provider.go
@@ -101,6 +101,7 @@ const TunnelKey = "t"
 //     `l` toggles the log pane and `s` opens an ssh session — the two a provider
 //     would most plausibly have tried to take.
 //   - This objective's own: t and T, the bridge keys.
+//   - History: H, which opens past runs for the selection in the dashboard.
 //
 // THIS IS A MIRROR, NOT THE SOURCE. The host tool's keymap is the source of
 // truth; this package is stdlib-only by contract and cannot import it. The
@@ -117,6 +118,8 @@ var ReservedKeys = map[rune]bool{
 	'p': true, 'P': true, 'A': true, 'F': true, 'e': true, 'J': true, 'K': true,
 	// this objective: the bridge keys
 	't': true, 'T': true,
+	// history: H opens the selection's past runs in the dashboard
+	'H': true,
 }
 
 // Provider is what fleet asks about a host. Probe answers "is your tool here,


### PR DESCRIPTION
## What

History navigation and log views **inside the fleet dashboard**. `fleet history`
(merged in #319) can read a capture back, but only from the shell — this puts it
where an operator is already standing when they wonder what happened last time.

```
H        open the past runs of the SELECTION (or the cursor host, like u and w)
j k gg G move the run cursor          /  search        h l e  toggle the panes
enter    open the run under the cursor into the log and stderr panes
esc      close the run, then leave history
```

```console
╭──────────────────────────────────────────────────────────────────────────╮
│     WHEN             HOST             RESULT     WARN   SIZE             │
│ >   2026-09-08 13:47 host-nano        finished   -      343B             │
│     2026-09-08 13:30 host-pi          finished   !1     244B             │
│     2026-09-07 03:15 host-nano        finished   -      207B             │
╰──────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────╮
│ logs   scrolled 1/2   tab: focus  l: hide                                │
│  12:00:00 host-pi       │ === step dotfiles.sync (sync) ===              │
│ !12:00:00 host-pi       │ fatal: could not read Username for 'https://…' │
╰──────────────────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────╮
│ errors — stderr   scrolled 1/1   tab: focus  e: hide                     │
│  12:00:00 host-pi       │ fatal: could not read Username for 'https://…' │
╰──────────────────────────────────────────────────────────────────────────╯
```

Those are real rendered frames, from the repo's own `FLEET_DEMO=1` harness
(frames 18 and 19), which also brings the new panel under the demo's width and
height guards.

## Why this shape

**History is VIEW state, not a `tuiMode`.** Modes exist to reroute keystrokes —
a key typed in search is text, not a motion. History reroutes nothing: every
motion, both pane toggles and `/` keep their meaning, and only what the panes
READ changes. The branch lives in two motion primitives (`move`/`moveTo`), in
`listLen`, and in one source accessor (`logEntries`). As a mode it would have
needed a second copy of the whole normal-mode routing table to drift out of sync.

**Scope follows the selection**, snapshotted from `updateTargets()` at press time
— the same rule `u` and `w` use — so moving the run cursor cannot silently change
which runs the list covers.

**Everything reads through `internal/histindex`**, so the dashboard and
`fleet history` cannot disagree about what a capture contains.

## What works

| | |
| :-- | :-- |
| `H` | opens the run list for the selection (or cursor host); toggles back |
| `j k gg G ctrl+d/u/f/b` | move the run cursor — no new bindings |
| `enter` | opens the run into the log pane, stderr into the error pane |
| `esc` | unwinds one level: run → history → its normal clear-search meaning |
| `h` `l` `e` `/` `J` `K` `tab` | unchanged, and work over the history panes |
| run list | `WHEN · [HOST] · RESULT · WARN · SIZE`; HOST only when scope > 1 host |
| empty / failed load | says so — never a bare frame or a silent empty list |

`RESULT` says `finished` / `unfinished`, never `ok` / `failed`: a capture records
output, not an exit code. A capture that cannot be read says `unreadable ?` rather
than inventing a result from an empty summary.

**Reading the past never costs the present.** Opening a capture leaves the live
buffer alone — a running update keeps appending the whole time, and closing the
run shows it again with nothing missing. `tailFor` deliberately does not follow
the switch: a host row's FAIL text is about the run that failed.

## Worth a reviewer's attention

- **A bug the demo caught that every unit test missed.** `errEntries()` returned
  the opened capture's stderr correctly, but the pane's *emptiness* check reads
  `errCount` — maintained incrementally for live lines, therefore zero for a
  capture read from disk. The pane rendered `stderr: none captured` directly
  underneath the captured stderr line it was showing. This is the argument for
  rendering real frames and looking at them.
- **`H` is reserved** in `provider.ReservedKeys`; the mechanical guard
  (`TestEveryFleetKeyIsReservedAgainstProviders`) caught the omission.
- **The run list has its own size sweep** — the existing 1219-size sweep renders
  the HOST list and says nothing about this panel, and bubbletea drops lines from
  the TOP of an over-tall frame.
- **Second review round (7 findings, all fixed in the last commit).** The two
  that mattered for someone watching an update: leaving history without opening a
  run stopped the live panes following (`closeHistoryRun` restored follow state
  that is only saved on open), and a busy update scrolled an opened capture
  (live-buffer eviction shifted offsets that index the capture). Also: the async
  open now carries a pending-request check (a late read after `esc`/`H`, or a
  double `enter`, no longer lands); `/` `n` `N` search the run list rather than
  handing a host-row index to the run cursor; the run window is recomputed from
  the current pane height so opening a run cannot scroll its row away; opened
  stamps render in local time like the WHEN column; unreadable captures say so.

## TODO — not in this PR

- [ ] **The problem digest in the TUI.** `--problems` exists on the CLI; the run
      list shows counts but there is no in-app digest view yet (likely `d`).
- [ ] **Filter the run list.** `/` `n` `N` now jump between matching runs (on
      the same cells the row shows, plus host), but the list is not narrowed to
      the matches.
- [ ] **Interactive runs still capture nothing** (~570 bytes). The row is honest
      but empty; closing that needs a pty proxy.
- [ ] **Live-refresh of the run list** — a run completing while history is open
      does not appear until `H` is toggled.
- [ ] **No `docs/mbo` objective** — no design/spec/plan artifacts or index row,
      so this is not in the objective tracker.

## Testing

TDD throughout; every test watched failing first, and the frame sweep was
explicitly checked for vacuity (it genuinely renders the history panel).

- Full `sdk/fleet` suite green; `go vet`, `gofmt`, and strict `make lint-go`
  (zero-backlog, all ten modules) clean.
- 18 history tests covering scope, toggle, motion, clamping, cursor
  independence, rendering, the empty and failed-load cases, drill-down,
  esc unwinding, live-stream preservation, and the stderr-pane bug.
- `TestHistoryFrameNeverExceedsTheTerminal` sweeps both history states across
  terminal sizes under ANSI256.
- Second review round: one failing test per finding, written first and watched
  red. Tests that injected an open message directly now open through `enter`
  (`openVia`), so the pending check is exercised, not bypassed. Suite also run
  under `TZ=UTC` and `-race`; `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014C8SFEQ9ukCThDPc9MH1FZ
https://claude.ai/code/session_01Q7w8pK62T382wWpN7ewaoQ

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **fleet-history-tui**.

- **#320 — edward-raigosa/tui-history (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->

