### PR TITLE
Read WORKER.md when publishing a worker: title from its description, Goal and Decisions as first-create prose; re-render the stack block once the PR number exists

### DIFF
--- a/sdk/gss/internal/feature/checkpoint.go
+++ b/sdk/gss/internal/feature/checkpoint.go
@@ -57,7 +57,14 @@ func (s *Service) Checkpoint(ctx context.Context, opts CheckpointOpts) (Checkpoi
 		return CheckpointResult{}, fmt.Errorf("%w: rebase onto origin/%s: %s", errors.ErrRebaseConflict, base, strings.TrimSpace(string(out)))
 	}
 
-	title := fmt.Sprintf("%s: %s", ref.Feature, ref.Purpose) // from worker_ref; WORKER.md is never read
+	// Title: the description recorded by `worker add --description` (the
+	// same line WORKER.md carries), so the PR reads like its commit subject
+	// rather than a "<feature>: <purpose>" label. The label remains the
+	// fallback for a worker added without one.
+	title := strings.TrimSpace(w.Description)
+	if title == "" {
+		title = fmt.Sprintf("%s: %s", ref.Feature, ref.Purpose)
+	}
 
 	// Adopt-existing-PR: a registry row may have no pr_url yet an open PR
 	// already exists on GitHub for this head branch (opened on another
@@ -75,7 +82,14 @@ func (s *Service) Checkpoint(ctx context.Context, opts CheckpointOpts) (Checkpoi
 
 	// Body is composed after adoption so an adopted PR's existing text is
 	// preserved rather than overwritten on the first checkpoint that finds it.
-	body := renderPRBody(feat, ref, s.currentPRBody(ctx, w.PRURL), s.featureNotes(feat.Name))
+	// A brand-new PR is seeded from WORKER.md (Goal + Decisions & notes)
+	// instead, so the author's notes reach reviewers without a second edit.
+	notes := s.featureNotes(feat.Name)
+	existing := s.currentPRBody(ctx, w.PRURL)
+	if w.PRURL == "" {
+		existing = s.workerProse(w)
+	}
+	body := renderPRBody(feat, ref, existing, notes)
 
 	res := CheckpointResult{Ref: ref.String()}
 	if w.PRURL == "" {
@@ -106,6 +120,20 @@ func (s *Service) Checkpoint(ctx context.Context, opts CheckpointOpts) (Checkpoi
 		res.Created = true
 		res.PRURL = pr.URL
 		res.PRState = "draft"
+		// The stack block was rendered before this PR had a number, so its
+		// own row read "(no PR yet)" until the next checkpoint. Re-render
+		// with the number and edit once. Best-effort: the commits are pushed
+		// and the PR exists, so a failed edit must not fail the checkpoint —
+		// the next one re-renders the block anyway.
+		numbered := feat
+		numbered.Workers = append([]registry.Worker(nil), feat.Workers...)
+		for i := range numbered.Workers {
+			nw := &numbered.Workers[i]
+			if nw.User == ref.User && nw.Purpose == ref.Purpose && nw.Suffix == ref.Suffix {
+				nw.PRURL = pr.URL
+			}
+		}
+		_ = s.GH.PREdit(ctx, pr.Number, gh.PREditOpts{Body: renderPRBody(numbered, ref, body, notes)})
 	} else {
 		if out, err := s.Git.Run(ctx, "-C", w.Worktree, "push", "--force-with-lease", "origin", w.Branch); err != nil {
 			return CheckpointResult{}, fmt.Errorf("checkpoint: force-push: %w: %s", err, strings.TrimSpace(string(out)))

--- a/sdk/gss/internal/feature/checkpoint_test.go
+++ b/sdk/gss/internal/feature/checkpoint_test.go
@@ -3,7 +3,10 @@ package feature_test
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -18,13 +21,20 @@ import (
 // checkpointService seeds one worker and wires git/gh fakes.
 func checkpointService(t *testing.T, prURL string, gitScript []gitfake.Response, ghc *ghfake.Client) (*feature.Service, *registry.Store, *gitfake.Runner) {
 	t.Helper()
+	return checkpointServiceAt(t, "/wt/api", prURL, gitScript, ghc)
+}
+
+// checkpointServiceAt is checkpointService with the worker's worktree at wt,
+// so a test can plant a WORKER.md at feature.WorkerMetaPath(wt).
+func checkpointServiceAt(t *testing.T, wt, prURL string, gitScript []gitfake.Response, ghc *ghfake.Client) (*feature.Service, *registry.Store, *gitfake.Runner) {
+	t.Helper()
 	store := registry.NewStore(filepath.Join(t.TempDir(), "registry.json"))
 	if err := store.Update(func(r *registry.Registry) error {
 		*r = registry.Registry{SchemaVersion: 1, Features: []registry.Feature{{
 			Name: "auth", DefaultBaseBranch: "main",
 			Workers: []registry.Worker{{
 				User: "erai", Purpose: "api", Branch: "feature/auth/erai/api",
-				Worktree: "/wt/api", BaseBranch: "main", Description: "endpoints", PRURL: prURL,
+				Worktree: wt, BaseBranch: "main", Description: "endpoints", PRURL: prURL,
 			}},
 		}}}
 		return nil
@@ -33,6 +43,113 @@ func checkpointService(t *testing.T, prURL string, gitScript []gitfake.Response,
 	}
 	gitr := &gitfake.Runner{Script: gitScript}
 	return &feature.Service{Store: store, Git: gitr, GH: ghc}, store, gitr
+}
+
+// plantWorkerMD writes a WORKER.md for the worker whose worktree is wt.
+func plantWorkerMD(t *testing.T, wt, md string) {
+	t.Helper()
+	p := feature.WorkerMetaPath(wt)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const seededWorkerMD = "# auth: api\n\n- **Description**: endpoints\n\n## Goal\nShip the endpoints.\n\n## Decisions & notes\n<!-- append freely -->\n- chose REST\n\n## Open questions\n"
+
+// TestCheckpoint_FirstCreateSeedsTitleAndBodyFromWorkerMD: the draft PR
+// opens with the worker description as its title and WORKER.md's Goal +
+// notes as its body, and the stack block is re-rendered with the new PR
+// number instead of "(no PR yet)" for the PR's own row. Before this, a
+// first checkpoint produced "<feature>: <purpose>" over a one-line body and
+// an unnumbered self-row, which every author then fixed by hand with gh.
+func TestCheckpoint_FirstCreateSeedsTitleAndBodyFromWorkerMD(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "auth", "erai", "api")
+	plantWorkerMD(t, wt, seededWorkerMD)
+	ghc := ghfake.NewClient()
+	svc, _, _ := checkpointServiceAt(t, wt, "", []gitfake.Response{{}, {}, {}}, ghc)
+
+	res, err := svc.Checkpoint(context.Background(), feature.CheckpointOpts{WorkerRef: "auth/erai/api"})
+	if err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	c := lastPRCreate(ghc)
+	if c == nil {
+		t.Fatal("PRCreate was never called")
+	}
+	if c.CreateOpts.Title != "endpoints" {
+		t.Errorf("title = %q; want the worker description", c.CreateOpts.Title)
+	}
+	for _, want := range []string{"Ship the endpoints.", "## Decisions & notes", "- chose REST", "<!-- gss:stack-begin -->"} {
+		if !strings.Contains(c.CreateOpts.Body, want) {
+			t.Errorf("created body missing %q:\n%s", want, c.CreateOpts.Body)
+		}
+	}
+	if strings.Contains(c.CreateOpts.Body, "append freely") {
+		t.Errorf("template comment leaked into the PR body:\n%s", c.CreateOpts.Body)
+	}
+	// One follow-up edit numbers the PR's own stack row.
+	e := lastPREdit(ghc)
+	num := prNumberOf(res.PRURL)
+	if e == nil || e.Num != num {
+		t.Fatalf("expected a PREdit on the new PR #%d after create; got %+v", num, e)
+	}
+	if !strings.Contains(e.EditOpts.Body, fmt.Sprintf("**#%d — erai/api (base: `main`)** ← you are here", num)) {
+		t.Errorf("stack row not renumbered after create:\n%s", e.EditOpts.Body)
+	}
+	if strings.Contains(e.EditOpts.Body, "(no PR yet)") {
+		t.Errorf("edited body still says (no PR yet):\n%s", e.EditOpts.Body)
+	}
+	if !strings.Contains(e.EditOpts.Body, "Ship the endpoints.") || strings.Count(e.EditOpts.Body, "<!-- gss:stack-begin -->") != 1 {
+		t.Errorf("renumbering must keep the prose and exactly one stack block:\n%s", e.EditOpts.Body)
+	}
+}
+
+// TestCheckpoint_FirstCreateWithoutWorkerMDFallsBack: no WORKER.md and no
+// description → the old "<feature>: <purpose>" title and description body.
+func TestCheckpoint_FirstCreateWithoutWorkerMDFallsBack(t *testing.T) {
+	ghc := ghfake.NewClient()
+	svc, store, _ := checkpointService(t, "", []gitfake.Response{{}, {}, {}}, ghc)
+	if err := store.Update(func(r *registry.Registry) error {
+		r.Features[0].Workers[0].Description = ""
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Checkpoint(context.Background(), feature.CheckpointOpts{WorkerRef: "auth/erai/api"}); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	c := lastPRCreate(ghc)
+	if c == nil || c.CreateOpts.Title != "auth: api" {
+		t.Errorf("PRCreate = %+v; want fallback title \"auth: api\"", c)
+	}
+}
+
+// TestCheckpoint_ExistingPRKeepsItsBodyOverWorkerMD: WORKER.md seeds only
+// the first body. A later checkpoint must preserve what is on GitHub.
+func TestCheckpoint_ExistingPRKeepsItsBodyOverWorkerMD(t *testing.T) {
+	wt := filepath.Join(t.TempDir(), "auth", "erai", "api")
+	plantWorkerMD(t, wt, seededWorkerMD)
+	ghc := ghfake.NewClient()
+	ghc.SeedPR(gh.PR{Number: 7, Head: "feature/auth/erai/api", State: "OPEN", IsDraft: true,
+		URL: "https://github.com/o/r/pull/7", Body: "human prose written on GitHub"})
+	svc, _, _ := checkpointServiceAt(t, wt, "https://github.com/o/r/pull/7", []gitfake.Response{{}, {}, {}}, ghc)
+
+	if _, err := svc.Checkpoint(context.Background(), feature.CheckpointOpts{WorkerRef: "auth/erai/api"}); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	e := lastPREdit(ghc)
+	if e == nil || e.Num != 7 {
+		t.Fatalf("expected PREdit on #7; got %+v", e)
+	}
+	if !strings.Contains(e.EditOpts.Body, "human prose written on GitHub") {
+		t.Errorf("existing PR body was not preserved:\n%s", e.EditOpts.Body)
+	}
+	if strings.Contains(e.EditOpts.Body, "Ship the endpoints.") {
+		t.Errorf("WORKER.md prose overwrote an existing PR body:\n%s", e.EditOpts.Body)
+	}
 }
 
 func TestCheckpoint_FirstTimeCreatesDraftPR(t *testing.T) {
@@ -269,6 +386,22 @@ func argsHasFC(args []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func lastPREdit(c *ghfake.Client) *ghfake.Call {
+	calls := c.Calls()
+	for i := len(calls) - 1; i >= 0; i-- {
+		if calls[i].Verb == ghfake.VerbPREdit {
+			return &calls[i]
+		}
+	}
+	return nil
+}
+
+// prNumberOf mirrors the package's unexported prNumber for assertions.
+func prNumberOf(url string) int {
+	n, _ := strconv.Atoi(url[strings.LastIndex(url, "/")+1:])
+	return n
 }
 
 func lastPRCreate(c *ghfake.Client) *ghfake.Call {

--- a/sdk/gss/internal/feature/notes.go
+++ b/sdk/gss/internal/feature/notes.go
@@ -44,10 +44,17 @@ func (s *Service) featureNotes(featureName string) string {
 // content. Exported behaviour lives on featureNotes; this is split out so the
 // parsing is testable without touching the filesystem.
 func extractNotes(md string) string {
+	return extractSection(md, notesHeadingRe)
+}
+
+// extractSection returns the body of the first section whose heading matches
+// heading, up to the next heading of any level, HTML comments stripped and
+// whitespace trimmed. "" when the section is absent or empty.
+func extractSection(md string, heading *regexp.Regexp) string {
 	lines := strings.Split(md, "\n")
 	start := -1
 	for i, ln := range lines {
-		if notesHeadingRe.MatchString(strings.TrimSpace(ln)) {
+		if heading.MatchString(strings.TrimSpace(ln)) {
 			start = i + 1
 			break
 		}

--- a/sdk/gss/internal/feature/workermeta.go
+++ b/sdk/gss/internal/feature/workermeta.go
@@ -1,0 +1,50 @@
+package feature
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/sfc-gh-eraigosa/dotfiles/sdk/gss/internal/registry"
+)
+
+// goalHeadingRe matches WORKER.md's "## Goal" heading at any ATX level.
+var goalHeadingRe = regexp.MustCompile(`(?i)^#{1,6}\s+goal\s*$`)
+
+// workerProse returns the free-form text a NEW PR body is seeded with: the
+// worker's WORKER.md "Goal" and "Decisions & notes" sections, template
+// comments stripped. "" when the file or both sections are absent, in which
+// case renderPRBody falls back to the one-line registry description.
+//
+// Read on create only. Once the PR exists its body belongs to whoever edits
+// it on GitHub, so later WORKER.md edits are never pushed over it — the same
+// rule that keeps feature notes marker-scoped. The WORKER.md template used to
+// promise its notes were "rendered verbatim into PR body" while nothing read
+// the file; this is the reader that makes the (narrowed) promise true.
+//
+// Errors are swallowed: prose is decoration, and an unreadable WORKER.md must
+// never fail a checkpoint.
+func (s *Service) workerProse(w registry.Worker) string {
+	if w.Worktree == "" {
+		return ""
+	}
+	raw, err := os.ReadFile(WorkerMetaPath(w.Worktree))
+	if err != nil {
+		return ""
+	}
+	return extractWorkerProse(string(raw))
+}
+
+// extractWorkerProse composes the PR prose from WORKER.md content: the Goal
+// body first (it reads as the PR summary), then the notes under their own
+// heading. Split out so the parsing is testable without the filesystem.
+func extractWorkerProse(md string) string {
+	var parts []string
+	if goal := extractSection(md, goalHeadingRe); goal != "" {
+		parts = append(parts, goal)
+	}
+	if notes := extractNotes(md); notes != "" {
+		parts = append(parts, "## Decisions & notes\n\n"+notes)
+	}
+	return strings.Join(parts, "\n\n")
+}

--- a/sdk/gss/internal/feature/workermeta_test.go
+++ b/sdk/gss/internal/feature/workermeta_test.go
@@ -1,0 +1,56 @@
+package feature
+
+import (
+	"strings"
+	"testing"
+)
+
+const workerMD = `# auth: api
+
+- **Description**: endpoints
+- **Branch**: feature/auth/erai/api
+
+## Goal
+Ship the endpoints.
+
+## Decisions & notes
+<!-- append freely; seeds the PR body -->
+- chose REST over gRPC
+
+## Open questions
+- none
+`
+
+func TestExtractWorkerProse_GoalThenNotes(t *testing.T) {
+	got := extractWorkerProse(workerMD)
+	want := "Ship the endpoints.\n\n## Decisions & notes\n\n- chose REST over gRPC"
+	if got != want {
+		t.Errorf("extractWorkerProse =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestExtractWorkerProse_TemplateInstructionsAreNotPublished(t *testing.T) {
+	got := extractWorkerProse(workerMD)
+	if strings.Contains(got, "append freely") || strings.Contains(got, "<!--") {
+		t.Errorf("template comment leaked into PR prose: %q", got)
+	}
+	if strings.Contains(got, "Open questions") || strings.Contains(got, "Description") {
+		t.Errorf("sections other than Goal/notes leaked: %q", got)
+	}
+}
+
+func TestExtractWorkerProse_UntouchedTemplateIsEmpty(t *testing.T) {
+	// A worker added and checkpointed without editing WORKER.md: both
+	// sections hold only the template's comments → "" → description fallback.
+	md := "# f: p\n\n## Goal\n<!-- describe this worker's goal -->\n\n## Decisions & notes\n<!-- append freely -->\n\n## Open questions\n"
+	if got := extractWorkerProse(md); got != "" {
+		t.Errorf("extractWorkerProse(template) = %q; want \"\"", got)
+	}
+}
+
+func TestExtractWorkerProse_NotesOnly(t *testing.T) {
+	md := "## Goal\n\n## Decisions & notes\n- a\n- b\n"
+	if got := extractWorkerProse(md); got != "## Decisions & notes\n\n- a\n- b" {
+		t.Errorf("notes-only = %q", got)
+	}
+}

--- a/sdk/gss/internal/tmpl/worker.md.tmpl
+++ b/sdk/gss/internal/tmpl/worker.md.tmpl
@@ -9,6 +9,6 @@
 {{if .Goal}}{{.Goal}}{{else}}<!-- describe this worker's goal -->{{end}}
 
 ## Decisions & notes
-<!-- append freely; rendered verbatim into PR body -->
+<!-- append freely; with Goal above, this seeds the PR body the first time gss opens the PR. After that the PR body is edited on GitHub, not here. FEATURE.md's notes are mirrored into every checkpoint. -->
 
 ## Open questions

--- a/sdk/gss/skill/SKILL.md
+++ b/sdk/gss/skill/SKILL.md
@@ -182,6 +182,14 @@ classic `--force-autonomous` inside a worker worktree.
 - Give every feature and worker a short, specific `--description`; it seeds
   FEATURE.md / WORKER.md and the PR body (NFC-normalised; control chars and
   injection markers stripped).
+- **What the first checkpoint publishes**: the draft PR's **title is the worker's
+  `--description`** (fallback `<feature>: <purpose>`), and its **body is seeded
+  from `WORKER.md`** — the `## Goal` text, then `## Decisions & notes` — with
+  the stack section appended and this PR's own row already numbered. So fill
+  Goal and notes in `WORKER.md` *before* the first checkpoint and there is
+  nothing to `gh pr edit` afterwards. Later checkpoints preserve whatever the
+  PR body says on GitHub (edit it there, not in `WORKER.md`); only
+  `FEATURE.md`'s notes and the stack block are re-mirrored each time.
 - **`WORKER.md` placement (issue #132)**: `WORKER.md` is seeded **outside** the
   worker's git worktree, at
   `<worktrees-root>/<owner>/<repo>/<feature>/<user>/.gss-meta/<leaf>/WORKER.md`,


### PR DESCRIPTION
A first checkpoint should produce a reviewable draft PR with no manual `gh pr edit`: title from the worker description, body from WORKER.md, stack row numbered.

## Decisions & notes

- `checkpoint.go` titled every PR `<feature>: <purpose>` and, by its own comment, never read WORKER.md — while the WORKER.md template promised its notes were "rendered verbatim into PR body". Authors fixed every first PR by hand (title + body) with `gh pr edit`.
- The stack block was rendered before `gh pr create`, so the PR's own row said "(no PR yet)" until the next checkpoint.
- Now: title = `strings.TrimSpace(w.Description)` with the old label as fallback; on **create only**, `WORKER.md` Goal + "Decisions & notes" (comments stripped) seed the body; after create, one `PREdit` re-renders the stack block with the new number (best-effort — a failed edit never fails a checkpoint whose commits are pushed).
- Existing PRs keep their GitHub body; WORKER.md is not re-pushed over it. The template comment now says exactly that.
- `extractNotes` generalised to `extractSection(md, heading)`; new `workermeta.go`. Tests: 4 prose cases + 3 checkpoint cases (seeded title/body/renumber, fallback, existing-body preserved); `golangci-lint` 0 issues. `cmd/TestIsDirty` fails on this host on unmodified main too (git identity in a temp repo) — unrelated.
- This PR was opened by the fixed binary itself (built from this worktree), so its title/body are the proof.

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **gss-checkpoint-body**.

- **#322 — edward-raigosa/fix (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiL2GBppSQZpf45mMwoW6Y
