### PR TITLE
fix(fleet): r hands the TUI status dots back to the selection; select/deselect clears a finished dot

### DIFF
--- a/sdk/fleet/README.md
+++ b/sdk/fleet/README.md
@@ -219,9 +219,11 @@ headless `fleet update` can be read the same way afterwards.
 The status dot left of each hostname is **navy** when selected, and flips
 **green** or **red** to report an update's outcome — so a finished wave reads at
 a glance. The outcome stays on the dot until you press `r`, which puts every dot
-back to showing the selection (the UPDATE column keeps its `ok` / `FAIL: …`), or
-until you deselect that host — leaving the selection always clears its dot. A
-later update's outcome shows on the dot again. Each area (host list, log pane, help, answer form) is its own framed
+back to showing the selection (the UPDATE column keeps its `ok` / `FAIL: …`, and
+the run stays in `H` history), or until you select or deselect that host —
+changing a finished host's selection always clears its outcome from the dot.
+Deselecting a host mid-update leaves its update alone: the UPDATE column keeps
+ticking and the outcome still lands on the dot. Each area (host list, log pane, help, answer form) is its own framed
 panel.
 
 Rows are colored by status (green up-to-date · yellow behind · magenta

--- a/sdk/fleet/README.md
+++ b/sdk/fleet/README.md
@@ -192,7 +192,7 @@ fleet tui --update-ref feature/x         # update targets that ref instead of ma
 | `J` / `K` | scroll the log pane |
 | `gg` / `G` | (a stream pane focused) first line / resume following the tail |
 | `/` `n` `N` | (a stream pane focused) search that pane, next / previous match |
-| `r` | refresh |
+| `r` | refresh — and after an update, hand the status dots back to the selection |
 | `?` | help overlay |
 | `q` | quit (guarded while updates run) |
 
@@ -218,7 +218,10 @@ headless `fleet update` can be read the same way afterwards.
 
 The status dot left of each hostname is **navy** when selected, and flips
 **green** or **red** to report an update's outcome — so a finished wave reads at
-a glance. Each area (host list, log pane, help, answer form) is its own framed
+a glance. The outcome stays on the dot until you press `r`, which puts every dot
+back to showing the selection (the UPDATE column keeps its `ok` / `FAIL: …`), or
+until you deselect that host — leaving the selection always clears its dot. A
+later update's outcome shows on the dot again. Each area (host list, log pane, help, answer form) is its own framed
 panel.
 
 Rows are colored by status (green up-to-date · yellow behind · magenta

--- a/sdk/fleet/cmd/tui_keys.go
+++ b/sdk/fleet/cmd/tui_keys.go
@@ -317,7 +317,7 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.vAnchor = nil
 		} else if m.cursor != "" {
 			if m.selected[m.cursor] {
-				delete(m.selected, m.cursor)
+				m.deselect(m.cursor)
 			} else {
 				m.selected[m.cursor] = true
 			}
@@ -347,6 +347,9 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.vAnchor = nil
+		for alias := range m.selected {
+			m.clearDot(alias) // leaving the selection clears the dot (see deselect)
+		}
 		m.selected = map[string]bool{}
 		m.search = searchState{}
 	case "enter":
@@ -469,6 +472,9 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, authorizeShell(m.cursor)
 		}
 	case "r":
+		// r is also the way back from a finished wave: the dots stop showing
+		// outcomes and show the selection again.
+		m.showSelection()
 		return m, m.refresh()
 	case "?":
 		m.mode = modeHelp

--- a/sdk/fleet/cmd/tui_keys.go
+++ b/sdk/fleet/cmd/tui_keys.go
@@ -312,14 +312,14 @@ func routeNormal(m tuiModel, k tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case " ":
 		if a, b, ok := m.visualRange(); ok {
 			for i := a; i <= b; i++ {
-				m.selected[m.rows[i].Alias] = true
+				m.selectHost(m.rows[i].Alias)
 			}
 			m.vAnchor = nil
 		} else if m.cursor != "" {
 			if m.selected[m.cursor] {
 				m.deselect(m.cursor)
 			} else {
-				m.selected[m.cursor] = true
+				m.selectHost(m.cursor)
 			}
 		}
 	case "v":

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -606,7 +606,12 @@ func (m *tuiModel) clearDot(alias string) {
 // a green/red dot is a terminal state (the run itself stays in history), and
 // while it showed, the dot could not say whether the host was chosen. A host
 // still updating has no outcome yet, so its result shows when it lands.
+// Re-selecting a host that is already chosen (a completing `a`, a visual
+// range over it) changes nothing, so its outcome dot stays.
 func (m *tuiModel) selectHost(alias string) {
+	if m.selected[alias] {
+		return
+	}
 	m.selected[alias] = true
 	m.clearDot(alias)
 }

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -582,7 +582,7 @@ func (m *tuiModel) selectAllFiltered() {
 		if all {
 			m.deselect(r.Alias)
 		} else {
-			m.selected[r.Alias] = true
+			m.selectHost(r.Alias)
 		}
 	}
 	if all {
@@ -601,9 +601,16 @@ func (m *tuiModel) clearDot(alias string) {
 	m.dotCleared[alias] = true
 }
 
-// deselect takes alias out of the selection. Leaving the selection always
-// clears the host's dot, whatever it was showing: a deselected host that kept
-// its green dot looked exactly like one that was still chosen.
+// selectHost and deselect are the only ways a host joins or leaves the
+// selection, and either one clears the host's finished outcome from its dot:
+// a green/red dot is a terminal state (the run itself stays in history), and
+// while it showed, the dot could not say whether the host was chosen. A host
+// still updating has no outcome yet, so its result shows when it lands.
+func (m *tuiModel) selectHost(alias string) {
+	m.selected[alias] = true
+	m.clearDot(alias)
+}
+
 func (m *tuiModel) deselect(alias string) {
 	delete(m.selected, alias)
 	m.clearDot(alias)

--- a/sdk/fleet/cmd/tui_model.go
+++ b/sdk/fleet/cmd/tui_model.go
@@ -109,12 +109,19 @@ type tuiModel struct {
 
 	// update engine (background-first)
 	updating map[string]updState
-	bgQueue  []string
-	iaQueue  []string
-	iaTotal  int               // interactive-queue size this wave, for the handoff banner
-	streams  map[string]stream // in-flight output channels, by alias
-	logs     []logEntry        // interleaved, capped ring of streamed lines
-	logOpen  bool              // `l` toggles the pane; off restores a full-height list
+	// dotCleared marks hosts whose FINISHED outcome no longer paints the
+	// status dot: `r` clears every one, and leaving the selection clears that
+	// host's. Without it an outcome outranked the selection for the rest of the
+	// session and space toggled an invisible selection. The UPDATE column keeps
+	// the outcome text; the next finishUpdate for the host shows its dot again.
+	dotCleared map[string]bool
+
+	bgQueue []string
+	iaQueue []string
+	iaTotal int               // interactive-queue size this wave, for the handoff banner
+	streams map[string]stream // in-flight output channels, by alias
+	logs    []logEntry        // interleaved, capped ring of streamed lines
+	logOpen bool              // `l` toggles the pane; off restores a full-height list
 	// hostOpen and errOpen complete the pane set: the host table, the log, and
 	// the stderr stream. Session-only, never persisted — the defaults ARE the
 	// contract, and a preference file would be a second source of truth for
@@ -573,7 +580,7 @@ func (m *tuiModel) selectAllFiltered() {
 	}
 	for _, r := range rows {
 		if all {
-			delete(m.selected, r.Alias)
+			m.deselect(r.Alias)
 		} else {
 			m.selected[r.Alias] = true
 		}
@@ -582,6 +589,34 @@ func (m *tuiModel) selectAllFiltered() {
 		m.status = "selection cleared"
 	} else {
 		m.status = fmt.Sprintf("%d host(s) selected", len(m.selected))
+	}
+}
+
+// clearDot stops a finished outcome from painting alias's status dot, so the
+// dot reads as selection again.
+func (m *tuiModel) clearDot(alias string) {
+	if m.dotCleared == nil {
+		m.dotCleared = map[string]bool{}
+	}
+	m.dotCleared[alias] = true
+}
+
+// deselect takes alias out of the selection. Leaving the selection always
+// clears the host's dot, whatever it was showing: a deselected host that kept
+// its green dot looked exactly like one that was still chosen.
+func (m *tuiModel) deselect(alias string) {
+	delete(m.selected, alias)
+	m.clearDot(alias)
+}
+
+// showSelection is `r`'s state transition: every finished outcome gives its
+// dot back to the selection. Hosts still queued or updating have no outcome
+// yet, so their result will show when it lands.
+func (m *tuiModel) showSelection() {
+	for alias, st := range m.updating {
+		if st.phase == updOK || st.phase == updFail {
+			m.clearDot(alias)
+		}
 	}
 }
 
@@ -703,6 +738,7 @@ func (m *tuiModel) finishUpdate(alias, log string, err error) tea.Cmd {
 		st = updState{phase: updFail, log: strings.TrimSpace(log + " " + err.Error())}
 	}
 	m.updating[alias] = st
+	delete(m.dotCleared, alias) // a new outcome is news: the dot shows it again
 	cmds := []tea.Cmd{pollHost(m.hosts[alias], m.run, m.base)}
 	if c := m.pump(); c != nil {
 		cmds = append(cmds, c)

--- a/sdk/fleet/cmd/tui_reselect_test.go
+++ b/sdk/fleet/cmd/tui_reselect_test.go
@@ -108,6 +108,12 @@ func TestSelectingAFinishedHostShowsTheSelection(t *testing.T) {
 	if got := markOf(m, "c"); got != markSel {
 		t.Fatalf("select-all must clear c's outcome dot, got %v", got)
 	}
+	// ...but a and b were already selected: their selection did not change, so
+	// completing it must not wipe their green/red outcome.
+	if markOf(m, "a") != markOK || markOf(m, "b") != markFail {
+		t.Fatalf("completing a selection must keep already-selected outcome dots: a=%v b=%v",
+			markOf(m, "a"), markOf(m, "b"))
+	}
 }
 
 // Selecting a host mid-update changes nothing about its coming outcome.

--- a/sdk/fleet/cmd/tui_reselect_test.go
+++ b/sdk/fleet/cmd/tui_reselect_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Owner-reported: after an update finished, the dots stayed green/red for the
+// rest of the session. The outcome outranked the selection forever, so
+// toggling a host with space changed m.selected but nothing on screen — the
+// selection had become invisible. The dot keeps its outcome after a wave, but
+// `r` hands every finished host's dot back to the selection, and taking a
+// host out of the selection always clears its outcome dot.
+
+func markOf(m tuiModel, alias string) markKind { return m.markState(m.indexOf(alias)) }
+
+// finished runs a/b/c through a wave: a and b selected and updated (a ok,
+// b failed), c updated from the cursor with nothing selected (ok).
+func finished(t *testing.T) tuiModel {
+	t.Helper()
+	m := testModel("a", "b", "c")
+	m.selected["a"], m.selected["b"] = true, true
+	m.finishUpdate("a", "", nil)
+	m.finishUpdate("b", "", errors.New("boom"))
+	m.finishUpdate("c", "", nil)
+	if markOf(m, "a") != markOK || markOf(m, "b") != markFail || markOf(m, "c") != markOK {
+		t.Fatalf("a finished wave shows its outcome on the dot: a=%v b=%v c=%v",
+			markOf(m, "a"), markOf(m, "b"), markOf(m, "c"))
+	}
+	return m
+}
+
+func TestDeselectClearsTheOutcomeDot(t *testing.T) {
+	m := finished(t)
+	m.cursor = "a"
+	m, _ = send(m, " ") // deselect a
+	if got := markOf(m, "a"); got != markNone {
+		t.Fatalf("deselecting a finished host must clear its dot, got %v", got)
+	}
+	if !strings.Contains(m.updateCell("a"), "ok") {
+		t.Fatalf("the UPDATE column keeps the outcome text, got %q", m.updateCell("a"))
+	}
+	m, _ = send(m, " ") // select it again
+	if got := markOf(m, "a"); got != markSel {
+		t.Fatalf("once cleared, selecting shows the selection dot, got %v", got)
+	}
+
+	m.cursor = "b"
+	m, _ = send(m, " ") // deselect the FAILED host too — "regardless of what's showing"
+	if got := markOf(m, "b"); got != markNone {
+		t.Fatalf("deselecting a failed host must clear its dot, got %v", got)
+	}
+	if !strings.Contains(m.updateCell("b"), "FAIL") {
+		t.Fatalf("the failure cause stays in the UPDATE column, got %q", m.updateCell("b"))
+	}
+}
+
+func TestRefreshHandsTheDotsBackToTheSelection(t *testing.T) {
+	m := finished(t)
+	m, _ = send(m, "r")
+	if markOf(m, "a") != markSel || markOf(m, "b") != markSel {
+		t.Fatalf("after r the selected hosts show the selection dot: a=%v b=%v", markOf(m, "a"), markOf(m, "b"))
+	}
+	if got := markOf(m, "c"); got != markNone {
+		t.Fatalf("after r an unselected host shows no dot, got %v", got)
+	}
+	if !strings.Contains(m.updateCell("b"), "FAIL") {
+		t.Fatalf("r keeps the UPDATE column's outcome, got %q", m.updateCell("b"))
+	}
+
+	// From here selection and deselection are visible again.
+	m.cursor = "c"
+	m, _ = send(m, " ")
+	if got := markOf(m, "c"); got != markSel {
+		t.Fatalf("selecting after r shows the selection dot, got %v", got)
+	}
+	m, _ = send(m, " ")
+	if got := markOf(m, "c"); got != markNone {
+		t.Fatalf("deselecting after r clears the dot, got %v", got)
+	}
+}
+
+// r is an acknowledgment of what has finished — not of what is still running.
+func TestRefreshLeavesInFlightAndLaterOutcomesAlone(t *testing.T) {
+	m := finished(t)
+	m.updating["a"] = updState{phase: updRunning} // a second wave is running on a
+	m, _ = send(m, "r")
+	if got := m.updating["a"].phase; got != updRunning {
+		t.Fatalf("r must not touch a host the engine owns, phase %v", got)
+	}
+	m.finishUpdate("a", "", errors.New("again"))
+	if got := markOf(m, "a"); got != markFail {
+		t.Fatalf("an outcome that lands after r shows on the dot again, got %v", got)
+	}
+
+	// Same for a deselected host that is updated again.
+	m.cursor = "c"
+	m.finishUpdate("c", "", nil)
+	if got := markOf(m, "c"); got != markOK {
+		t.Fatalf("a new outcome replaces a cleared one, got %v", got)
+	}
+}
+
+// Every way a host leaves the selection clears its outcome dot, not just space.
+func TestBulkDeselectClearsOutcomeDots(t *testing.T) {
+	m := finished(t)
+	m.selected["c"] = true
+	m, _ = send(m, "a") // everything selected -> a clears the selection
+	for _, h := range []string{"a", "b", "c"} {
+		if got := markOf(m, h); got != markNone {
+			t.Fatalf("select-all toggling off must clear %s's dot, got %v", h, got)
+		}
+	}
+
+	m = finished(t)
+	m, _ = send(m, "esc") // esc clears the selection
+	if markOf(m, "a") != markNone || markOf(m, "b") != markNone {
+		t.Fatalf("esc clearing the selection must clear the dots: a=%v b=%v", markOf(m, "a"), markOf(m, "b"))
+	}
+	if got := markOf(m, "c"); got != markOK {
+		t.Fatalf("c was never selected, so deselection did not touch it, got %v", got)
+	}
+}

--- a/sdk/fleet/cmd/tui_reselect_test.go
+++ b/sdk/fleet/cmd/tui_reselect_test.go
@@ -81,6 +81,98 @@ func TestRefreshHandsTheDotsBackToTheSelection(t *testing.T) {
 	}
 }
 
+// Owner follow-up: a green/red dot is a terminal state and the run stays in
+// history, so selecting such a host clears it too — no `r` needed first.
+func TestSelectingAFinishedHostShowsTheSelection(t *testing.T) {
+	m := finished(t)
+	m.cursor = "c" // unselected, green from a cursor-only update
+	m, _ = send(m, " ")
+	if got := markOf(m, "c"); got != markSel {
+		t.Fatalf("selecting a finished host shows the selection dot, got %v", got)
+	}
+
+	// Visual range select (v, move, space) clears every host it adds.
+	m = finished(t)
+	m.selected = map[string]bool{}
+	m.cursor = "a"
+	m, _ = send(m, "v", "j", "j", " ")
+	for _, h := range []string{"a", "b", "c"} {
+		if got := markOf(m, h); got != markSel {
+			t.Fatalf("visual select must clear %s's outcome dot, got %v", h, got)
+		}
+	}
+
+	// Select-all (a) with part of the rows unselected completes the selection.
+	m = finished(t)
+	m, _ = send(m, "a")
+	if got := markOf(m, "c"); got != markSel {
+		t.Fatalf("select-all must clear c's outcome dot, got %v", got)
+	}
+}
+
+// Selecting a host mid-update changes nothing about its coming outcome.
+func TestSelectingAnInFlightHostKeepsItsComingOutcome(t *testing.T) {
+	m := testModel("a")
+	m.updating["a"] = updState{phase: updRunning}
+	m.cursor = "a"
+	m, _ = send(m, " ")
+	if got := markOf(m, "a"); got != markSel {
+		t.Fatalf("a selected in-flight host shows the selection dot, got %v", got)
+	}
+	m.finishUpdate("a", "", nil)
+	if got := markOf(m, "a"); got != markOK {
+		t.Fatalf("its outcome still shows when it lands, got %v", got)
+	}
+}
+
+// Owner follow-up: deselecting a host mid-update must not make its update
+// status go away. Deselect clears only a FINISHED outcome from the dot; the
+// UPDATE column keeps showing queued / precheck / updating, the engine keeps
+// owning the host, and the outcome still lands on the dot.
+func TestDeselectDuringAnUpdateKeepsTheUpdateStatus(t *testing.T) {
+	phases := map[string]updPhase{"q": updQueued, "p": updPrecheck, "u": updRunning}
+	cells := map[string]string{"q": "queued", "p": "precheck", "u": "updating"}
+	for _, how := range []string{"space", "a", "esc"} {
+		m := testModel("q", "p", "u")
+		for h, ph := range phases {
+			m.selected[h] = true
+			m.updating[h] = updState{phase: ph}
+		}
+		m.bgQueue = []string{"q"}
+		switch how {
+		case "space":
+			for h := range phases {
+				m.cursor = h
+				m, _ = send(m, " ")
+			}
+		default:
+			m, _ = send(m, how)
+		}
+		for h, ph := range phases {
+			if len(m.selected) != 0 {
+				t.Fatalf("%s: the hosts must be deselected, selection %v", how, m.selected)
+			}
+			if got := m.updating[h].phase; got != ph {
+				t.Fatalf("%s: deselecting %s must not touch its update, phase %v -> %v", how, h, ph, got)
+			}
+			if !m.inFlight(h) {
+				t.Fatalf("%s: %s must still be owned by the update engine", how, h)
+			}
+			if got := m.updateCell(h); !strings.Contains(got, cells[h]) {
+				t.Fatalf("%s: %s's UPDATE column must still say %q, got %q", how, h, cells[h], got)
+			}
+		}
+		if len(m.bgQueue) != 1 || m.bgQueue[0] != "q" {
+			t.Fatalf("%s: deselecting must not drop a queued host from the queue, got %v", how, m.bgQueue)
+		}
+		m.finishUpdate("u", "", nil)
+		m.finishUpdate("p", "", errors.New("boom"))
+		if markOf(m, "u") != markOK || markOf(m, "p") != markFail {
+			t.Fatalf("%s: outcomes that land after a deselect still show: u=%v p=%v", how, markOf(m, "u"), markOf(m, "p"))
+		}
+	}
+}
+
 // r is an acknowledgment of what has finished — not of what is still running.
 func TestRefreshLeavesInFlightAndLaterOutcomesAlone(t *testing.T) {
 	m := finished(t)

--- a/sdk/fleet/cmd/tui_view.go
+++ b/sdk/fleet/cmd/tui_view.go
@@ -738,7 +738,8 @@ const (
 
 // markState decides the row's status dot. Selection is navy; a finished update
 // recolours it to its outcome so the list can be read at a glance without
-// looking at the UPDATE column — until `r` or a deselect clears it (dotCleared).
+// looking at the UPDATE column — until `r`, or a select/deselect of that host,
+// clears it (dotCleared).
 func (m tuiModel) markState(i int) markKind {
 	alias := m.rows[i].Alias
 	if st, ok := m.updating[alias]; ok && !m.dotCleared[alias] {

--- a/sdk/fleet/cmd/tui_view.go
+++ b/sdk/fleet/cmd/tui_view.go
@@ -726,20 +726,43 @@ func (m tuiModel) rowView(i int) string {
 	return line + " " + m.updateCell(r.Alias)
 }
 
-// markFor is the row's status dot. Selection is navy; a finished update
+// markKind is what a row's status dot is saying.
+type markKind int
+
+const (
+	markNone markKind = iota
+	markSel
+	markOK
+	markFail
+)
+
+// markState decides the row's status dot. Selection is navy; a finished update
 // recolours it to its outcome so the list can be read at a glance without
-// looking at the UPDATE column.
-func (m tuiModel) markFor(i int) string {
+// looking at the UPDATE column — until `r` or a deselect clears it (dotCleared).
+func (m tuiModel) markState(i int) markKind {
 	alias := m.rows[i].Alias
-	if st, ok := m.updating[alias]; ok {
+	if st, ok := m.updating[alias]; ok && !m.dotCleared[alias] {
 		switch st.phase {
 		case updOK:
-			return th.markOK.Render("●")
+			return markOK
 		case updFail:
-			return th.markFail.Render("●")
+			return markFail
 		}
 	}
 	if m.isSelected(i) {
+		return markSel
+	}
+	return markNone
+}
+
+// markFor renders markState.
+func (m tuiModel) markFor(i int) string {
+	switch m.markState(i) {
+	case markOK:
+		return th.markOK.Render("●")
+	case markFail:
+		return th.markFail.Render("●")
+	case markSel:
 		return th.markSel.Render("●")
 	}
 	return " "


### PR DESCRIPTION
## What

Changes to the fleet TUI's status dot (the `●` left of each hostname). The dot behaves exactly as before while you're selecting and while an update runs; this only changes what happens once an update has finished.

1. **`r` gives the dots back to the selection.** Besides re-polling, `r` clears every *finished* outcome (green ok / red fail) from the dots, so each dot shows the selection again: navy when selected, blank when not. Hosts still queued or updating are untouched, and any outcome that lands later shows on its dot as before.
2. **Changing a finished host's selection always clears its outcome from the dot**, in both directions:
   - **deselect** (space on a selected host, `a` toggling a full selection off, `esc` clearing the selection) → blank
   - **select** (space, visual range `v` + space, `a` completing a selection) → navy, with no `r` needed first. A green/red dot is a terminal state, and the run itself stays in `H` history. Re-selecting a host that is *already* selected (e.g. `a` adding one more host, or a visual range over chosen hosts) changes nothing, so its green/red dot stays.
3. **Deselecting mid-update leaves the update alone.** A queued, prechecking or updating host keeps its UPDATE-column status and stays owned by the engine (and in the queue), and its outcome still lands on the dot when it finishes.

The UPDATE column keeps its `ok` / `ok ⚠N` / `FAIL: cause` text throughout, and every run remains in `H` history.

## Why

Reported by the owner: after an update finished, the dots stayed green or red, and toggling host selection appeared to do nothing. Cause: `markFor` checked `m.updating[alias]` before the selection, and `updOK`/`updFail` entries are never removed. The outcome therefore outranked the selection for the rest of the session, and space changed `m.selected` without anything on screen changing.

## Impact

- `cmd/tui_model.go`: a new `dotCleared` set. `selectHost` / `deselect` are now the only ways a host joins or leaves the selection, and both clear its finished-outcome dot. `showSelection` is `r`'s transition. `finishUpdate` removes the host from `dotCleared`, so a new outcome is shown. `selectAllFiltered` goes through the helpers.
- `cmd/tui_view.go`: `markFor` is split into `markState` (what the dot means: none / sel / ok / fail) and rendering, because the tests pin an ASCII colour profile under which every dot is the same `●`. Rendering is unchanged.
- `cmd/tui_keys.go`: the space toggle and visual select → the helpers, `esc` clears the dots of the hosts it deselects, and `r` → `showSelection()` then `refresh()`. `refresh()` itself is unchanged (it's still only a re-poll), and the footer label stays `r: refresh`, so the golden frames don't move.
- `README.md`: the keys table and the status-dot paragraph describe the new behavior.
- The update engine is not touched: finished outcomes were display-only (read only by `markFor` and `updateCell`), and in-flight state and the queues are never modified.

## Testing

- New `cmd/tui_reselect_test.go` (7 tests). These failed before the fix, with the dot still `markOK`/`markFail`: deselect clears ok and failed dots while the UPDATE text stays; `r` gives the dots back to the selection and toggling is visible afterwards; `a` and `esc` clear the dots; selecting a finished host shows navy (space, visual range, `a`), while a partial `a` keeps the already-selected hosts' ok/FAIL dots. That last case came from the code review and is mutation-checked: dropping `selectHost`'s already-selected guard makes it fail.
- The remaining tests guard behavior that must not change, and pass both before and after: `r` leaves in-flight hosts alone and later outcomes show again; selecting an in-flight host keeps its coming outcome; and `TestDeselectDuringAnUpdateKeepsTheUpdateStatus`. That last one covers queued, precheck and updating hosts × space / `a` / `esc`: the phase, the UPDATE cell, engine ownership and the queue are all unchanged, and outcomes still land. Mutation-checked: making `deselect` also drop the `m.updating` entry makes it fail.
- `go test ./...` passes for all of `sdk/fleet`. `TZ=UTC go test -race ./cmd/` passes. `go vet` and `golangci-lint` report 0 issues, and `gofmt` is clean.
- Manual, in real colour (a throwaway ANSI256 render through the real model and keys, deleted afterwards). The scenario was: select web-01 and web-02 (navy), run the update (navy), finish it (web-01 green, web-02 red), deselect web-02 (blank), press `r` (web-01 navy), then toggle db-01 and web-01 (navy, then blank). No real hosts were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7w8pK62T382wWpN7ewaoQ

<!-- gss:stack-begin -->
## Stack

This PR is part of a stack on **fleet-tui-select**.

- **#324 — edward-raigosa/reselect (base: `main`)** ← you are here

Review bottom-up. Merge bottom-up; gss will re-target the rest of the stack when a parent merges.
<!-- gss:stack-end -->

